### PR TITLE
Fix CardEditor overflow and deselect behavior

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -19,6 +19,8 @@ import FabricCanvas, {
   PreviewSpec,
   previewW,
   previewH,
+  HANDLE_PAD,
+  discardSelection,
 } from './FabricCanvas'
 import TextToolbar                      from './TextToolbar'
 import ImageToolbar                     from './ImageToolbar'
@@ -188,7 +190,12 @@ export default function CardEditor({
         fc.renderAll()
         requestAnimationFrame(() => {
           try {
-            const canvasEl = fc.toCanvasElement(THUMB_MULT)
+            const canvasEl = fc.toCanvasElement(THUMB_MULT, {
+              left: HANDLE_PAD,
+              top: HANDLE_PAD,
+              width: pageW(),
+              height: pageH(),
+            })
             canvasEl.toBlob(
               blob => {
                 if (!blob) return
@@ -310,6 +317,10 @@ export default function CardEditor({
             format: 'jpeg',
             quality: 0.8,
             multiplier: EXPORT_MULT(),
+            left: HANDLE_PAD,
+            top: HANDLE_PAD,
+            width: pageW(),
+            height: pageH(),
           })
           const res = await fetch(dataUrl)
           const blob = await res.blob()
@@ -485,6 +496,10 @@ const handlePreview = () => {
       format: 'png',
       quality: 1,
       multiplier: EXPORT_MULT(),
+      left: HANDLE_PAD,
+      top: HANDLE_PAD,
+      width: pageW(),
+      height: pageH(),
     })
   })
   setPreviewImgs(imgs)
@@ -510,7 +525,15 @@ const collectProofData = (showGuides = false) => {
     guides.forEach(g => g.set('visible', showGuides))
     fc.renderAll()
     pageImages.push(
-      fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })
+      fc.toDataURL({
+        format: 'png',
+        quality: 1,
+        multiplier: EXPORT_MULT(),
+        left: HANDLE_PAD,
+        top: HANDLE_PAD,
+        width: pageW(),
+        height: pageH(),
+      })
     )
     guides.forEach(g => g.set('visible', true))
   })
@@ -729,7 +752,7 @@ const handleProofAll = async () => {
     )
   }
 
-  const boxWidth = previewW() * zoom
+  const boxWidth = previewW() * zoom + HANDLE_PAD * 2
   const box = `flex-shrink-0`
 
   /* ---------------- UI ------------------------------------------ */
@@ -738,6 +761,11 @@ const handleProofAll = async () => {
       ref={containerRef}
       className="flex flex-col h-screen box-border"
       style={{ paddingTop: "calc(var(--walty-header-h) + var(--walty-toolbar-h))" }}
+      onMouseDown={e => {
+        if (!(e.target as HTMLElement).closest('canvas')) {
+          activeFc && discardSelection(activeFc)
+        }
+      }}
     >
       <WaltyEditorHeader                     /* ② mount new component */
         onPreview={handlePreview}
@@ -758,7 +786,7 @@ const handleProofAll = async () => {
         />
       )}
       
-      <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
+      <div className="flex flex-1 relative bg-[--walty-cream]">
         {/* global overlays */}
         <CoachMark
           anchor={anchor}
