### PR TITLE
Fix safe area overlay update

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -116,6 +116,7 @@ export default function CardEditor({
     // 1️⃣  explicit safe insets from the preview spec
     if (previewSpec.safeInsetXPx || previewSpec.safeInsetYPx) {
       setSafeInsetPx(previewSpec.safeInsetXPx ?? 0, previewSpec.safeInsetYPx ?? 0)
+      document.dispatchEvent(new Event('safe-inset-changed'))
       return
     }
 
@@ -140,6 +141,7 @@ export default function CardEditor({
     const insetX = (baseW - safeW) / 2 + printSpec.bleedIn + 0.125
     const insetY = (baseH - safeH) / 2 + printSpec.bleedIn + 0.125
     setSafeInset(insetX, insetY)
+    document.dispatchEvent(new Event('safe-inset-changed'))
   }, [printSpec, previewSpec, products])
   /* 1 ─ hydrate Zustand once ------------------------------------- */
   useEffect(() => {

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1074,6 +1074,19 @@ window.addEventListener('keydown', onKey)
     }
   }, [isCropping])
 
+  /* ---------- safe inset redraw --------------------------- */
+  useEffect(() => {
+    const fc = fcRef.current
+    if (!fc) return
+    const handler = () => {
+      addGuides(fc, mode)
+      hoverRef.current?.bringToFront()
+      fc.requestRenderAll()
+    }
+    document.addEventListener('safe-inset-changed', handler)
+    return () => document.removeEventListener('safe-inset-changed', handler)
+  }, [mode])
+
 
 
   /* ---------- redraw on page change ----------------------------- */


### PR DESCRIPTION
## Summary
- dispatch an event when safe inset changes
- listen for the event in FabricCanvas and redraw guides

## Testing
- `npm run lint` *(fails: React Hook lint errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685c25a0762c8323bb08664ce861ce96