### PR TITLE
Fix safe-area overlay in card editor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -86,12 +86,14 @@ export const setPrintSpec = (spec: PrintSpec) => {
   console.log('FabricCanvas setSpec', spec.trimWidthIn, spec.trimHeightIn)
   currentSpec = spec
   recompute()
+  document.dispatchEvent(new Event('safe-inset-change'))
 }
 
 export const setSafeInset = (xIn: number, yIn: number) => {
   safeInsetXIn = xIn
   safeInsetYIn = yIn
   recompute()
+  document.dispatchEvent(new Event('safe-inset-change'))
 }
 
 export const setSafeInsetPx = (xPx: number, yPx: number) => {
@@ -99,11 +101,13 @@ export const setSafeInsetPx = (xPx: number, yPx: number) => {
   safeInsetXIn = xPx / (currentSpec.dpi * scale)
   safeInsetYIn = yPx / (currentSpec.dpi * scale)
   recompute()
+  document.dispatchEvent(new Event('safe-inset-change'))
 }
 
 export const setPreviewSpec = (spec: PreviewSpec) => {
   currentPreview = spec
   recompute()
+  document.dispatchEvent(new Event('safe-inset-change'))
 }
 
 /* ---------- size helpers ---------------------------------------- */
@@ -1040,6 +1044,8 @@ window.addEventListener('keydown', onKey)
   // expose editing ref so external controls can pause re-hydration
   ;(fc as any)._editingRef = isEditing
   fcRef.current = fc; onReady(fc)
+  // refresh guides now that the canvas exists
+  document.dispatchEvent(new Event('safe-inset-change'))
 
     return () => {
       fc.upperCanvasEl.removeEventListener('contextmenu', ctxMenu)
@@ -1073,6 +1079,20 @@ window.addEventListener('keydown', onKey)
       }
     }
   }, [isCropping])
+
+  /* ---------- refresh guides when safe insets change ----------- */
+  useEffect(() => {
+    const handler = () => {
+      const fc = fcRef.current
+      if (!fc) return
+      addGuides(fc, mode)
+      hoverRef.current?.bringToFront()
+      fc.requestRenderAll()
+    }
+    document.addEventListener("safe-inset-change", handler)
+    return () => document.removeEventListener("safe-inset-change", handler)
+  }, [mode])
+
 
 
 


### PR DESCRIPTION
## Summary
- refresh safe guides when safe insets or preview spec change
- listen for safe-inset updates in `FabricCanvas`
- trigger safe guide refresh after canvas initialisation
- trigger safe guide refresh when print spec updates

## Testing
- `npm run lint` *(fails: React Hook rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_685c25a0762c8323bb08664ce861ce96