### PR TITLE
Implement DOM overlays for editor

### DIFF
--- a/app/components/syncGhost.ts
+++ b/app/components/syncGhost.ts
@@ -19,17 +19,10 @@
      // 1 - read positions
      const { left, top, width, height } = img.getBoundingRect();
      const canvasRect = canvas.getBoundingClientRect();
-   
-     // 2 - clamp to canvas bounds (no bleed outside)
-     //    Fabric positions can be negative 👉 clamp at 0..PAGE_W/​H
-     const clampedLeft   = Math.max(0, Math.min(left,  canvas.width));
-     const clampedTop    = Math.max(0, Math.min(top,   canvas.height));
-     const clampedWidth  = Math.max(0, Math.min(width,  canvas.width  - clampedLeft));
-     const clampedHeight = Math.max(0, Math.min(height, canvas.height - clampedTop));
-   
-     // 3 - apply to the overlay div  (convert canvas-space ➜ screen-space)
-     ghost.style.left   = `${canvasRect.left + clampedLeft   * scale}px`;
-     ghost.style.top    = `${canvasRect.top  + clampedTop    * scale}px`;
-     ghost.style.width  = `${clampedWidth  * scale}px`;
-     ghost.style.height = `${clampedHeight * scale}px`;
+
+     // 2 - apply to the overlay div  (canvas-space ➜ screen-space)
+     ghost.style.left   = `${canvasRect.left + left   * scale}px`;
+     ghost.style.top    = `${canvasRect.top  + top    * scale}px`;
+     ghost.style.width  = `${width  * scale}px`;
+     ghost.style.height = `${height * scale}px`;
    }

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,3 +89,30 @@ html {
   height:36px;
   margin-bottom:4px;
 }
+
+/* === DOM selection overlay ==================================== */
+@layer utilities {
+  .sel-overlay {
+    @apply absolute pointer-events-none box-border z-40;
+    border:1px dashed #2EC4B6; /* SEL_COLOR */
+  }
+  .sel-overlay .handle {
+    position:absolute;
+    width:8px;
+    height:8px;
+    background:#fff;
+    border:1px solid #2EC4B6;
+    border-radius:50%;
+    transform:translate(-50%,-50%);
+    pointer-events:auto;
+  }
+  .sel-overlay .handle.side {
+    width:4px;
+    height:12px;
+    border-radius:2px;
+  }
+  .sel-overlay .handle.rotate {
+    width:10px;
+    height:10px;
+  }
+}


### PR DESCRIPTION
## Summary
- style DOM overlay elements
- create hover and selection overlays in `FabricCanvas`
- allow overlays to position outside canvas
- **add selection handles to DOM overlay** so elements remain editable past canvas bounds

## Testing
- `npm run lint` *(fails: React hooks / lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ff5ffceac8323b8fd5a1c4148dc24