### PR TITLE
Fix safe area overlay

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -114,9 +114,40 @@ export default function CardEditor({
     if (!printSpec || !previewSpec) return
 
     // 1️⃣  explicit safe insets from the preview spec
-    if (previewSpec.safeInsetXPx || previewSpec.safeInsetYPx) {
-      setSafeInsetPx(previewSpec.safeInsetXPx ?? 0, previewSpec.safeInsetYPx ?? 0)
+    const explicitX =
+      previewSpec.safeInsetXPx ??
+      (previewSpec as any).safeInsetX ??
+      undefined
+    const explicitY =
+      previewSpec.safeInsetYPx ??
+      (previewSpec as any).safeInsetY ??
+      undefined
+    const hasValue =
+      (explicitX != null && explicitX !== 0) ||
+      (explicitY != null && explicitY !== 0)
+    if (hasValue) {
+      setSafeInsetPx(explicitX ?? 0, explicitY ?? 0)
       return
+    }
+
+    // 2️⃣  use product-level preview spec if present
+    const prodSafe = products.find(p =>
+      (p.previewSpec?.safeInsetXPx ?? (p.previewSpec as any)?.safeInsetX) ||
+      (p.previewSpec?.safeInsetYPx ?? (p.previewSpec as any)?.safeInsetY)
+    )
+    if (prodSafe && prodSafe.previewSpec) {
+      const x =
+        prodSafe.previewSpec.safeInsetXPx ??
+        (prodSafe.previewSpec as any).safeInsetX ??
+        0
+      const y =
+        prodSafe.previewSpec.safeInsetYPx ??
+        (prodSafe.previewSpec as any).safeInsetY ??
+        0
+      if (x !== 0 || y !== 0) {
+        setSafeInsetPx(x, y)
+        return
+      }
     }
 
     if (!products.length) return

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -47,6 +47,10 @@ export interface PreviewSpec {
   maxMobileWidthPx?: number
   safeInsetXPx?: number
   safeInsetYPx?: number
+  /** legacy field name */
+  safeInsetX?: number
+  /** legacy field name */
+  safeInsetY?: number
 }
 
 let currentSpec: PrintSpec = {
@@ -59,8 +63,10 @@ let currentSpec: PrintSpec = {
 let currentPreview: PreviewSpec = {
   previewWidthPx: 420,
   previewHeightPx: 580,
-  safeInsetXPx: 0,
-  safeInsetYPx: 0,
+  safeInsetXPx: undefined,
+  safeInsetYPx: undefined,
+  safeInsetX: undefined,
+  safeInsetY: undefined,
 }
 
 let safeInsetXIn = 0
@@ -104,8 +110,21 @@ export const setSafeInsetPx = (xPx: number, yPx: number) => {
 }
 
 export const setPreviewSpec = (spec: PreviewSpec) => {
-  currentPreview = spec
+  const safeX = spec.safeInsetXPx ?? (spec as any).safeInsetX
+  const safeY = spec.safeInsetYPx ?? (spec as any).safeInsetY
+
+  currentPreview = {
+    ...spec,
+    // allow legacy field names
+    safeInsetXPx: safeX,
+    safeInsetYPx: safeY,
+  }
   recompute()
+
+  const hasValue =
+    (safeX != null && safeX !== 0) ||
+    (safeY != null && safeY !== 0)
+  if (hasValue) setSafeInsetPx(safeX ?? 0, safeY ?? 0)
 }
 
 /* ---------- size helpers ---------------------------------------- */
@@ -865,12 +884,14 @@ fc.on('mouse:over', e => {
   fc.requestRenderAll()
 })
 
-addGuides(fc, mode)                           // add guides based on mode
+  addGuides(fc, mode)                           // add guides based on mode
   const onSafeInsetChange = () => {
     addGuides(fc, mode)
     fc.requestRenderAll()
   }
   document.addEventListener('safe-inset-change', onSafeInsetChange)
+  // ensure guides reflect the latest safe inset on first mount
+  onSafeInsetChange()
   /* ── 4.5 ▸ Fabric ➜ Zustand sync ──────────────────────────── */
   fc.on('object:modified', e=>{
     isEditing.current = true

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -26,6 +26,7 @@ export interface TemplateProduct {
   printSpec?: PrintSpec
   showSafeArea?: boolean
   showProofSafeArea?: boolean
+  previewSpec?: PreviewSpec
 }
 
 export interface TemplateData {
@@ -63,6 +64,7 @@ export async function getTemplatePages(
       variantHandle,
       price,
       "printSpec": coalesce(printSpec->, printSpec),
+      "previewSpec": ^.^.previewSpec,
       "showSafeArea": ^.^.showSafeArea,
       "showProofSafeArea": ^.^.showProofSafeArea
     },


### PR DESCRIPTION
## Summary
- restore safe-area overlay in the card editor
- allow older `safeInsetX`/`safeInsetY` preview fields
- handle undefined safe insets correctly
- fix safe-area flags GROQ projection
- ignore default zero values so preview safe insets fall back to product settings
- refresh guides when safe inset changes
- use product previewSpec safe inset when available
- **fix safe-area data lookup**
- refresh safe-area guides when canvas mounts

## Testing
- `npm run lint` *(fails: React hooks rules and others)*

------
https://chatgpt.com/codex/tasks/task_e_685c67e445048323b5141cd53cd495ea