### PR TITLE
Fix canvas zoom clipping and selection clearing

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -758,7 +758,7 @@ const handleProofAll = async () => {
         />
       )}
       
-      <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
+      <div className="flex flex-1 relative bg-[--walty-cream]">
         {/* global overlays */}
         <CoachMark
           anchor={anchor}
@@ -785,7 +785,7 @@ const handleProofAll = async () => {
         {!isCropMode && <LayerPanel />}
 
         {/* main */}
-        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[868px]">
+        <div className="flex flex-col flex-1 min-h-0 mx-auto w-full">
           {!isCropMode && (activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}
@@ -811,7 +811,15 @@ const handleProofAll = async () => {
           ))}
 
                     {/* canvases */}
-          <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
+          <div
+            className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6"
+            onMouseDown={e => {
+              if (e.target === e.currentTarget && activeFc) {
+                activeFc.discardActiveObject();
+                activeFc.requestRenderAll();
+              }
+            }}
+          >
             {/* front */}
             <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,6 +70,12 @@ html {
 /* Fabric preview wrapper — clips the ghost */
 .canvas-wrap { @apply relative overflow-hidden; }
 
+/* allow Fabric selection boxes outside the canvas bounds */
+.canvas-container {
+  /* allow Fabric selection boxes outside the canvas bounds */
+  overflow: visible !important;
+}
+
 /* Center icon + helper text */
 .ai-ghost__center {
   display:flex;


### PR DESCRIPTION
## Summary
- allow CardEditor layout to fill available width
- deselect elements when clicking the canvas background
- show Fabric selection handles beyond canvas bounds

## Testing
- `npm run lint` *(fails: React hook rule violations and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685fc5b904348323b70f3c61cd530993