### PR TITLE
Fix safe-area overlay in card editor

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -113,12 +113,6 @@ export default function CardEditor({
   useEffect(() => {
     if (!printSpec || !previewSpec) return
 
-    // 1️⃣  explicit safe insets from the preview spec
-    if (previewSpec.safeInsetXPx || previewSpec.safeInsetYPx) {
-      setSafeInsetPx(previewSpec.safeInsetXPx ?? 0, previewSpec.safeInsetYPx ?? 0)
-      return
-    }
-
     if (!products.length) return
     const baseW = printSpec.trimWidthIn + printSpec.bleedIn * 2
     const baseH = printSpec.trimHeightIn + printSpec.bleedIn * 2

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -92,6 +92,7 @@ export const setSafeInset = (xIn: number, yIn: number) => {
   safeInsetXIn = xIn
   safeInsetYIn = yIn
   recompute()
+  document.dispatchEvent(new Event('safe-inset-change'))
 }
 
 export const setSafeInsetPx = (xPx: number, yPx: number) => {
@@ -99,11 +100,19 @@ export const setSafeInsetPx = (xPx: number, yPx: number) => {
   safeInsetXIn = xPx / (currentSpec.dpi * scale)
   safeInsetYIn = yPx / (currentSpec.dpi * scale)
   recompute()
+  document.dispatchEvent(new Event('safe-inset-change'))
 }
 
 export const setPreviewSpec = (spec: PreviewSpec) => {
   currentPreview = spec
   recompute()
+  if (spec.safeInsetXPx != null || spec.safeInsetYPx != null) {
+    const scale = SCALE || (PREVIEW_W / PAGE_W)
+    safeInsetXIn = (spec.safeInsetXPx ?? 0) / (currentSpec.dpi * scale)
+    safeInsetYIn = (spec.safeInsetYPx ?? 0) / (currentSpec.dpi * scale)
+    recompute()
+  }
+  document.dispatchEvent(new Event('safe-inset-change'))
 }
 
 /* ---------- size helpers ---------------------------------------- */
@@ -1040,6 +1049,8 @@ window.addEventListener('keydown', onKey)
   // expose editing ref so external controls can pause re-hydration
   ;(fc as any)._editingRef = isEditing
   fcRef.current = fc; onReady(fc)
+  // refresh guides now that the canvas exists
+  document.dispatchEvent(new Event('safe-inset-change'))
 
     return () => {
       fc.upperCanvasEl.removeEventListener('contextmenu', ctxMenu)
@@ -1073,6 +1084,20 @@ window.addEventListener('keydown', onKey)
       }
     }
   }, [isCropping])
+
+  /* ---------- refresh guides when safe insets change ----------- */
+  useEffect(() => {
+    const handler = () => {
+      const fc = fcRef.current
+      if (!fc) return
+      addGuides(fc, mode)
+      hoverRef.current?.bringToFront()
+      fc.requestRenderAll()
+    }
+    document.addEventListener("safe-inset-change", handler)
+    return () => document.removeEventListener("safe-inset-change", handler)
+  }, [mode])
+
 
 
 


### PR DESCRIPTION
## Summary
- refresh safe guides after previewSpec is applied
- don't set safe inset from CardEditor when previewSpec already supplies it

## Testing
- `npm run lint` *(fails: React Hook rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_685c25a0762c8323bb08664ce861ce96