### PR TITLE
Fix handle selection outside canvas

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -644,7 +644,8 @@ useEffect(() => {
     document.addEventListener('pointerup', up);
     e.preventDefault();
   };
-  selEl.addEventListener('pointerdown', bridge);
+  // forward pointer events from each handle so they remain interactive
+  Object.values(handleMap).forEach(h => h.addEventListener('pointerdown', bridge));
 
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- forward pointer events from each DOM handle to the Fabric canvas

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, react-hooks/rules-of-hooks, etc)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd095d7083238466e5e26dd448ec