### PR TITLE
Fix safe area path in template query

### DIFF
--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -63,8 +63,8 @@ export async function getTemplatePages(
       variantHandle,
       price,
       "printSpec": coalesce(printSpec->, printSpec),
-      "showSafeArea": ^.showSafeArea,
-      "showProofSafeArea": ^.showProofSafeArea
+      "showSafeArea": ^.^.showSafeArea,
+      "showProofSafeArea": ^.^.showProofSafeArea
     },
     pages[]{
       layers[]{


### PR DESCRIPTION
## Summary
- adjust `getTemplatePages` GROQ query to pull `showSafeArea` and `showProofSafeArea` from the parent product

## Testing
- `npm run build` *(fails: Failed to fetch fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c632f562c8323b1dae605e0134bac