### PR TITLE
Fix safe area overlay

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -114,8 +114,16 @@ export default function CardEditor({
     if (!printSpec || !previewSpec) return
 
     // 1️⃣  explicit safe insets from the preview spec
-    if (previewSpec.safeInsetXPx || previewSpec.safeInsetYPx) {
-      setSafeInsetPx(previewSpec.safeInsetXPx ?? 0, previewSpec.safeInsetYPx ?? 0)
+    const legacyX =
+      previewSpec.safeInsetXPx ??
+      (previewSpec as any).safeInsetX ??
+      undefined
+    const legacyY =
+      previewSpec.safeInsetYPx ??
+      (previewSpec as any).safeInsetY ??
+      undefined
+    if (legacyX !== undefined || legacyY !== undefined) {
+      setSafeInsetPx(legacyX ?? 0, legacyY ?? 0)
       return
     }
 

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -47,6 +47,10 @@ export interface PreviewSpec {
   maxMobileWidthPx?: number
   safeInsetXPx?: number
   safeInsetYPx?: number
+  /** legacy field name */
+  safeInsetX?: number
+  /** legacy field name */
+  safeInsetY?: number
 }
 
 let currentSpec: PrintSpec = {
@@ -61,6 +65,8 @@ let currentPreview: PreviewSpec = {
   previewHeightPx: 580,
   safeInsetXPx: 0,
   safeInsetYPx: 0,
+  safeInsetX: 0,
+  safeInsetY: 0,
 }
 
 let safeInsetXIn = 0
@@ -104,7 +110,12 @@ export const setSafeInsetPx = (xPx: number, yPx: number) => {
 }
 
 export const setPreviewSpec = (spec: PreviewSpec) => {
-  currentPreview = spec
+  currentPreview = {
+    ...spec,
+    // allow legacy field names
+    safeInsetXPx: spec.safeInsetXPx ?? (spec as any).safeInsetX ?? 0,
+    safeInsetYPx: spec.safeInsetYPx ?? (spec as any).safeInsetY ?? 0,
+  }
   recompute()
 }
 


### PR DESCRIPTION
## Summary
- restore safe-area overlay in the card editor
- allow older `safeInsetX`/`safeInsetY` preview fields

## Testing
- `npm run lint` *(fails: React hooks rules and others)*

------
https://chatgpt.com/codex/tasks/task_e_685c67e445048323b5141cd53cd495ea