### PR TITLE
Add product page template

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -140,6 +140,10 @@ export default async function HomePage() {
       {/* FOOTER */}
       <footer className="py-10 text-center text-sm" style={{ backgroundColor: teal, color: cream }}>
         © {new Date().getFullYear()} Walty Ltd. All rights reserved.
+        {' '}
+        <Link href="/products/digital/test-27-jun-2025" className="underline ml-2">
+          Test product page
+        </Link>
       </footer>
     </main>
   );

--- a/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
+++ b/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
@@ -1,0 +1,82 @@
+'use client'
+import { useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+
+interface Variant { title: string; variantHandle: string; slug: string }
+
+export default function ProductClient({
+  title,
+  slug,
+  description,
+  images,
+  variants,
+}: {
+  title: string
+  slug: string
+  description?: string
+  images: string[]
+  variants: Variant[]
+}) {
+  const [selected, setSelected] = useState<string>('')
+  const [tab, setTab] = useState<'desc'|'delivery'>('desc')
+
+  return (
+    <main className="p-6 space-y-6">
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="space-y-4">
+          {images.map((src, i) => (
+            <Image key={i} src={src} width={420} height={580} alt={`page ${i+1}`} className="w-full rounded shadow" />
+          ))}
+        </div>
+        <div className="space-y-4">
+          <h1 className="text-2xl font-bold">{title}</h1>
+          <ul className="space-y-2">
+            {variants.map(v => (
+              <li key={v.variantHandle}>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="variant"
+                    value={v.variantHandle}
+                    onChange={() => setSelected(v.variantHandle)}
+                    className="accent-[--walty-orange]"
+                  />
+                  {v.title}
+                </label>
+              </li>
+            ))}
+          </ul>
+          <Link
+            href={`/cards/${slug}/customise`}
+            className="inline-block bg-[--walty-orange] text-white px-6 py-3 rounded text-center w-full"
+          >
+            Personalise →
+          </Link>
+        </div>
+      </div>
+      <div>
+        <div className="flex gap-4 border-b">
+          <button
+            onClick={() => setTab('desc')}
+            className={`pb-2 ${tab==='desc' ? 'border-b-2 border-[--walty-orange]' : ''}`}
+          >
+            Description
+          </button>
+          <button
+            onClick={() => setTab('delivery')}
+            className={`pb-2 ${tab==='delivery' ? 'border-b-2 border-[--walty-orange]' : ''}`}
+          >
+            Delivery
+          </button>
+        </div>
+        {tab==='desc' && (
+          <p className="mt-4 whitespace-pre-wrap">{description || 'No description available.'}</p>
+        )}
+        {tab==='delivery' && (
+          <p className="mt-4">Delivery information coming soon.</p>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/app/products/[productSlug]/[templateSlug]/page.tsx
+++ b/app/products/[productSlug]/[templateSlug]/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from 'next/navigation'
+import ProductClient from './ProductClient'
+import { sanityPreview } from '@/sanity/lib/client'
+import { urlFor } from '@/sanity/lib/image'
+
+export default async function ProductPage({
+  params,
+}: {
+  params: { productSlug: string; templateSlug: string }
+}) {
+  const { templateSlug } = params
+  const data = await sanityPreview.fetch(
+    `*[_type=="cardTemplate" && slug.current==$slug][0]{
+      title,
+      slug,
+      description,
+      pages[]{ layers[]{ _type, src, srcUrl, bgImage } },
+      coverImage,
+      "variants": products[]->variants[]->{ title, variantHandle, "slug": slug.current }
+    }`,
+    { slug: templateSlug }
+  )
+
+  if (!data) return notFound()
+
+  const images: string[] = []
+  if (Array.isArray(data.pages)) {
+    for (const p of data.pages) {
+      const layer = p?.layers?.find((l: any) => l?.src || l?.bgImage)
+      if (layer?.src) images.push(urlFor(layer.src).width(420).height(580).url())
+      else if (layer?.bgImage) images.push(urlFor(layer.bgImage).width(420).height(580).url())
+    }
+  }
+  if (!images.length && data.coverImage) {
+    images.push(urlFor(data.coverImage).width(420).height(580).url())
+  }
+
+  return (
+    <ProductClient
+      title={data.title}
+      slug={data.slug.current}
+      description={data.description}
+      images={images}
+      variants={data.variants || []}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add a dynamic product page that can show any card template
- allow variant selection and CTA to the editor
- link to example product in the homepage footer

## Testing
- `npm run lint` *(fails: various lint errors in repo)*
- `npm run build` *(fails: failed to fetch fonts due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6861aab582508323a8f38416bf0b0a14