### PR TITLE
Update DOM overlay style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -94,25 +94,33 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:1px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;
-    width:8px;
-    height:8px;
+    width:12px;
+    height:12px;
     background:#fff;
     border:1px solid #2EC4B6;
     border-radius:50%;
+    box-shadow:0 0 4px rgba(0,0,0,0.15);
     transform:translate(-50%,-50%);
     pointer-events:auto;
   }
-  .sel-overlay .handle.side {
-    width:4px;
-    height:12px;
-    border-radius:2px;
+  .sel-overlay .handle.ml,
+  .sel-overlay .handle.mr {
+    width:5px;
+    height:20px;
+    border-radius:2.5px;
+  }
+  .sel-overlay .handle.mt,
+  .sel-overlay .handle.mb {
+    width:20px;
+    height:5px;
+    border-radius:2.5px;
   }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -11,10 +11,10 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerSize        = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).touchCornerSize   = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).borderScaleFactor = 1;
-(fabric.Object.prototype as any).borderColor       = SEL_COLOR;
+(fabric.Object.prototype as any).borderColor       = 'transparent';
 (fabric.Object.prototype as any).borderDashArray   = [];
-(fabric.Object.prototype as any).cornerStrokeColor = '#fff';
-(fabric.Object.prototype as any).cornerColor       = '#fff';
+(fabric.Object.prototype as any).cornerStrokeColor = 'transparent';
+(fabric.Object.prototype as any).cornerColor       = 'transparent';
 (fabric.Object.prototype as any).transparentCorners= false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
 


### PR DESCRIPTION
## Summary
- style DOM selection overlay with solid teal borders and drop-shadowed handles
- hide Fabric's built-in borders and handle graphics

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686136ef6c348323b071c2289d998b67