### PR TITLE
Add product page template

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -140,6 +140,10 @@ export default async function HomePage() {
       {/* FOOTER */}
       <footer className="py-10 text-center text-sm" style={{ backgroundColor: teal, color: cream }}>
         © {new Date().getFullYear()} Walty Ltd. All rights reserved.
+        <br />
+        <Link href="/products/cards/daisy" className="underline">
+          Sample product page
+        </Link>
       </footer>
     </main>
   );

--- a/app/products/[product]/[slug]/ProductPageClient.tsx
+++ b/app/products/[product]/[slug]/ProductPageClient.tsx
@@ -1,0 +1,83 @@
+'use client'
+import { useState } from 'react'
+
+interface Product {
+  title: string
+  variantHandle: string
+}
+
+export default function ProductPageClient({
+  gallery,
+  title,
+  description,
+  products,
+  editorUrl,
+}: {
+  gallery: string[]
+  title: string
+  description?: string
+  products?: Product[]
+  editorUrl: string
+}) {
+  const [tab, setTab] = useState<'desc' | 'delivery'>('desc')
+  const opts = products && products.length
+    ? products.map(p => ({ label: p.title, handle: p.variantHandle }))
+    : [
+        { label: 'Digital Card', handle: 'digital' },
+        { label: 'Mini Card', handle: 'gc-mini' },
+        { label: 'Classic Card', handle: 'gc-classic' },
+        { label: 'Giant Card', handle: 'gc-large' },
+      ]
+  const [variant, setVariant] = useState(opts[0].handle)
+  return (
+    <main className="p-6 max-w-2xl mx-auto space-y-6">
+      <div className="grid grid-cols-2 gap-4">
+        {gallery.map((src, i) => (
+          <img key={i} src={src} alt="" className="w-full rounded" />
+        ))}
+      </div>
+      <h1 className="text-2xl font-bold">{title}</h1>
+      <div className="space-y-2">
+        {opts.map(o => (
+          <label key={o.handle} className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="variant"
+              value={o.handle}
+              checked={variant === o.handle}
+              onChange={() => setVariant(o.handle)}
+            />
+            {o.label}
+          </label>
+        ))}
+      </div>
+      <a
+        href={editorUrl}
+        className="block text-center bg-pink-600 text-white py-3 rounded mt-4"
+      >
+        Personalise →
+      </a>
+      <div>
+        <nav className="flex border-b mt-6">
+          <button
+            onClick={() => setTab('desc')}
+            className={`px-4 py-2 ${tab === 'desc' ? 'border-b-2 border-pink-600' : ''}`}
+          >
+            Description
+          </button>
+          <button
+            onClick={() => setTab('delivery')}
+            className={`px-4 py-2 ${tab === 'delivery' ? 'border-b-2 border-pink-600' : ''}`}
+          >
+            Delivery Info
+          </button>
+        </nav>
+        {tab === 'desc' ? (
+          <div className="p-4 whitespace-pre-line">{description || 'No description available.'}</div>
+        ) : (
+          <div className="p-4">Delivery information coming soon.</div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/app/products/[product]/[slug]/page.tsx
+++ b/app/products/[product]/[slug]/page.tsx
@@ -1,0 +1,30 @@
+import ProductPageClient from './ProductPageClient'
+import { getTemplatePages } from '@/app/library/getTemplatePages'
+import { sanityFetch } from '@/lib/sanityClient'
+import { urlFor } from '@/sanity/lib/image'
+
+export default async function ProductPage({ params }: { params: { product: string; slug: string } }) {
+  const { slug } = params
+  const { pages, products } = await getTemplatePages(slug)
+  const meta = await sanityFetch<{title:string;description?:string}>(
+    `*[_type=="cardTemplate" && slug.current==$s][0]{title,description}`,
+    { s: slug }
+  )
+
+  const gallery: string[] = []
+  for (const page of pages) {
+    const img = page.layers?.find((l: any) => l.type === 'image' && l.src)
+    if (img?.src) gallery.push(urlFor(img.src).url())
+    else if (img?.srcUrl) gallery.push(img.srcUrl)
+  }
+
+  return (
+    <ProductPageClient
+      gallery={gallery}
+      title={meta?.title || slug}
+      description={meta?.description}
+      products={products}
+      editorUrl={`/cards/${slug}/customise`}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- create dynamic marketing page at `/products/[product]/[slug]`
- implement `ProductPageClient` with gallery, variant radio buttons and tabs
- link to a sample product page in the home page footer

## Testing
- `npm run lint` *(fails: React hook errors and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861a7f36d3883239644433d22827a62