### PR TITLE
Update selection overlay styling

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -592,6 +592,10 @@ useEffect(() => {
   const fc = new fabric.Canvas(canvasRef.current!) as fabric.Canvas & { upperCanvasEl: HTMLCanvasElement };
   fc.backgroundColor = '#fff';
   fc.preserveObjectStacking = true;
+  fc.selectionColor = 'transparent';
+  fc.selectionBorderColor = 'transparent';
+  fc.selectionDashArray = [];
+  fc.selectionLineWidth = 0;
 
   /* create DOM overlays for hover & selection */
   const hoverEl = document.createElement('div');
@@ -1315,6 +1319,7 @@ img.on('mouseup', () => {
           /* keep z-order */
           ;(img as any).layerIdx = idx
           fc.insertAt(img, idx, false)
+          img.set({ hasControls:false, hasBorders:false })
           img.setCoords()
           fc.requestRenderAll()
           doSync()
@@ -1348,6 +1353,7 @@ img.on('mouseup', () => {
         })
         ;(tb as any).layerIdx = idx
         fc.insertAt(tb, idx, false)
+        tb.set({ hasControls:false, hasBorders:false })
       }
     }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -94,24 +94,25 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:1px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;
-    width:8px;
-    height:8px;
+    width:12px;
+    height:12px;
     background:#fff;
     border:1px solid #2EC4B6;
     border-radius:50%;
     transform:translate(-50%,-50%);
     pointer-events:auto;
+    box-shadow:0 0 4px rgba(0,0,0,0.15);
   }
   .sel-overlay .handle.side {
-    width:4px;
-    height:12px;
+    width:20px;
+    height:5px;
     border-radius:2px;
   }
   .sel-overlay .handle.tl,

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -17,6 +17,8 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerColor       = '#fff';
 (fabric.Object.prototype as any).transparentCorners= false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
+(fabric.Object.prototype as any).hasBorders        = false;
+(fabric.Object.prototype as any).hasControls       = false;
 
 /* ───────────────── helpers ──────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- style DOM overlay handles to match Fabric style
- hide Fabric's default selection outline
- remove Fabric handles/borders by default

## Testing
- `npm run lint` *(fails: React hooks and Next.js warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686136ef6c348323b071c2289d998b67