### PR TITLE
Dispatch safe inset change events

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -92,6 +92,7 @@ export const setSafeInset = (xIn: number, yIn: number) => {
   safeInsetXIn = xIn
   safeInsetYIn = yIn
   recompute()
+  document.dispatchEvent(new CustomEvent('safe-inset-change'))
 }
 
 export const setSafeInsetPx = (xPx: number, yPx: number) => {
@@ -99,6 +100,7 @@ export const setSafeInsetPx = (xPx: number, yPx: number) => {
   safeInsetXIn = xPx / (currentSpec.dpi * scale)
   safeInsetYIn = yPx / (currentSpec.dpi * scale)
   recompute()
+  document.dispatchEvent(new CustomEvent('safe-inset-change'))
 }
 
 export const setPreviewSpec = (spec: PreviewSpec) => {
@@ -864,6 +866,11 @@ fc.on('mouse:over', e => {
 })
 
 addGuides(fc, mode)                           // add guides based on mode
+  const onSafeInsetChange = () => {
+    addGuides(fc, mode)
+    fc.requestRenderAll()
+  }
+  document.addEventListener('safe-inset-change', onSafeInsetChange)
   /* ── 4.5 ▸ Fabric ➜ Zustand sync ──────────────────────────── */
   fc.on('object:modified', e=>{
     isEditing.current = true
@@ -1053,6 +1060,7 @@ window.addEventListener('keydown', onKey)
       fc.off('before:transform', startCrop);
       fc.off('object:scaling', duringCrop);
       fc.off('object:scaled', endCrop);
+      document.removeEventListener('safe-inset-change', onSafeInsetChange)
       onReady(null)
       cropToolRef.current?.abort()
       fc.dispose()


### PR DESCRIPTION
## Summary
- notify listeners when safe inset values change
- refresh guides when safe inset value updates

## Testing
- `npm run lint` *(fails: React hooks and no-img warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685c5ab1273c83238d28b56d09059851