### PR TITLE
Fix layout shift when scrollbar appears

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,7 @@ body {
   background : var(--background);
   color      : var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  scrollbar-gutter: stable;
 }
 
 /* ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- ensure scrollbar space doesn't collapse by adding `scrollbar-gutter: stable` to the `body` element

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fc6537ec88323a199f35b6d10a53c