### PR TITLE
Add refreshGuides logic for safe-area overlays

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -15,6 +15,7 @@ import FabricCanvas, {
   setPreviewSpec,
   setSafeInset,
   setSafeInsetPx,
+  refreshGuides,
   PrintSpec,
   PreviewSpec,
   previewW,
@@ -116,6 +117,7 @@ export default function CardEditor({
     // 1️⃣  explicit safe insets from the preview spec
     if (previewSpec.safeInsetXPx || previewSpec.safeInsetYPx) {
       setSafeInsetPx(previewSpec.safeInsetXPx ?? 0, previewSpec.safeInsetYPx ?? 0)
+      refreshGuides()
       return
     }
 
@@ -140,6 +142,7 @@ export default function CardEditor({
     const insetX = (baseW - safeW) / 2 + printSpec.bleedIn + 0.125
     const insetY = (baseH - safeH) / 2 + printSpec.bleedIn + 0.125
     setSafeInset(insetX, insetY)
+    refreshGuides()
   }, [printSpec, previewSpec, products])
   /* 1 ─ hydrate Zustand once ------------------------------------- */
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep a global list of mounted Fabric canvases
- export `refreshGuides()` that redraws guides for all canvases
- refresh guides when safe insets change
- trigger guide refresh in `CardEditor`

## Testing
- `npm run lint` *(fails: React Hook errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c5aa6151883238c9f57292618d709