### PR TITLE
Adjust crop tool canvas expansion

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -25,7 +25,7 @@ export class CropTool {
   /** canvas size before cropping */
   private baseW = 0;
   private baseH = 0;
-  private wrapStyles: { w:string; h:string; mw:string; mh:string } | null = null;
+  private wrapStyles: { w:string; h:string; mw:string; mh:string; left:string; top:string } | null = null;
   /** clean‑up callbacks to run on `teardown()` */
   private cleanup: Array<() => void> = [];
 
@@ -127,12 +127,20 @@ export class CropTool {
         h : wrapper.style.height,
         mw: wrapper.style.maxWidth,
         mh: wrapper.style.maxHeight,
+        left: wrapper.style.left,
+        top : wrapper.style.top,
       }
     }
     const br = img.getBoundingRect(true, true)
-    const needW = Math.max(this.baseW, (br.left + br.width) * this.SCALE)
-    const needH = Math.max(this.baseH, (br.top + br.height) * this.SCALE)
-    if (needW > this.baseW || needH > this.baseH) {
+    const minX = Math.min(0, br.left)
+    const minY = Math.min(0, br.top)
+    const maxX = Math.max(this.baseW / this.SCALE, br.left + br.width)
+    const maxY = Math.max(this.baseH / this.SCALE, br.top + br.height)
+
+    const needW = (maxX - minX) * this.SCALE
+    const needH = (maxY - minY) * this.SCALE
+
+    if (needW > this.baseW || needH > this.baseH || minX < 0 || minY < 0) {
       this.fc.setWidth(needW)
       this.fc.setHeight(needH)
       if (wrapper) {
@@ -140,6 +148,8 @@ export class CropTool {
         wrapper.style.height = `${needH}px`
         wrapper.style.maxWidth = `${needW}px`
         wrapper.style.maxHeight = `${needH}px`
+        wrapper.style.left = `${-minX * this.SCALE}px`
+        wrapper.style.top  = `${-minY * this.SCALE}px`
       }
     }
     this.cleanup.push(() => {
@@ -725,6 +735,8 @@ export class CropTool {
         wrap.style.height = this.wrapStyles.h
         wrap.style.maxWidth = this.wrapStyles.mw
         wrap.style.maxHeight = this.wrapStyles.mh
+        wrap.style.left = this.wrapStyles.left
+        wrap.style.top  = this.wrapStyles.top
       }
       this.baseW = 0
       this.baseH = 0


### PR DESCRIPTION
## Summary
- adjust CropTool to expand canvas bounds in all directions
- store/restore wrapper offset when cropping finishes

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68619c9f778c8323a84bbfb5110a4095