### PR TITLE
Fix CardEditor container scroll behavior

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -736,8 +736,11 @@ const handleProofAll = async () => {
   return (
     <div
       ref={containerRef}
-      className="flex flex-col h-screen box-border"
-      style={{ paddingTop: "calc(var(--walty-header-h) + var(--walty-toolbar-h))" }}
+      className="flex flex-col h-screen box-border overflow-y-auto"
+      style={{
+        paddingTop: 'var(--walty-header-h)',
+        scrollbarGutter: 'stable',
+      }}
     >
       <WaltyEditorHeader                     /* ② mount new component */
         onPreview={handlePreview}


### PR DESCRIPTION
## Summary
- keep content from shifting when vertical scrollbars appear in CardEditor
- ensure toolbars stay aligned with the header by adjusting padding

## Testing
- `npm run lint` *(fails: React hook and display name errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fc65b85308323b7aaf7cc62b1f9c5