### PR TITLE
Fix selection handles clipping

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -73,6 +73,11 @@ html {
   overflow: visible !important;
 }
 
+.canvas-clip {
+  overflow: hidden;
+  position: relative;
+}
+
 /* allow Fabric selection boxes outside the canvas bounds */
 .canvas-container {
   /* allow Fabric selection boxes outside the canvas bounds */


### PR DESCRIPTION
## Summary
- add wrapper around Fabric canvas so content clips but outlines don't
- enlarge Fabric canvas and apply clipPath
- adjust zoom effect and ghost sync for new offsets
- add CSS helper for `canvas-clip`

## Testing
- `npm run lint` *(fails: React hooks errors)*
- `npx tsc -p tsconfig.json` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fd56c85188323bff1d99832ef7deb