### PR TITLE
Enable draggable selection overlay

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -597,6 +597,7 @@ useEffect(() => {
   const hoverEl = document.createElement('div');
   hoverEl.className = 'sel-overlay';
   hoverEl.style.display = 'none';
+  hoverEl.style.pointerEvents = 'none';
   document.body.appendChild(hoverEl);
   hoverDomRef.current = hoverEl;
 
@@ -884,6 +885,7 @@ let scrollHandler: (() => void) | null = null
 const syncSel = () => {
   const obj = fc.getActiveObject() as fabric.Object | undefined
   if (!obj || !selDomRef.current || !canvasRef.current) return
+  obj.setCoords()
   const box = obj.getBoundingRect(true, true)
   const rect = canvasRef.current.getBoundingClientRect()
   const left   = rect.left + box.left * SCALE

--- a/app/globals.css
+++ b/app/globals.css
@@ -93,7 +93,8 @@ html {
 /* === DOM selection overlay ==================================== */
 @layer utilities {
   .sel-overlay {
-    @apply absolute pointer-events-none box-border z-40;
+    /* allow dragging objects even when the overlay extends outside the canvas */
+    @apply absolute pointer-events-auto box-border z-40;
     border:1px dashed #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay .handle {


### PR DESCRIPTION
## Summary
- allow the DOM selection overlay to capture pointer events
- keep hover overlay pointer-events none
- update selection sync after setting coords

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861284ec5808323926aa46648050adb