### PR TITLE
Enable draggable selection overlay

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -601,7 +601,7 @@ useEffect(() => {
   hoverDomRef.current = hoverEl;
 
   const selEl = document.createElement('div');
-  selEl.className = 'sel-overlay';
+  selEl.className = 'sel-overlay interactive';
   selEl.style.display = 'none';
   document.body.appendChild(selEl);
   selDomRef.current = selEl;
@@ -645,6 +645,9 @@ useEffect(() => {
     e.preventDefault();
   };
   selEl.addEventListener('pointerdown', bridge);
+  selEl.addEventListener('pointermove', e => {
+    fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(e)))
+  })
 
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();
@@ -915,6 +918,7 @@ fc.on('selection:created', () => {
   fc.requestRenderAll()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   syncSel()
+  requestAnimationFrame(syncSel)
   scrollHandler = () => syncSel()
   window.addEventListener('scroll', scrollHandler, { passive:true })
   window.addEventListener('resize', scrollHandler)
@@ -1312,6 +1316,7 @@ img.on('mouseup', () => {
           fc.insertAt(img, idx, false)
           img.setCoords()
           fc.requestRenderAll()
+          doSync()
           document.dispatchEvent(
             new CustomEvent('card-canvas-rendered', {
               detail: { pageIdx, canvas: fc },

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,6 +96,9 @@ html {
     @apply absolute pointer-events-none box-border z-40;
     border:1px dashed #2EC4B6; /* SEL_COLOR */
   }
+  .sel-overlay.interactive {
+    @apply pointer-events-auto;
+  }
   .sel-overlay .handle {
     position:absolute;
     width:8px;


### PR DESCRIPTION
## Summary
- allow DOM selection overlay to accept pointer events via `.interactive` modifier
- fix initial DOM overlay alignment
- forward pointermove events from overlay to canvas

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6861284ec5808323926aa46648050adb