### PR TITLE
Implement DOM overlays for editor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -473,6 +473,9 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
   const hydrating    = useRef(false)
   const isEditing    = useRef(false)
 
+  const hoverDomRef  = useRef<HTMLDivElement | null>(null)
+  const selDomRef    = useRef<HTMLDivElement | null>(null)
+
   const cropToolRef = useRef<CropTool | null>(null)
   const croppingRef = useRef(false)
 
@@ -589,6 +592,19 @@ useEffect(() => {
   const fc = new fabric.Canvas(canvasRef.current!) as fabric.Canvas & { upperCanvasEl: HTMLCanvasElement };
   fc.backgroundColor = '#fff';
   fc.preserveObjectStacking = true;
+
+  /* create DOM overlays for hover & selection */
+  const hoverEl = document.createElement('div');
+  hoverEl.className = 'sel-overlay';
+  hoverEl.style.display = 'none';
+  document.body.appendChild(hoverEl);
+  hoverDomRef.current = hoverEl;
+
+  const selEl = document.createElement('div');
+  selEl.className = 'sel-overlay';
+  selEl.style.display = 'none';
+  document.body.appendChild(selEl);
+  selDomRef.current = selEl;
 
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();
@@ -822,44 +838,58 @@ const hoverHL = new fabric.Rect({
 fc.add(hoverHL)
 hoverRef.current = hoverHL
 
-/* ── 3 ▸ Selection lifecycle (no extra overlay) ─────────── */
+/* ── 3 ▸ Selection lifecycle (DOM overlay) ─────────── */
 let scrollHandler: (() => void) | null = null
 
+const syncSel = () => {
+  const obj = fc.getActiveObject() as fabric.Object | undefined
+  if (!obj || !selDomRef.current || !canvasRef.current) return
+  const box = obj.getBoundingRect(true, true)
+  const rect = canvasRef.current.getBoundingClientRect()
+  selDomRef.current.style.left = `${rect.left + box.left * SCALE}px`
+  selDomRef.current.style.top = `${rect.top + box.top * SCALE}px`
+  selDomRef.current.style.width = `${box.width * SCALE}px`
+  selDomRef.current.style.height = `${box.height * SCALE}px`
+}
+
 fc.on('selection:created', () => {
-  hoverHL.visible = false            // hide leftover hover rectangle
+  hoverHL.visible = false
   fc.requestRenderAll()
-  scrollHandler = () => fc.requestRenderAll()
+  selDomRef.current && (selDomRef.current.style.display = 'block')
+  syncSel()
+  scrollHandler = () => syncSel()
   window.addEventListener('scroll', scrollHandler, { passive:true })
+  window.addEventListener('resize', scrollHandler)
 })
+.on('selection:updated', syncSel)
 .on('selection:cleared', () => {
-  if (scrollHandler) { window.removeEventListener('scroll', scrollHandler); scrollHandler = null }
+  if (scrollHandler) { window.removeEventListener('scroll', scrollHandler); window.removeEventListener('resize', scrollHandler); scrollHandler = null }
+  selDomRef.current && (selDomRef.current.style.display = 'none')
 })
 
 /* also hide hover during any transform of the active object */
-fc.on('object:moving',   () => { hoverHL.visible = false })
-  .on('object:scaling',  () => { hoverHL.visible = false })
-  .on('object:rotating', () => { hoverHL.visible = false })
+fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
+  .on('object:scaling',  () => { hoverHL.visible = false; syncSel() })
+  .on('object:rotating', () => { hoverHL.visible = false; syncSel() })
 
 /* ── 4 ▸ Hover outline (only when NOT the active object) ─── */
 fc.on('mouse:over', e => {
   const t = e.target as fabric.Object | undefined
   if (!t || (t as any)._guide || t === hoverHL) return
   if (fc.getActiveObject() === t) return           // skip active selection
-
   const box = t.getBoundingRect(true, true)
-  hoverHL.set({
-    width : box.width  + PAD * 2,
-    height: box.height + PAD * 2,
-    left  : box.left  - PAD,
-    top   : box.top   - PAD,
-    visible: true,
-  })
-  hoverHL.setCoords()
-  hoverHL.bringToFront()
-  fc.requestRenderAll()
+  const rect = canvasRef.current!.getBoundingClientRect()
+  hoverDomRef.current && (() => {
+    hoverDomRef.current.style.left = `${rect.left + (box.left - PAD) * SCALE}px`
+    hoverDomRef.current.style.top = `${rect.top + (box.top - PAD) * SCALE}px`
+    hoverDomRef.current.style.width = `${(box.width + PAD * 2) * SCALE}px`
+    hoverDomRef.current.style.height = `${(box.height + PAD * 2) * SCALE}px`
+    hoverDomRef.current.style.display = 'block'
+  })()
 })
 .on('mouse:out', () => {
   hoverHL.visible = false
+  hoverDomRef.current && (hoverDomRef.current.style.display = 'none')
   fc.requestRenderAll()
 })
 
@@ -1056,6 +1086,12 @@ window.addEventListener('keydown', onKey)
       onReady(null)
       cropToolRef.current?.abort()
       fc.dispose()
+      hoverDomRef.current?.remove()
+      selDomRef.current?.remove()
+      if (scrollHandler) {
+        window.removeEventListener('scroll', scrollHandler)
+        window.removeEventListener('resize', scrollHandler)
+      }
     }
 // eslint-disable-next-line react-hooks/exhaustive-deps
 }, [])

--- a/app/components/syncGhost.ts
+++ b/app/components/syncGhost.ts
@@ -19,17 +19,10 @@
      // 1 - read positions
      const { left, top, width, height } = img.getBoundingRect();
      const canvasRect = canvas.getBoundingClientRect();
-   
-     // 2 - clamp to canvas bounds (no bleed outside)
-     //    Fabric positions can be negative 👉 clamp at 0..PAGE_W/​H
-     const clampedLeft   = Math.max(0, Math.min(left,  canvas.width));
-     const clampedTop    = Math.max(0, Math.min(top,   canvas.height));
-     const clampedWidth  = Math.max(0, Math.min(width,  canvas.width  - clampedLeft));
-     const clampedHeight = Math.max(0, Math.min(height, canvas.height - clampedTop));
-   
-     // 3 - apply to the overlay div  (convert canvas-space ➜ screen-space)
-     ghost.style.left   = `${canvasRect.left + clampedLeft   * scale}px`;
-     ghost.style.top    = `${canvasRect.top  + clampedTop    * scale}px`;
-     ghost.style.width  = `${clampedWidth  * scale}px`;
-     ghost.style.height = `${clampedHeight * scale}px`;
+
+     // 2 - apply to the overlay div  (canvas-space ➜ screen-space)
+     ghost.style.left   = `${canvasRect.left + left   * scale}px`;
+     ghost.style.top    = `${canvasRect.top  + top    * scale}px`;
+     ghost.style.width  = `${width  * scale}px`;
+     ghost.style.height = `${height * scale}px`;
    }

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,10 +104,19 @@ html {
     border:1px solid #2EC4B6;
     border-radius:50%;
     transform:translate(-50%,-50%);
+    pointer-events:auto;
   }
   .sel-overlay .handle.side {
     width:4px;
     height:12px;
     border-radius:2px;
   }
