### PR TITLE
Enable draggable selection overlay

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -93,7 +93,8 @@ html {
 /* === DOM selection overlay ==================================== */
 @layer utilities {
   .sel-overlay {
-    @apply absolute pointer-events-none box-border z-40;
+    /* allow dragging objects even when the overlay extends outside the canvas */
+    @apply absolute pointer-events-auto box-border z-40;
     border:1px dashed #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay .handle {


### PR DESCRIPTION
## Summary
- allow the DOM selection overlay to capture pointer events

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861284ec5808323926aa46648050adb