### PR TITLE
Fix selection handles clipping

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -19,6 +19,7 @@ import FabricCanvas, {
   PreviewSpec,
   previewW,
   previewH,
+  HANDLE_PAD,
 } from './FabricCanvas'
 import TextToolbar                      from './TextToolbar'
 import ImageToolbar                     from './ImageToolbar'
@@ -729,7 +730,7 @@ const handleProofAll = async () => {
     )
   }
 
-  const boxWidth = previewW() * zoom
+  const boxWidth = previewW() * zoom + HANDLE_PAD * zoom * 2
   const box = `flex-shrink-0`
 
   /* ---------------- UI ------------------------------------------ */

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -18,6 +18,9 @@ import { CropTool } from '@/lib/CropTool'
 import { enableSnapGuides } from '@/lib/useSnapGuides'
 import ContextMenu from './ContextMenu'
 
+// Extra padding around the canvas so selection handles aren't clipped
+export const HANDLE_PAD = 24
+
 /* ---------- print spec ----------------------------------------- */
 export interface PrintSpec {
   trimWidthIn: number
@@ -602,7 +605,7 @@ useEffect(() => {
   /* --- keep Fabric’s wrapper the same size as the visible preview --- */
   const container = canvasRef.current!.parentElement as HTMLElement | null;
   if (container) {
-    const pad = 4 * zoom;
+    const pad = HANDLE_PAD * zoom;
     container.style.width = `${PREVIEW_W * zoom}px`;
     container.style.height = `${PREVIEW_H * zoom}px`;
     container.style.maxWidth = `${PREVIEW_W * zoom}px`;
@@ -1077,7 +1080,7 @@ window.addEventListener('keydown', onKey)
 
     const container = canvas.parentElement as HTMLElement | null
     if (container) {
-      const pad = 4 * zoom
+      const pad = HANDLE_PAD * zoom
       container.style.width = `${PREVIEW_W * zoom}px`
       container.style.height = `${PREVIEW_H * zoom}px`
       container.style.maxWidth = `${PREVIEW_W * zoom}px`


### PR DESCRIPTION
## Summary
- prevent Fabric canvas controls from being clipped by adding a constant padding around the canvas
- widen the canvas wrapper in `CardEditor` so extra padding is considered

## Testing
- `npm run lint` *(fails: React hook rules and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_685fd56c85188323bff1d99832ef7deb