### PR TITLE
Allow selection handles outside canvas

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -617,6 +617,76 @@ useEffect(() => {
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
   enableSnapGuides(fc, PAGE_W, PAGE_H);
 
+  /* ---------- selection overlay above canvas -------------------- */
+  let selGhost: HTMLDivElement | null = null
+  const ensureGhost = () => {
+    if (!selGhost) {
+      selGhost = document.createElement('div')
+      selGhost.className = 'selection-ghost'
+      selGhost.innerHTML = `
+        <div class="handle tl"></div>
+        <div class="handle tr"></div>
+        <div class="handle bl"></div>
+        <div class="handle br"></div>
+        <div class="handle ml"></div>
+        <div class="handle mr"></div>
+        <div class="handle mt"></div>
+        <div class="handle mb"></div>`
+      selGhost.style.display = 'none'
+      document.body.appendChild(selGhost)
+
+      const forward = (type: string) => (e: PointerEvent) => {
+        if (!canvasRef.current) return
+        const ev = new PointerEvent(type, {
+          bubbles: true,
+          clientX: e.clientX,
+          clientY: e.clientY,
+          screenX: e.screenX,
+          screenY: e.screenY,
+          pointerId: e.pointerId,
+          pointerType: e.pointerType,
+          pressure: e.pressure,
+          buttons: e.buttons
+        })
+        canvasRef.current.dispatchEvent(ev)
+      }
+      selGhost.addEventListener('pointerdown', forward('pointerdown'))
+      selGhost.addEventListener('pointermove', forward('pointermove'))
+      selGhost.addEventListener('pointerup', forward('pointerup'))
+      selGhost.addEventListener('pointercancel', forward('pointercancel'))
+    }
+  }
+
+  const syncSelGhost = () => {
+    if (!selGhost || !canvasRef.current) return
+    const obj = fc.getActiveObject() as fabric.Object | null
+    if (!obj || croppingRef.current) { selGhost.style.display = 'none'; return }
+    const box = obj.getBoundingRect(true, true)
+    // only show overlay if part of the selection sits outside the canvas
+    if (box.left >= 0 && box.top >= 0 &&
+        box.left + box.width  <= PAGE_W &&
+        box.top  + box.height <= PAGE_H) {
+      selGhost.style.display = 'none'
+      return
+    }
+    const rect = canvasRef.current.getBoundingClientRect()
+    const s = SCALE * zoom
+    selGhost.style.left   = `${rect.left + box.left * s}px`
+    selGhost.style.top    = `${rect.top  + box.top  * s}px`
+    selGhost.style.width  = `${box.width  * s}px`
+    selGhost.style.height = `${box.height * s}px`
+    selGhost.style.display = 'block'
+  }
+
+  fc.on('selection:created', () => { ensureGhost(); syncSelGhost() })
+    .on('selection:updated', syncSelGhost)
+    .on('selection:cleared', () => { if (selGhost) selGhost.style.display = 'none' })
+    .on('object:moving',   syncSelGhost)
+    .on('object:scaling',  syncSelGhost)
+    .on('object:rotating', syncSelGhost)
+  window.addEventListener('scroll', syncSelGhost, { passive: true })
+  window.addEventListener('resize', syncSelGhost)
+
   /* keep event coordinates aligned with any scroll/resize */
   const updateOffset = () => fc.calcOffset();
   updateOffset();
@@ -1061,6 +1131,15 @@ window.addEventListener('keydown', onKey)
       fc.off('before:transform', startCrop);
       fc.off('object:scaling', duringCrop);
       fc.off('object:scaled', endCrop);
+      fc.off('selection:created', syncSelGhost)
+        .off('selection:updated', syncSelGhost)
+        .off('selection:cleared', syncSelGhost)
+        .off('object:moving',   syncSelGhost)
+        .off('object:scaling',  syncSelGhost)
+        .off('object:rotating', syncSelGhost)
+      window.removeEventListener('scroll', syncSelGhost)
+      window.removeEventListener('resize', syncSelGhost)
+      selGhost?.remove()
       onReady(null)
       cropToolRef.current?.abort()
       fc.dispose()

--- a/app/globals.css
+++ b/app/globals.css
@@ -98,3 +98,32 @@ html {
   height:36px;
   margin-bottom:4px;
 }
+
+/* === selection overlay ======================================= */
+@layer utilities {
+  .selection-ghost {
+    @apply fixed box-border;
+    border: 1px solid #2ec4b6;
+    border-radius: 0;
+    background: transparent;
+    z-index: 40;
+  }
+  .selection-ghost .handle {
+    position:absolute;
+    width:8px;
+    height:8px;
+    background:#fff;
+    border:1px solid #2ec4b6;
+    border-radius:50%;
+    box-shadow:0 0 2px rgba(0,0,0,0.4);
+    transform:translate(-50%, -50%);
+  }
+  .selection-ghost .tl{left:0;top:0}
+  .selection-ghost .tr{left:100%;top:0}
+  .selection-ghost .bl{left:0;top:100%}
+  .selection-ghost .br{left:100%;top:100%}
+  .selection-ghost .ml{left:0;top:50%}
+  .selection-ghost .mr{left:100%;top:50%}
+  .selection-ghost .mt{left:50%;top:0}
+  .selection-ghost .mb{left:50%;top:100%}
+}


### PR DESCRIPTION
## Summary
- overlay ghost only when object spills outside canvas
- style `.selection-ghost` to match Fabric borders and remain unclickable
- make overlay interactive so handles outside the canvas forward pointer events to Fabric

## Testing
- `npm run lint` *(fails: React hook rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_685fe40e66348323ab5251b0f8cc4b44