### PR TITLE
Add basic product page template

### DIFF
--- a/app/components/ProductTabs.tsx
+++ b/app/components/ProductTabs.tsx
@@ -1,0 +1,29 @@
+'use client'
+import { useState } from 'react'
+
+export default function ProductTabs({ description }: { description: string }) {
+  const [tab, setTab] = useState<'desc' | 'delivery'>('desc')
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-6 border-b pb-2">
+        <button
+          onClick={() => setTab('desc')}
+          className={`font-semibold ${tab==='desc' ? 'border-b-2 border-[--walty-teal]' : ''}`}
+        >
+          Description
+        </button>
+        <button
+          onClick={() => setTab('delivery')}
+          className={`font-semibold ${tab==='delivery' ? 'border-b-2 border-[--walty-teal]' : ''}`}
+        >
+          Delivery
+        </button>
+      </div>
+      {tab === 'desc' ? (
+        <p>{description || 'No description available.'}</p>
+      ) : (
+        <p>Delivery information coming soon.</p>
+      )}
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -139,6 +139,9 @@ export default async function HomePage() {
 
       {/* FOOTER */}
       <footer className="py-10 text-center text-sm" style={{ backgroundColor: teal, color: cream }}>
+        <p className="mb-2">
+          <Link href="/products/cards/test-27-jun-2025" className="underline">Test product page</Link>
+        </p>
         © {new Date().getFullYear()} Walty Ltd. All rights reserved.
       </footer>
     </main>

--- a/app/products/[product]/[template]/page.tsx
+++ b/app/products/[product]/[template]/page.tsx
@@ -1,0 +1,71 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { sanityFetch } from '@/lib/sanityClient'
+import { urlFor } from '@/sanity/lib/image'
+import ProductTabs from '@/app/components/ProductTabs'
+
+interface PageData {
+  title: string
+  description?: string
+  pages?: { layers?: any[] }[]
+  products?: { title: string; variantHandle: string }[]
+}
+
+export default async function ProductPage({
+  params,
+}: {
+  params: { product: string; template: string }
+}) {
+  const { template } = params
+  const query = `*[_type=="cardTemplate" && slug.current==$slug][0]{
+    title,
+    description,
+    pages[]{ layers[0]{ _type, src, srcUrl, asset-> } },
+    products[]->{ title, variantHandle }
+  }`
+  const data = await sanityFetch<PageData>(query, { slug: template })
+  if (!data) return null
+
+  const images = (data.pages || [])
+    .map(p => {
+      const l = p.layers?.[0]
+      if (!l) return null
+      if (l.asset) return urlFor(l.asset).width(480).url()
+      if (l.src) return typeof l.src === 'string' ? l.src : urlFor(l.src).width(480).url()
+      if (l.srcUrl) return l.srcUrl
+      return null
+    })
+    .filter(Boolean) as string[]
+
+  const variants = (data.products || []).map(p => ({ label: p.title, handle: p.variantHandle }))
+
+  return (
+    <main className="max-w-5xl mx-auto p-6 space-y-8">
+      <div className="grid md:grid-cols-2 gap-8">
+        <div className="grid grid-cols-2 gap-4">
+          {images.map((src, i) => (
+            <Image key={i} src={src} alt={data.title} width={300} height={420} className="w-full h-auto rounded shadow" />
+          ))}
+        </div>
+        <div>
+          <h1 className="font-serif text-3xl font-bold mb-4">{data.title}</h1>
+          {variants.length > 0 && (
+            <ul className="space-y-2 mb-6">
+              {variants.map(v => (
+                <li key={v.handle} className="flex items-center gap-2">
+                  <input type="radio" name="variant" id={v.handle} />
+                  <label htmlFor={v.handle}>{v.label}</label>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Link href={`/cards/${template}/customise`} className="block text-center bg-[--walty-orange] text-white font-semibold py-3 rounded">
+            Personalise →
+          </Link>
+        </div>
+      </div>
+      <ProductTabs description={data.description || ''} />
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- create dynamic product page for `/products/[product]/[template]`
- show gallery images and variant options
- add simple client tabs for description/delivery
- link to test product page in footer

## Testing
- `npm run lint` *(fails: react-hooks rules and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6861aab582508323a8f38416bf0b0a14