### PR TITLE
Fix hover overlay update while dragging

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -96,6 +96,9 @@ html {
     @apply absolute pointer-events-none box-border z-40;
     border:1px dashed #2EC4B6; /* SEL_COLOR */
   }
+  .sel-overlay.interactive {
+    @apply pointer-events-auto;
+  }
   .sel-overlay .handle {
     position:absolute;
     width:8px;


### PR DESCRIPTION
## Summary
- avoid overlay capturing when selecting other elements
- resync selection overlay on pointer down
- toggle `.interactive` based on out-of-bounds

## Testing
- `npx next lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6861284ec5808323926aa46648050adb