### PR TITLE
Add smooth zoom control

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -27,6 +27,7 @@ import SelfieDrawer                     from './SelfieDrawer'
 import CropDrawer                      from './CropDrawer'
 import PreviewModal                    from './PreviewModal'
 import AddToBasketDialog               from './AddToBasketDialog'
+import ZoomSlider                      from './ZoomSlider'
 import { CropTool }                     from '@/lib/CropTool'
 import WaltyEditorHeader                from './WaltyEditorHeader'
 import type { TemplatePage }            from './FabricCanvas'
@@ -602,9 +603,10 @@ const handleProofAll = async () => {
 
   /* 7 ─ coach-mark ----------------------------------------------- */
   const [anchor, setAnchor] = useState<DOMRect | null>(null)
+  const clampZoom = (v: number) => Math.min(5, Math.max(0.5, v))
   const [zoom, setZoom] = useState(1)
-  const handleZoomIn  = () => setZoom(z => Math.min(z + 0.25, 3))
-  const handleZoomOut = () => setZoom(z => Math.max(z - 0.25, 0.5))
+  const handleZoomIn  = () => setZoom(z => clampZoom(z + 0.1))
+  const handleZoomOut = () => setZoom(z => clampZoom(z - 0.1))
   const ran = useRef(false)
   useEffect(() => {
     if (ran.current || typeof window === 'undefined') return
@@ -636,7 +638,7 @@ const handleProofAll = async () => {
   }
 
   const boxWidth = previewW() * zoom
-  const box = `flex-shrink-0`
+  const box = `flex-shrink-0 transition-all`
 
   /* ---------------- UI ------------------------------------------ */
   return (
@@ -812,6 +814,7 @@ const handleProofAll = async () => {
         products={products}
         generateProofUrls={generateProofURLs}
       />
+      <ZoomSlider value={zoom} onChange={z => setZoom(z)} />
     </div>
   )
 }

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -602,6 +602,7 @@ useEffect(() => {
   /* --- keep Fabric’s wrapper the same size as the visible preview --- */
   const container = canvasRef.current!.parentElement as HTMLElement | null;
   if (container) {
+    container.style.transition = 'width .15s ease, height .15s ease';
     container.style.width  = `${PREVIEW_W * zoom}px`;
     container.style.height = `${PREVIEW_H * zoom}px`;
     container.style.maxWidth  = `${PREVIEW_W * zoom}px`;
@@ -609,6 +610,7 @@ useEffect(() => {
   }
   fc.setWidth(PREVIEW_W * zoom)
   fc.setHeight(PREVIEW_H * zoom)
+  canvasRef.current!.style.transition = 'width .15s ease, height .15s ease'
   addBackdrop(fc);
   // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
@@ -1074,6 +1076,7 @@ window.addEventListener('keydown', onKey)
 
     const container = canvas.parentElement as HTMLElement | null
     if (container) {
+      container.style.transition = 'width .15s ease, height .15s ease'
       container.style.width = `${PREVIEW_W * zoom}px`
       container.style.height = `${PREVIEW_H * zoom}px`
       container.style.maxWidth = `${PREVIEW_W * zoom}px`
@@ -1082,12 +1085,14 @@ window.addEventListener('keydown', onKey)
 
     fc.setWidth(PREVIEW_W * zoom)
     fc.setHeight(PREVIEW_H * zoom)
+    canvas.style.transition = 'width .15s ease, height .15s ease'
     canvas.style.width = `${PREVIEW_W * zoom}px`
     canvas.style.height = `${PREVIEW_H * zoom}px`
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
     fc.requestRenderAll()
+    fc.calcOffset()
   }, [zoom])
 
   /* ---------- crop mode toggle ------------------------------ */

--- a/app/components/ZoomSlider.tsx
+++ b/app/components/ZoomSlider.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { useEffect } from 'react'
+
+interface Props {
+  value: number
+  onChange: (v: number) => void
+}
+
+const clamp = (v: number) => Math.min(5, Math.max(0.5, v))
+
+export default function ZoomSlider({ value, onChange }: Props) {
+  useEffect(() => {
+    const handleWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return
+      e.preventDefault()
+      const delta = e.deltaY < 0 ? 0.1 : -0.1
+      onChange(clamp(value + delta))
+    }
+    window.addEventListener('wheel', handleWheel, { passive: false })
+    return () => window.removeEventListener('wheel', handleWheel)
+  }, [value, onChange])
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return
+      if (e.key === '=' || e.key === '+') {
+        e.preventDefault()
+        onChange(clamp(value + 0.1))
+      } else if (e.key === '-') {
+        e.preventDefault()
+        onChange(clamp(value - 0.1))
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [value, onChange])
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 flex items-center gap-2 bg-white px-2 py-1 rounded-md shadow pointer-events-auto">
+      <input
+        type="range"
+        min={50}
+        max={500}
+        value={Math.round(value * 100)}
+        onChange={e => onChange(clamp(e.target.valueAsNumber / 100))}
+        className="accent-[--walty-orange]"
+      />
+      <span className="text-xs w-12 text-right">{Math.round(value * 100)}%</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a slider UI for zooming the canvas
- support ctrl/⌘ + scroll or keyboard shortcuts for zoom
- ease width/height transitions for the canvas to make zooming smoother

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fb5bd5e348323940d9d2870725d0f