### PR TITLE
Fix safe area retrieval and guides

### DIFF
--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -60,6 +60,18 @@ export default defineType({
         title: 'Safe inset Y (px)',
         initialValue: 0,
       }),
+      defineField({
+        name: 'safeInsetX',
+        type: 'number',
+        title: 'Safe inset X (inches)',
+        hidden: true,
+      }),
+      defineField({
+        name: 'safeInsetY',
+        type: 'number',
+        title: 'Safe inset Y (inches)',
+        hidden: true,
+      }),
     ],
   }),
 


### PR DESCRIPTION
## Summary
- support legacy safe insets in the product schema
- include safe inset fields in `getTemplatePages` query and merge them
- adjust preview spec handling for legacy fields
- redraw guides on top of the canvas

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685da37667e48323ace49ad43aa06f58