### PR TITLE
Fix safe area overlay

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -114,9 +114,47 @@ export default function CardEditor({
     if (!printSpec || !previewSpec) return
 
     // 1️⃣  explicit safe insets from the preview spec
-    if (previewSpec.safeInsetXPx || previewSpec.safeInsetYPx) {
-      setSafeInsetPx(previewSpec.safeInsetXPx ?? 0, previewSpec.safeInsetYPx ?? 0)
-      return
+    const explicitX = Number(
+      previewSpec.safeInsetXPx ?? (previewSpec as any).safeInsetX ?? NaN,
+    )
+    const explicitY = Number(
+      previewSpec.safeInsetYPx ?? (previewSpec as any).safeInsetY ?? NaN,
+    )
+    if (!Number.isNaN(explicitX) || !Number.isNaN(explicitY)) {
+      const x = Number.isNaN(explicitX) ? 0 : explicitX
+      const y = Number.isNaN(explicitY) ? 0 : explicitY
+      if (x !== 0 || y !== 0) {
+        setSafeInsetPx(x, y)
+        return
+      }
+    }
+
+    // 2️⃣  use product-level preview spec if present
+    const prodSafe = products.find(p => {
+      if (!p.previewSpec) return false
+      const x = Number(
+        p.previewSpec.safeInsetXPx ?? (p.previewSpec as any).safeInsetX ?? NaN,
+      )
+      const y = Number(
+        p.previewSpec.safeInsetYPx ?? (p.previewSpec as any).safeInsetY ?? NaN,
+      )
+      return (x && !Number.isNaN(x)) || (y && !Number.isNaN(y))
+    })
+    if (prodSafe && prodSafe.previewSpec) {
+      const x = Number(
+        prodSafe.previewSpec.safeInsetXPx ??
+          (prodSafe.previewSpec as any).safeInsetX ??
+          0,
+      )
+      const y = Number(
+        prodSafe.previewSpec.safeInsetYPx ??
+          (prodSafe.previewSpec as any).safeInsetY ??
+          0,
+      )
+      if (x !== 0 || y !== 0) {
+        setSafeInsetPx(x, y)
+        return
+      }
     }
 
     if (!products.length) return

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -47,6 +47,10 @@ export interface PreviewSpec {
   maxMobileWidthPx?: number
   safeInsetXPx?: number
   safeInsetYPx?: number
+  /** legacy field name */
+  safeInsetX?: number
+  /** legacy field name */
+  safeInsetY?: number
 }
 
 let currentSpec: PrintSpec = {
@@ -59,8 +63,10 @@ let currentSpec: PrintSpec = {
 let currentPreview: PreviewSpec = {
   previewWidthPx: 420,
   previewHeightPx: 580,
-  safeInsetXPx: 0,
-  safeInsetYPx: 0,
+  safeInsetXPx: undefined,
+  safeInsetYPx: undefined,
+  safeInsetX: undefined,
+  safeInsetY: undefined,
 }
 
 let safeInsetXIn = 0
@@ -104,8 +110,23 @@ export const setSafeInsetPx = (xPx: number, yPx: number) => {
 }
 
 export const setPreviewSpec = (spec: PreviewSpec) => {
-  currentPreview = spec
+  const rawX = spec.safeInsetXPx ?? (spec as any).safeInsetX
+  const rawY = spec.safeInsetYPx ?? (spec as any).safeInsetY
+  const safeX = rawX != null ? Number(rawX) : undefined
+  const safeY = rawY != null ? Number(rawY) : undefined
+
+  currentPreview = {
+    ...spec,
+    // normalise legacy field names and types
+    safeInsetXPx: safeX,
+    safeInsetYPx: safeY,
+  }
   recompute()
+
+  const hasValue =
+    (safeX != null && safeX !== 0) ||
+    (safeY != null && safeY !== 0)
+  if (hasValue) setSafeInsetPx(safeX ?? 0, safeY ?? 0)
 }
 
 /* ---------- size helpers ---------------------------------------- */

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -26,6 +26,7 @@ export interface TemplateProduct {
   printSpec?: PrintSpec
   showSafeArea?: boolean
   showProofSafeArea?: boolean
+  previewSpec?: PreviewSpec
 }
 
 export interface TemplateData {
@@ -63,6 +64,7 @@ export async function getTemplatePages(
       variantHandle,
       price,
       "printSpec": coalesce(printSpec->, printSpec),
+      "previewSpec": ^.^.previewSpec,
       "showSafeArea": ^.^.showSafeArea,
       "showProofSafeArea": ^.^.showProofSafeArea
     },


### PR DESCRIPTION
## Summary
- refine previewSpec handling
- use product-level safe inset pixels reliably

## Testing
- `npm run lint` *(fails: React hooks rules and others)*

------
https://chatgpt.com/codex/tasks/task_e_685c67e445048323b5141cd53cd495ea