+  .sel-overlay .handle.tl,
+  .sel-overlay .handle.br { cursor:nwse-resize; }
+  .sel-overlay .handle.tr,
+  .sel-overlay .handle.bl { cursor:nesw-resize; }
+  .sel-overlay .handle.ml,
+  .sel-overlay .handle.mr { cursor:ew-resize; }
+  .sel-overlay .handle.mt,
+  .sel-overlay .handle.mb { cursor:ns-resize; }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,3 +89,25 @@ html {
   height:36px;
   margin-bottom:4px;
 }
+
+/* === DOM selection overlay ==================================== */
+@layer utilities {
+  .sel-overlay {
+    @apply absolute pointer-events-none box-border z-40;
+    border:1px dashed #2EC4B6; /* SEL_COLOR */
+  }
+  .sel-overlay .handle {
+    position:absolute;
+    width:8px;
+    height:8px;
+    background:#fff;
+    border:1px solid #2EC4B6;
+    border-radius:50%;
+    transform:translate(-50%,-50%);
+  }
+  .sel-overlay .handle.side {
+    width:4px;
+    height:12px;
+    border-radius:2px;
+  }
+}


### PR DESCRIPTION
## Summary
- style DOM overlay elements
- create hover and selection overlays in `FabricCanvas`
- allow overlays to position outside canvas

## Testing
- `npm run lint` *(fails: React hooks / lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ff5ffceac8323b8fd5a1c4148dc24