### PR TITLE
Fix scroll bar causing layout shift

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,8 @@ body {
   background : var(--background);
   color      : var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  /* Reserve space for vertical scrollbars so layout doesn't shift */
+  scrollbar-gutter: stable;
 }
 
 /* ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- reserve space for vertical scrollbars in global styles to prevent layout jumps

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc48bebb08323a4ea921a5e4a9761