### PR TITLE
Add DOM overlays for canvas hover and selection

### DIFF
--- a/app/components/syncOutline.ts
+++ b/app/components/syncOutline.ts
@@ -1,0 +1,25 @@
+import { fabric } from 'fabric'
+
+/**
+ * Position a DOM overlay to match a Fabric object.
+ * Used for hover/selection outlines outside the canvas.
+ */
+export function syncOutline(
+  obj: fabric.Object,
+  el: HTMLDivElement,
+  canvas: HTMLCanvasElement,
+  scale: number,
+) {
+  obj.setCoords()
+  const center = obj.getCenterPoint()
+  const w = obj.getScaledWidth()
+  const h = obj.getScaledHeight()
+  const canvasRect = canvas.getBoundingClientRect()
+
+  el.style.left = `${canvasRect.left + (center.x - w / 2) * scale}px`
+  el.style.top = `${canvasRect.top + (center.y - h / 2) * scale}px`
+  el.style.width = `${w * scale}px`
+  el.style.height = `${h * scale}px`
+  el.style.transform = `rotate(${obj.angle || 0}deg)`
+  el.style.transformOrigin = 'center'
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,3 +89,33 @@ html {
   height:36px;
   margin-bottom:4px;
 }
+
+/* === Canvas selection/hover overlays ========================= */
+@layer utilities {
+  .canvas-outline {
+    @apply absolute pointer-events-none box-border;
+    border:1px dashed #2EC4B6;
+    position:absolute;
+    box-sizing:border-box;
+  }
+  .canvas-outline--selection .handle {
+    position:absolute;
+    width:8px;
+    height:8px;
+    border-radius:50%;
+    background:#fff;
+    border:1px solid #2EC4B6;
+    box-shadow:0 0 2px rgba(0,0,0,0.15);
+  }
+  .canvas-outline--selection .handle.tl{left:-4px;top:-4px}
+  .canvas-outline--selection .handle.tr{right:-4px;top:-4px}
+  .canvas-outline--selection .handle.bl{left:-4px;bottom:-4px}
+  .canvas-outline--selection .handle.br{right:-4px;bottom:-4px}
+  .canvas-outline--selection .handle.ml{left:-4px;top:50%;transform:translateY(-50%)}
+  .canvas-outline--selection .handle.mr{right:-4px;top:50%;transform:translateY(-50%)}
+  .canvas-outline--selection .handle.mt{top:-4px;left:50%;transform:translateX(-50%)}
+  .canvas-outline--selection .handle.mb{bottom:-4px;left:50%;transform:translateX(-50%)}
+  .canvas-outline--selection .handle.mtr{
+    top:-20px;left:50%;transform:translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Summary
- sync DOM overlays with Fabric objects using `syncOutline`
- add overlay styles in `globals.css`
- update `FabricCanvas` to display hover and selection outlines outside the canvas

## Testing
- `npm run lint` *(fails: react-hooks rules and others)*

------
https://chatgpt.com/codex/tasks/task_e_685ff5ffceac8323b8fd5a1c4148dc24