### PR TITLE
Fix selection overlay jumping while dragging new object

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -601,7 +601,7 @@ useEffect(() => {
   hoverDomRef.current = hoverEl;
 
   const selEl = document.createElement('div');
-  selEl.className = 'sel-overlay';
+  selEl.className = 'sel-overlay interactive';
   selEl.style.display = 'none';
   document.body.appendChild(selEl);
   selDomRef.current = selEl;
@@ -631,20 +631,24 @@ useEffect(() => {
   });
 
   const bridge = (e: PointerEvent) => {
-    const down = new MouseEvent('mousedown', forward(e));
-    fc.upperCanvasEl.dispatchEvent(down);
+    const down = new MouseEvent('mousedown', forward(e))
+    fc.upperCanvasEl.dispatchEvent(down)
     const move = (ev: PointerEvent) =>
-      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(ev)));
+      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(ev)))
     const up = (ev: PointerEvent) => {
-      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mouseup', forward(ev)));
-      document.removeEventListener('pointermove', move);
-      document.removeEventListener('pointerup', up);
-    };
-    document.addEventListener('pointermove', move);
-    document.addEventListener('pointerup', up);
-    e.preventDefault();
-  };
-  selEl.addEventListener('pointerdown', bridge);
+      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mouseup', forward(ev)))
+      document.removeEventListener('pointermove', move)
+      document.removeEventListener('pointerup', up)
+    }
+    document.addEventListener('pointermove', move)
+    document.addEventListener('pointerup', up)
+    e.preventDefault()
+  }
+  selEl.addEventListener('pointerdown', bridge)
+
+  const relayMove = (ev: PointerEvent) =>
+    fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(ev)))
+  selEl.addEventListener('pointermove', relayMove)
 
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();
@@ -915,6 +919,7 @@ fc.on('selection:created', () => {
   fc.requestRenderAll()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   syncSel()
+  requestAnimationFrame(syncSel)
   scrollHandler = () => syncSel()
   window.addEventListener('scroll', scrollHandler, { passive:true })
   window.addEventListener('resize', scrollHandler)
@@ -923,6 +928,15 @@ fc.on('selection:created', () => {
 .on('selection:cleared', () => {
   if (scrollHandler) { window.removeEventListener('scroll', scrollHandler); window.removeEventListener('resize', scrollHandler); scrollHandler = null }
   selDomRef.current && (selDomRef.current.style.display = 'none')
+})
+
+// immediately reposition overlay when clicking a different object
+fc.on('mouse:down', e => {
+  if (e.target && e.target !== hoverHL) {
+    selDomRef.current && (selDomRef.current.style.display = 'block')
+    syncSel()
+    requestAnimationFrame(syncSel)
+  }
 })
 
 /* also hide hover during any transform of the active object */
@@ -1312,6 +1326,7 @@ img.on('mouseup', () => {
           fc.insertAt(img, idx, false)
           img.setCoords()
           fc.requestRenderAll()
+          doSync()
           document.dispatchEvent(
             new CustomEvent('card-canvas-rendered', {
               detail: { pageIdx, canvas: fc },

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,6 +96,9 @@ html {
     @apply absolute pointer-events-none box-border z-40;
     border:1px dashed #2EC4B6; /* SEL_COLOR */
   }
+  .sel-overlay.interactive {
+    @apply pointer-events-auto;
+  }
   .sel-overlay .handle {
     position:absolute;
     width:8px;


### PR DESCRIPTION
## Summary
- ensure the DOM selection overlay is repositioned immediately when clicking a different object

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, react/no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861284ec5808323926aa46648050adb