### PR TITLE
Add product page template

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -139,7 +139,10 @@ export default async function HomePage() {
 
       {/* FOOTER */}
       <footer className="py-10 text-center text-sm" style={{ backgroundColor: teal, color: cream }}>
-        © {new Date().getFullYear()} Walty Ltd. All rights reserved.
+        © {new Date().getFullYear()} Walty Ltd. All rights reserved.{' '}
+        <Link href="/products/cards/daisy" className="underline ml-2">
+          Example product
+        </Link>
       </footer>
     </main>
   );

--- a/app/products/[product]/[slug]/page.tsx
+++ b/app/products/[product]/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from 'next/navigation'
+import Image from 'next/image'
+import Link from 'next/link'
+import { sanityPreview } from '@/sanity/lib/client'
+import { getTemplatePages } from '@/app/library/getTemplatePages'
+import ProductTabs from '@/components/ProductTabs'
+
+export default async function ProductPage({ params }: { params: { product: string; slug: string } }) {
+  const { slug } = params
+
+  const meta = await sanityPreview.fetch<{title:string;description:string;coverImage?:any}>(
+    `*[_type=="cardTemplate" && slug.current==$s][0]{title,description,coverImage}`,
+    { s: slug }
+  )
+  if (!meta) return notFound()
+
+  const { pages } = await getTemplatePages(slug)
+
+  const images = pages.map(p => {
+    const img = p.layers.find(l => l.type === 'image' && l.src) as {src:string} | undefined
+    return img?.src
+  }).filter(Boolean) as string[]
+
+  return (
+    <main className="max-w-4xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl font-serif font-bold text-center">{meta.title}</h1>
+
+      <div className="flex gap-4 overflow-x-auto">
+        {images.map((src, i) => (
+          <Image key={i} src={src} alt="" width={300} height={420} className="rounded shadow" />
+        ))}
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex gap-2 justify-center">
+          {['Digital Card','Mini Card','Classic Card','Giant Card'].map(label => (
+            <button key={label} className="border px-3 py-1 rounded-full" disabled>
+              {label}
+            </button>
+          ))}
+        </div>
+        <Link href={`/cards/${slug}/customise`} className="block text-center bg-[--walty-orange] text-white font-semibold py-3 rounded">
+          Personalise this card
+        </Link>
+      </div>
+
+      <ProductTabs description={meta.description || ''} />
+    </main>
+  )
+}

--- a/components/ProductTabs.tsx
+++ b/components/ProductTabs.tsx
@@ -1,0 +1,32 @@
+'use client'
+import { useState } from 'react'
+
+export default function ProductTabs({ description }: { description: string }) {
+  const [tab, setTab] = useState<'description' | 'delivery'>('description')
+
+  return (
+    <div>
+      <div className="flex border-b mb-4">
+        <button
+          onClick={() => setTab('description')}
+          className={`px-4 py-2 ${tab==='description'?'border-b-2 border-[--walty-orange]':''}`}
+        >
+          Description
+        </button>
+        <button
+          onClick={() => setTab('delivery')}
+          className={`px-4 py-2 ${tab==='delivery'?'border-b-2 border-[--walty-orange]':''}`}
+        >
+          Delivery
+        </button>
+      </div>
+      <div className="p-4 bg-gray-50 rounded">
+        {tab==='description' ? (
+          <p>{description}</p>
+        ) : (
+          <p>Standard delivery 1-3 days. Worldwide shipping available.</p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new product page route at `/products/[product]/[slug]`
- implement tabbed description/delivery info
- link to new product page from footer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861a7f36d3883239644433d22827a62