### PR TITLE
Add smooth zoom controls

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -603,8 +603,39 @@ const handleProofAll = async () => {
   /* 7 ─ coach-mark ----------------------------------------------- */
   const [anchor, setAnchor] = useState<DOMRect | null>(null)
   const [zoom, setZoom] = useState(1)
-  const handleZoomIn  = () => setZoom(z => Math.min(z + 0.25, 3))
-  const handleZoomOut = () => setZoom(z => Math.max(z - 0.25, 0.5))
+  const handleZoomIn  = () => setZoom(z => Math.min(z + 0.25, 5))
+  const handleZoomOut = () => setZoom(z => Math.max(z - 0.25, 0.2))
+
+  // allow Cmd/Ctrl + scroll for smooth zooming
+  useEffect(() => {
+    const onWheel = (e: WheelEvent) => {
+      if (e.metaKey || e.ctrlKey) {
+        e.preventDefault()
+        setZoom(z => {
+          const next = z - e.deltaY * 0.002
+          return Math.min(Math.max(next, 0.2), 5)
+        })
+      }
+    }
+    window.addEventListener('wheel', onWheel, { passive: false })
+    return () => window.removeEventListener('wheel', onWheel)
+  }, [])
+
+  // keyboard +/- like Canva
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return
+      if (e.key === '=' || e.key === '+') {
+        e.preventDefault()
+        handleZoomIn()
+      } else if (e.key === '-' || e.key === '_') {
+        e.preventDefault()
+        handleZoomOut()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
   const ran = useRef(false)
   useEffect(() => {
     if (ran.current || typeof window === 'undefined') return
@@ -812,6 +843,22 @@ const handleProofAll = async () => {
         products={products}
         generateProofUrls={generateProofURLs}
       />
+
+      {/* zoom slider bottom-right */}
+      {!isCropMode && (
+        <div className="fixed bottom-4 right-4 z-40 flex items-center gap-2 bg-white/80 px-3 py-2 rounded shadow">
+          <input
+            type="range"
+            min={0.2}
+            max={5}
+            step={0.01}
+            value={zoom}
+            onChange={e => setZoom(e.currentTarget.valueAsNumber)}
+            className="accent-[--walty-orange]"
+          />
+          <span className="w-10 text-right text-xs">{Math.round(zoom * 100)}%</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1078,12 +1078,14 @@ window.addEventListener('keydown', onKey)
       container.style.height = `${PREVIEW_H * zoom}px`
       container.style.maxWidth = `${PREVIEW_W * zoom}px`
       container.style.maxHeight = `${PREVIEW_H * zoom}px`
+      container.style.transition = 'width 0.15s ease-out, height 0.15s ease-out'
     }
 
     fc.setWidth(PREVIEW_W * zoom)
     fc.setHeight(PREVIEW_H * zoom)
     canvas.style.width = `${PREVIEW_W * zoom}px`
     canvas.style.height = `${PREVIEW_H * zoom}px`
+    canvas.style.transition = 'width 0.15s ease-out, height 0.15s ease-out'
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom


### PR DESCRIPTION
## Summary
- tweak card editor zoom logic with wheel and keyboard shortcuts
- add on screen zoom slider
- animate canvas resizing for smoother transitions

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fb5bd5e348323940d9d2870725d0f