### PR TITLE
Fix DOM overlay handle dragging

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -606,17 +606,6 @@ useEffect(() => {
   document.body.appendChild(selEl);
   selDomRef.current = selEl;
 
-  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
-  const handleMap: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
-    const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : ''} ${c}`;
-    h.dataset.corner = c;
-    selEl.appendChild(h);
-    handleMap[c] = h;
-  });
-  (selEl as any)._handles = handleMap;
-
   const forward = (ev: PointerEvent) => ({
     pointerId: ev.pointerId,
     clientX: ev.clientX,
@@ -644,7 +633,18 @@ useEffect(() => {
     document.addEventListener('pointerup', up);
     e.preventDefault();
   };
-  selEl.addEventListener('pointerdown', bridge);
+
+  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const handleMap: Record<string, HTMLDivElement> = {};
+  corners.forEach(c => {
+    const h = document.createElement('div');
+    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : ''} ${c}`;
+    h.dataset.corner = c;
+    selEl.appendChild(h);
+    h.addEventListener('pointerdown', bridge);
+    handleMap[c] = h;
+  });
+  (selEl as any)._handles = handleMap;
 
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add pointerdown listeners directly on each selection handle element
- remove unused pointerdown listener on container overlay

## Testing
- `npm run lint` *(fails: react-hooks rules in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6860059987388323b28b40bd251619bc