### PR TITLE
Fix AddToBasketDialog when products missing

### DIFF
--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -27,13 +27,13 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
-  const options = products
-    ? products
-        .filter((p): p is { title: string; variantHandle: string } =>
-          Boolean(p && p.title && p.variantHandle),
-        )
-        .map(p => ({ label: p.title, handle: p.variantHandle }))
-    : DEFAULT_OPTIONS
+  const filtered = (products || [])
+    .filter((p): p is { title: string; variantHandle: string } =>
+      Boolean(p && p.title && p.variantHandle),
+    )
+    .map(p => ({ label: p.title, handle: p.variantHandle }))
+
+  const options = filtered.length ? filtered : DEFAULT_OPTIONS
 
   const handleAdd = async () => {
     if (!choice) return

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -27,11 +27,13 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
-  const options =
-    products?.filter((p): p is { title: string; variantHandle: string } =>
-      Boolean(p && p.title && p.variantHandle),
-    ).map(p => ({ label: p.title, handle: p.variantHandle })) ??
-    DEFAULT_OPTIONS
+  const options = products
+    ? products
+        .filter((p): p is { title: string; variantHandle: string } =>
+          Boolean(p && p.title && p.variantHandle),
+        )
+        .map(p => ({ label: p.title, handle: p.variantHandle }))
+    : DEFAULT_OPTIONS
 
   const handleAdd = async () => {
     if (!choice) return


### PR DESCRIPTION
## Summary
- avoid optional chaining error when products undefined in AddToBasketDialog

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e647023608323bdaa515ef14af1cf