### PR TITLE
Fix selection handles outside canvas

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -645,6 +645,7 @@ useEffect(() => {
     e.preventDefault();
   };
   selEl.addEventListener('pointerdown', bridge);
+  Object.values(handleMap).forEach(h => h.addEventListener('pointerdown', bridge));
 
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- fix DOM overlay pointer events to allow dragging selection handles that spill outside canvas bounds

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860059987388323b28b40bd251619bc