### PR TITLE
Fix CardEditor scroll behavior

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -737,7 +737,9 @@ const handleProofAll = async () => {
     <div
       ref={containerRef}
       className="flex flex-col h-screen box-border"
-      style={{ paddingTop: "calc(var(--walty-header-h) + var(--walty-toolbar-h))" }}
+      style={{
+        paddingTop: "calc(var(--walty-header-h) + var(--walty-toolbar-h))",
+      }}
     >
       <WaltyEditorHeader                     /* ② mount new component */
         onPreview={handlePreview}
@@ -785,7 +787,10 @@ const handleProofAll = async () => {
         {!isCropMode && <LayerPanel />}
 
         {/* main */}
-        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[868px]">
+        <div
+          className="flex flex-col flex-1 min-h-0 mx-auto max-w-[868px] overflow-y-auto"
+          style={{ scrollbarGutter: 'stable' }}
+        >
           {!isCropMode && (activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}
@@ -811,7 +816,9 @@ const handleProofAll = async () => {
           ))}
 
                     {/* canvases */}
-          <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
+          <div
+            className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6"
+          >
             {/* front */}
             <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas


### PR DESCRIPTION
## Summary
- restore outer CardEditor container
- scroll inner editor area with stable scrollbar gutter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fc65b85308323b7aaf7cc62b1f9c5