@@ -785,7 +813,7 @@ const handleProofAll = async () => {
         {!isCropMode && <LayerPanel />}
 
         {/* main */}
-        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[868px]">
+        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-none">
           {!isCropMode && (activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,6 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 4
+export const HANDLE_PAD = 40
 
 recompute()
 
@@ -248,7 +249,7 @@ export interface TemplatePage {
   layers: Layer[]
 }
 /* ----------another helper --------------------------------------------- */
-const discardSelection = (fc: fabric.Canvas) => {
+export const discardSelection = (fc: fabric.Canvas) => {
   fc.discardActiveObject();   // removes the wrapper
   fc.requestRenderAll();
 };
@@ -602,16 +603,16 @@ useEffect(() => {
   /* --- keep Fabric’s wrapper the same size as the visible preview --- */
   const container = canvasRef.current!.parentElement as HTMLElement | null;
   if (container) {
-    container.style.width  = `${PREVIEW_W * zoom}px`;
-    container.style.height = `${PREVIEW_H * zoom}px`;
-    container.style.maxWidth  = `${PREVIEW_W * zoom}px`;
-    container.style.maxHeight = `${PREVIEW_H * zoom}px`;
+    container.style.width  = `${PREVIEW_W * zoom + HANDLE_PAD * 2}px`;
+    container.style.height = `${PREVIEW_H * zoom + HANDLE_PAD * 2}px`;
+    container.style.maxWidth  = `${PREVIEW_W * zoom + HANDLE_PAD * 2}px`;
+    container.style.maxHeight = `${PREVIEW_H * zoom + HANDLE_PAD * 2}px`;
   }
-  fc.setWidth(PREVIEW_W * zoom)
-  fc.setHeight(PREVIEW_H * zoom)
+  fc.setWidth(PREVIEW_W * zoom + HANDLE_PAD * 2)
+  fc.setHeight(PREVIEW_H * zoom + HANDLE_PAD * 2)
   addBackdrop(fc);
   // keep the preview scaled to the configured width
-  fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
+  fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, HANDLE_PAD, HANDLE_PAD]);
   enableSnapGuides(fc, PAGE_W, PAGE_H);
 
   /* keep event coordinates aligned with any scroll/resize */
@@ -1074,18 +1075,18 @@ window.addEventListener('keydown', onKey)
 
     const container = canvas.parentElement as HTMLElement | null
     if (container) {
-      container.style.width = `${PREVIEW_W * zoom}px`
-      container.style.height = `${PREVIEW_H * zoom}px`
-      container.style.maxWidth = `${PREVIEW_W * zoom}px`
-      container.style.maxHeight = `${PREVIEW_H * zoom}px`
+      container.style.width = `${PREVIEW_W * zoom + HANDLE_PAD * 2}px`
+      container.style.height = `${PREVIEW_H * zoom + HANDLE_PAD * 2}px`
+      container.style.maxWidth = `${PREVIEW_W * zoom + HANDLE_PAD * 2}px`
+      container.style.maxHeight = `${PREVIEW_H * zoom + HANDLE_PAD * 2}px`
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
-    canvas.style.width = `${PREVIEW_W * zoom}px`
-    canvas.style.height = `${PREVIEW_H * zoom}px`
+    fc.setWidth(PREVIEW_W * zoom + HANDLE_PAD * 2)
+    fc.setHeight(PREVIEW_H * zoom + HANDLE_PAD * 2)
+    canvas.style.width = `${PREVIEW_W * zoom + HANDLE_PAD * 2}px`
+    canvas.style.height = `${PREVIEW_H * zoom + HANDLE_PAD * 2}px`
 
-    fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
+    fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, HANDLE_PAD, HANDLE_PAD])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
     fc.requestRenderAll()
   }, [zoom])
@@ -1297,9 +1298,9 @@ img.on('mouseup', () => {
     <>
       <canvas
         ref={canvasRef}
-        width={PREVIEW_W * zoom}
-        height={PREVIEW_H * zoom}
-        style={{ width: PREVIEW_W * zoom, height: PREVIEW_H * zoom }}
+        width={PREVIEW_W * zoom + HANDLE_PAD * 2}
+        height={PREVIEW_H * zoom + HANDLE_PAD * 2}
+        style={{ width: PREVIEW_W * zoom + HANDLE_PAD * 2, height: PREVIEW_H * zoom + HANDLE_PAD * 2 }}
         className="border shadow rounded"
       />
       {menuPos && (


### PR DESCRIPTION
## Summary
- allow editor canvas to grow beyond old `max-w` limits
- let selection handles overflow canvas by adding padding and offset
- deselect active objects when clicking outside the canvas
- crop exported and thumbnail images to page bounds

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685fc5b904348323b70f3c61cd530993