### PR TITLE
Fix canvas zoom clipping and selection clearing

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -758,7 +758,7 @@ const handleProofAll = async () => {
         />
       )}
       
-      <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
+      <div className="flex flex-1 relative bg-[--walty-cream]">
         {/* global overlays */}
         <CoachMark
           anchor={anchor}
@@ -785,7 +785,7 @@ const handleProofAll = async () => {
         {!isCropMode && <LayerPanel />}
 
         {/* main */}
-        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[868px]">
+        <div className="flex flex-col flex-1 min-h-0 mx-auto w-full">
           {!isCropMode && (activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}
@@ -811,7 +811,15 @@ const handleProofAll = async () => {
           ))}
 
                     {/* canvases */}
-          <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
+          <div
+            className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6"
+            onMouseDown={e => {
+              if (e.target === e.currentTarget && activeFc) {
+                activeFc.discardActiveObject();
+                activeFc.requestRenderAll();
+              }
+            }}
+          >
             {/* front */}
             <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -600,18 +600,23 @@ useEffect(() => {
   };
   fc.upperCanvasEl.addEventListener('contextmenu', ctxMenu);
   /* --- keep Fabric’s wrapper the same size as the visible preview --- */
+  const pad = 4 * zoom;
   const container = canvasRef.current!.parentElement as HTMLElement | null;
   if (container) {
-    container.style.width  = `${PREVIEW_W * zoom}px`;
-    container.style.height = `${PREVIEW_H * zoom}px`;
-    container.style.maxWidth  = `${PREVIEW_W * zoom}px`;
-    container.style.maxHeight = `${PREVIEW_H * zoom}px`;
+    const w = PREVIEW_W * zoom + pad * 2;
+    const h = PREVIEW_H * zoom + pad * 2;
+    container.style.width = `${w}px`;
+    container.style.height = `${h}px`;
+    container.style.maxWidth = `${w}px`;
+    container.style.maxHeight = `${h}px`;
+    container.style.padding = `${pad}px`;
+    container.style.overflow = 'visible';
   }
-  fc.setWidth(PREVIEW_W * zoom)
-  fc.setHeight(PREVIEW_H * zoom)
+  fc.setWidth(PREVIEW_W * zoom + pad * 2)
+  fc.setHeight(PREVIEW_H * zoom + pad * 2)
   addBackdrop(fc);
   // keep the preview scaled to the configured width
-  fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
+  fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, pad, pad]);
   enableSnapGuides(fc, PAGE_W, PAGE_H);
 
   /* keep event coordinates aligned with any scroll/resize */
@@ -1072,20 +1077,24 @@ window.addEventListener('keydown', onKey)
     const canvas = canvasRef.current
     if (!fc || !canvas) return
 
+    const pad = 4 * zoom
     const container = canvas.parentElement as HTMLElement | null
     if (container) {
-      container.style.width = `${PREVIEW_W * zoom}px`
-      container.style.height = `${PREVIEW_H * zoom}px`
-      container.style.maxWidth = `${PREVIEW_W * zoom}px`
-      container.style.maxHeight = `${PREVIEW_H * zoom}px`
+      const w = PREVIEW_W * zoom + pad * 2
+      const h = PREVIEW_H * zoom + pad * 2
+      container.style.width = `${w}px`
+      container.style.height = `${h}px`
+      container.style.maxWidth = `${w}px`
+      container.style.maxHeight = `${h}px`
+      container.style.padding = `${pad}px`
+      container.style.overflow = 'visible'
     }
+    fc.setWidth(PREVIEW_W * zoom + pad * 2)
+    fc.setHeight(PREVIEW_H * zoom + pad * 2)
+    canvas.style.width = `${PREVIEW_W * zoom + pad * 2}px`
+    canvas.style.height = `${PREVIEW_H * zoom + pad * 2}px`
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
-    canvas.style.width = `${PREVIEW_W * zoom}px`
-    canvas.style.height = `${PREVIEW_H * zoom}px`
-
-    fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
+    fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, pad, pad])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
     fc.requestRenderAll()
   }, [zoom])

--- a/app/globals.css
+++ b/app/globals.css
@@ -68,7 +68,16 @@ html {
 }
 
 /* Fabric preview wrapper — clips the ghost */
-.canvas-wrap { @apply relative overflow-hidden; }
+.canvas-wrap {
+  @apply relative;
+  overflow: visible !important;
+}
+
+/* allow Fabric selection boxes outside the canvas bounds */
+.canvas-container {
+  /* allow Fabric selection boxes outside the canvas bounds */
+  overflow: visible !important;
+}
 
 /* Center icon + helper text */
 .ai-ghost__center {


### PR DESCRIPTION
## Summary
- allow CardEditor layout to fill available width
- deselect elements when clicking the canvas background
- show Fabric selection handles beyond canvas bounds
- expand canvas padding so outlines are visible at edges

## Testing
- `npm run lint` *(fails: React hook rule violations and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685fc5b904348323b70f3c61cd530993