### PR TITLE
Add basic product page and footer link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -140,6 +140,7 @@ export default async function HomePage() {
       {/* FOOTER */}
       <footer className="py-10 text-center text-sm" style={{ backgroundColor: teal, color: cream }}>
         © {new Date().getFullYear()} Walty Ltd. All rights reserved.
+                  <div className="mt-2"><Link href="/products/cards/test-27-jun-2025" className="underline">Test product page</Link></div>
       </footer>
     </main>
   );

--- a/app/products/[productSlug]/[templateSlug]/page.tsx
+++ b/app/products/[productSlug]/[templateSlug]/page.tsx
@@ -1,0 +1,58 @@
+import ProductTabs from "@/components/ProductTabs";
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { sanityPreview } from '@/sanity/lib/client';
+import { getTemplatePages } from '@/app/library/getTemplatePages';
+
+export default async function ProductPage({ params }: { params: { productSlug: string; templateSlug: string } }) {
+  const { productSlug, templateSlug } = params;
+
+  const query = `*[_type=="cardTemplate" && slug.current==$tpl][0]{
+    title,
+    products[slug.current==$prod][0]->{
+      title,
+      description,
+      slug,
+      variants[]->{title, variantHandle, slug, price}
+    }
+  }`;
+
+  const tpl = await sanityPreview.fetch<{ title: string; products?: any }>(query, { tpl: templateSlug, prod: productSlug });
+
+  if (!tpl || !tpl.products) notFound();
+  const product = tpl.products;
+
+  const { pages } = await getTemplatePages(templateSlug);
+
+  const images = pages
+    .map(p => p.layers.find(l => l.type === 'image' && typeof l.src === 'string')?.src)
+    .filter(Boolean) as string[];
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10 space-y-8">
+      <div className="grid md:grid-cols-2 gap-8">
+        <div className="flex gap-4 overflow-x-auto">
+          {images.map((src, i) => (
+            <img key={i} src={src} alt={`Page ${i + 1}`} className="w-60 h-auto rounded shadow" />
+          ))}
+        </div>
+        <div className="space-y-4">
+          <h1 className="text-3xl font-serif font-bold">{tpl.title}</h1>
+          <ul className="space-y-1">
+            {product.variants?.map((v: any) => (
+              <li key={v.variantHandle}>{v.title}</li>
+            ))}
+          </ul>
+          <Link
+            href={`/cards/${templateSlug}/customise`}
+            className="block text-center bg-[--walty-orange] text-white font-semibold py-3 rounded-md"
+          >
+            Personalise this design
+          </Link>
+        </div>
+      </div>
+      <ProductTabs description={product.description} />
+    </main>
+  );
+}
+

--- a/components/ProductTabs.tsx
+++ b/components/ProductTabs.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { useState } from "react";
+
+export default function ProductTabs({ description }: { description?: string }) {
+  const [tab, setTab] = useState<'desc' | 'delivery'>('desc');
+  return (
+    <div>
+      <div className="flex border-b mb-4">
+        <button
+          onClick={() => setTab('desc')}
+          className={`px-4 py-2 font-semibold ${tab==='desc' ? 'border-b-2 border-[--walty-orange]' : ''}`}
+        >
+          Description
+        </button>
+        <button
+          onClick={() => setTab('delivery')}
+          className={`px-4 py-2 font-semibold ${tab==='delivery' ? 'border-b-2 border-[--walty-orange]' : ''}`}
+        >
+          Delivery
+        </button>
+      </div>
+      {tab === 'desc' ? (
+        <p>{description || 'No description available.'}</p>
+      ) : (
+        <p>Orders are printed within 2 working days and shipped via Royal Mail.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple ProductTabs client component
- add dynamic product page under `/products/[productSlug]/[templateSlug]`
- link to test product page from site footer

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861aab582508323a8f38416bf0b0a14