### PR TITLE
Add smooth zooming & slider

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -601,10 +601,35 @@ const handleProofAll = async () => {
 }
 
   /* 7 ─ coach-mark ----------------------------------------------- */
+  const containerRef = useRef<HTMLDivElement | null>(null)
   const [anchor, setAnchor] = useState<DOMRect | null>(null)
   const [zoom, setZoom] = useState(1)
-  const handleZoomIn  = () => setZoom(z => Math.min(z + 0.25, 3))
-  const handleZoomOut = () => setZoom(z => Math.max(z - 0.25, 0.5))
+  const zoomRef = useRef(1)
+  const targetZoom = useRef(1)
+  const animRef = useRef<number>()
+
+  const animateZoom = () => {
+    const current = zoomRef.current
+    const target = targetZoom.current
+    if (Math.abs(current - target) < 0.001) {
+      zoomRef.current = target
+      setZoom(target)
+      animRef.current = undefined
+      return
+    }
+    const next = current + (target - current) * 0.2
+    zoomRef.current = next
+    setZoom(next)
+    animRef.current = requestAnimationFrame(animateZoom)
+  }
+
+  const setZoomSmooth = (val: number) => {
+    targetZoom.current = Math.min(Math.max(val, 0.1), 5)
+    if (!animRef.current) animRef.current = requestAnimationFrame(animateZoom)
+  }
+
+  const handleZoomIn  = () => setZoomSmooth(targetZoom.current + 0.25)
+  const handleZoomOut = () => setZoomSmooth(targetZoom.current - 0.25)
   const ran = useRef(false)
   useEffect(() => {
     if (ran.current || typeof window === 'undefined') return
@@ -626,6 +651,29 @@ const handleProofAll = async () => {
     ran.current = true
   }, [])
 
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const wheel = (e: WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        setZoomSmooth(targetZoom.current + -e.deltaY / 500)
+        e.preventDefault()
+      }
+    }
+    const key = (e: KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        if (e.key === '+' || e.key === '=' ) { setZoomSmooth(targetZoom.current + 0.25); e.preventDefault() }
+        if (e.key === '-' ) { setZoomSmooth(targetZoom.current - 0.25); e.preventDefault() }
+      }
+    }
+    el.addEventListener('wheel', wheel, { passive: false })
+    window.addEventListener('keydown', key)
+    return () => {
+      el.removeEventListener('wheel', wheel)
+      window.removeEventListener('keydown', key)
+    }
+  }, [])
+
   /* 8 ─ loader guard --------------------------------------------- */
   if (pages.length !== 4) {
     return (
@@ -641,6 +689,7 @@ const handleProofAll = async () => {
   /* ---------------- UI ------------------------------------------ */
   return (
     <div
+      ref={containerRef}
       className="flex flex-col h-screen box-border"
       style={{ paddingTop: "calc(var(--walty-header-h) + var(--walty-toolbar-h))" }}
     >
@@ -812,6 +861,18 @@ const handleProofAll = async () => {
         products={products}
         generateProofUrls={generateProofURLs}
       />
+      <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 bg-white shadow px-3 py-2 rounded">
+        <span className="text-xs">{Math.round(zoom * 100)}%</span>
+        <input
+          type="range"
+          min="10"
+          max="500"
+          step="1"
+          value={targetZoom.current * 100}
+          onChange={e => setZoomSmooth(Number(e.currentTarget.value) / 100)}
+          className="h-2 w-32"
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- smooth zoom animation in card editor
- wheel & keyboard zoom controls
- add zoom slider in bottom right of editor

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks etc)*
- `npm run build` *(fails: Failed to fetch fonts)*


------
https://chatgpt.com/codex/tasks/task_e_685fb5bd5e348323940d9d2870725d0f