### PR TITLE
Improve crop overlay alignment

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -268,7 +268,9 @@ const syncGhost = (
   ghost : HTMLDivElement,
   canvas: HTMLCanvasElement,
 ) => {
-  const canvasRect = canvas.getBoundingClientRect()
+  const canvasRect =
+    canvas.parentElement?.getBoundingClientRect() ??
+    canvas.getBoundingClientRect()
   const { left, top, width, height } = img.getBoundingRect()
 
   ghost.style.left   = `${canvasRect.left + left   * SCALE}px`

--- a/app/components/syncGhost.ts
+++ b/app/components/syncGhost.ts
@@ -10,19 +10,21 @@
     * @param canvas  The <canvas> element for this page
     * @param scale   Canvas → preview scale (SCALE from FabricCanvas)
     */
-   export function syncGhost(
-     img    : fabric.Image,
-     ghost  : HTMLDivElement,
-     canvas : HTMLCanvasElement,
-     scale  : number,
-   ) {
-     // 1 - read positions
-     const { left, top, width, height } = img.getBoundingRect();
-     const canvasRect = canvas.getBoundingClientRect();
+export function syncGhost(
+  img    : fabric.Image,
+  ghost  : HTMLDivElement,
+  canvas : HTMLCanvasElement,
+  scale  : number,
+) {
+  // 1 - read positions
+  const { left, top, width, height } = img.getBoundingRect();
+  const wrapperRect =
+    canvas.parentElement?.getBoundingClientRect() ??
+    canvas.getBoundingClientRect();
 
-     // 2 - apply to the overlay div  (canvas-space ➜ screen-space)
-     ghost.style.left   = `${canvasRect.left + left   * scale}px`;
-     ghost.style.top    = `${canvasRect.top  + top    * scale}px`;
-     ghost.style.width  = `${width  * scale}px`;
-     ghost.style.height = `${height * scale}px`;
-   }
+  // 2 - apply to the overlay div  (canvas-space ➜ screen-space)
+  ghost.style.left   = `${wrapperRect.left + left   * scale}px`;
+  ghost.style.top    = `${wrapperRect.top  + top    * scale}px`;
+  ghost.style.width  = `${width  * scale}px`;
+  ghost.style.height = `${height * scale}px`;
+}


### PR DESCRIPTION
## Summary
- adjust syncGhost to use wrapper dimensions when positioning overlays
- update local syncGhost helper in FabricCanvas

## Testing
- `npm run lint` *(fails: react-hooks and other existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6861a5d302148323abeada150de673cc