### PR TITLE
Fix template fetch for customer editor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -92,6 +92,9 @@ export const setSafeInset = (xIn: number, yIn: number) => {
   safeInsetXIn = xIn
   safeInsetYIn = yIn
   recompute()
+  if (typeof document !== 'undefined') {
+    document.dispatchEvent(new Event('safe-inset-changed'))
+  }
 }
 
 export const setSafeInsetPx = (xPx: number, yPx: number) => {
@@ -99,6 +102,9 @@ export const setSafeInsetPx = (xPx: number, yPx: number) => {
   safeInsetXIn = xPx / (currentSpec.dpi * scale)
   safeInsetYIn = yPx / (currentSpec.dpi * scale)
   recompute()
+  if (typeof document !== 'undefined') {
+    document.dispatchEvent(new Event('safe-inset-changed'))
+  }
 }
 
 export const setPreviewSpec = (spec: PreviewSpec) => {
@@ -615,6 +621,12 @@ useEffect(() => {
   window.addEventListener('scroll', updateOffset, { passive: true });
   window.addEventListener('resize', updateOffset);
 
+  const refreshGuides = () => {
+    addGuides(fc, mode);
+    fc.requestRenderAll();
+  };
+  document.addEventListener('safe-inset-changed', refreshGuides);
+
   /* ── Crop‑tool wiring ────────────────────────────────────── */
   // create a reusable crop helper and keep it in a ref
   const crop = new CropTool(fc, SCALE, SEL_COLOR, state => {
@@ -1053,6 +1065,7 @@ window.addEventListener('keydown', onKey)
       fc.off('before:transform', startCrop);
       fc.off('object:scaling', duringCrop);
       fc.off('object:scaled', endCrop);
+      document.removeEventListener('safe-inset-changed', refreshGuides);
       onReady(null)
       cropToolRef.current?.abort()
       fc.dispose()

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -626,6 +626,8 @@ useEffect(() => {
     fc.requestRenderAll();
   };
   document.addEventListener('safe-inset-changed', refreshGuides);
+  // ensure guides are drawn even if the event fired before mount
+  refreshGuides();
 
   /* ── Crop‑tool wiring ────────────────────────────────────── */
   // create a reusable crop helper and keep it in a ref

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -4,7 +4,7 @@
  * convert every layer with `fromSanity`.
  *********************************************************************/
 
-import { sanityPreview } from '@/sanity/lib/client'
+import { sanityPreview, sanity } from '@/sanity/lib/client'
 import { urlFor } from '@/sanity/lib/image'
 import { fromSanity } from '@/app/library/layerAdapters'
 import type { TemplatePage, PrintSpec, PreviewSpec } from '@/app/components/FabricCanvas'
@@ -85,7 +85,8 @@ export async function getTemplatePages(
     draftKey: idOrSlug.startsWith('drafts.') ? idOrSlug : `drafts.${idOrSlug}`,
   }
 
-  const raw = await sanityPreview.fetch<{
+  const client = process.env.SANITY_READ_TOKEN ? sanityPreview : sanity
+  const raw = await client.fetch<{
     pages?: any[]
     coverImage?: any
     previewSpec?: PreviewSpec


### PR DESCRIPTION
## Summary
- load templates with the public Sanity client when no read token is available

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685bb7b60bb883238d99bb2345518a56