### PR TITLE
Improve product gallery layout

### DIFF
--- a/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
+++ b/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
@@ -1,9 +1,13 @@
-'use client'
-import { useState } from 'react'
-import Image from 'next/image'
-import Link from 'next/link'
+"use client";
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
 
-interface Variant { title: string; variantHandle: string; slug: string }
+interface Variant {
+  title: string;
+  variantHandle: string;
+  slug: string;
+}
 
 export default function ProductClient({
   title,
@@ -12,27 +16,53 @@ export default function ProductClient({
   images,
   variants,
 }: {
-  title: string
-  slug: string
-  description?: string
-  images: string[]
-  variants: Variant[]
+  title: string;
+  slug: string;
+  description?: string;
+  images: string[];
+  variants: Variant[];
 }) {
-  const [selected, setSelected] = useState<string>('')
-  const [tab, setTab] = useState<'desc'|'delivery'>('desc')
+  const [selected, setSelected] = useState<string>("");
+  const [tab, setTab] = useState<"desc" | "delivery">("desc");
+  const [activeIdx, setActiveIdx] = useState(0);
 
   return (
-    <main className="p-6 space-y-6">
+    <main className="p-6 space-y-6 max-w-4xl mx-auto">
       <div className="grid md:grid-cols-2 gap-6">
         <div className="space-y-4">
-          {images.map((src, i) => (
-            <Image key={i} src={src} width={420} height={580} alt={`page ${i+1}`} className="w-full rounded shadow" />
-          ))}
+          {images[activeIdx] && (
+            <Image
+              src={images[activeIdx]}
+              width={320}
+              height={440}
+              alt={`page ${activeIdx + 1}`}
+              className="w-full rounded shadow"
+            />
+          )}
+          {images.length > 1 && (
+            <div className="flex justify-center gap-2">
+              {images.map((src, i) => (
+                <button
+                  key={i}
+                  onClick={() => setActiveIdx(i)}
+                  className={`rounded shadow focus:outline-none ${activeIdx === i ? "ring-2 ring-[--walty-orange]" : ""}`}
+                >
+                  <Image
+                    src={src}
+                    width={60}
+                    height={80}
+                    alt={`thumb ${i + 1}`}
+                    className="w-16 h-auto rounded"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
         </div>
         <div className="space-y-4">
           <h1 className="text-2xl font-bold">{title}</h1>
           <ul className="space-y-2">
-            {variants.map(v => (
+            {variants.map((v) => (
               <li key={v.variantHandle}>
                 <label className="flex items-center gap-2">
                   <input
@@ -58,25 +88,27 @@ export default function ProductClient({
       <div>
         <div className="flex gap-4 border-b">
           <button
-            onClick={() => setTab('desc')}
-            className={`pb-2 ${tab==='desc' ? 'border-b-2 border-[--walty-orange]' : ''}`}
+            onClick={() => setTab("desc")}
+            className={`pb-2 ${tab === "desc" ? "border-b-2 border-[--walty-orange]" : ""}`}
           >
             Description
           </button>
           <button
-            onClick={() => setTab('delivery')}
-            className={`pb-2 ${tab==='delivery' ? 'border-b-2 border-[--walty-orange]' : ''}`}
+            onClick={() => setTab("delivery")}
+            className={`pb-2 ${tab === "delivery" ? "border-b-2 border-[--walty-orange]" : ""}`}
           >
             Delivery
           </button>
         </div>
-        {tab==='desc' && (
-          <p className="mt-4 whitespace-pre-wrap">{description || 'No description available.'}</p>
+        {tab === "desc" && (
+          <p className="mt-4 whitespace-pre-wrap">
+            {description || "No description available."}
+          </p>
         )}
-        {tab==='delivery' && (
+        {tab === "delivery" && (
           <p className="mt-4">Delivery information coming soon.</p>
         )}
       </div>
     </main>
-  )
+  );
 }

--- a/app/products/[productSlug]/[templateSlug]/page.tsx
+++ b/app/products/[productSlug]/[templateSlug]/page.tsx
@@ -1,14 +1,14 @@
-import { notFound } from 'next/navigation'
-import ProductClient from './ProductClient'
-import { sanityPreview } from '@/sanity/lib/client'
-import { urlFor } from '@/sanity/lib/image'
+import { notFound } from "next/navigation";
+import ProductClient from "./ProductClient";
+import { sanityPreview } from "@/sanity/lib/client";
+import { urlFor } from "@/sanity/lib/image";
 
 export default async function ProductPage({
   params,
 }: {
-  params: { productSlug: string; templateSlug: string }
+  params: { productSlug: string; templateSlug: string };
 }) {
-  const { templateSlug } = params
+  const { templateSlug } = params;
   const data = await sanityPreview.fetch(
     `*[_type=="cardTemplate" && slug.current==$slug][0]{
       title,
@@ -18,21 +18,23 @@ export default async function ProductPage({
       coverImage,
       "variants": products[]->variants[]->{ title, variantHandle, "slug": slug.current }
     }`,
-    { slug: templateSlug }
-  )
+    { slug: templateSlug },
+  );
 
-  if (!data) return notFound()
+  if (!data) return notFound();
 
-  const images: string[] = []
+  const images: string[] = [];
   if (Array.isArray(data.pages)) {
     for (const p of data.pages) {
-      const layer = p?.layers?.find((l: any) => l?.src || l?.bgImage)
-      if (layer?.src) images.push(urlFor(layer.src).width(420).height(580).url())
-      else if (layer?.bgImage) images.push(urlFor(layer.bgImage).width(420).height(580).url())
+      const layer = p?.layers?.find((l: any) => l?.src || l?.bgImage);
+      if (layer?.src)
+        images.push(urlFor(layer.src).width(320).height(440).url());
+      else if (layer?.bgImage)
+        images.push(urlFor(layer.bgImage).width(320).height(440).url());
     }
   }
   if (!images.length && data.coverImage) {
-    images.push(urlFor(data.coverImage).width(420).height(580).url())
+    images.push(urlFor(data.coverImage).width(320).height(440).url());
   }
 
   return (
@@ -43,5 +45,5 @@ export default async function ProductPage({
       images={images}
       variants={data.variants || []}
     />
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- shrink the main product image and show gallery thumbnails
- add navigation state for the active page image
- limit product page width
- adjust image fetch sizes to match smaller display

## Testing
- `npm run lint` *(fails: multiple lint errors across unrelated files)*
- `npx prettier -w app/products/[productSlug]/[templateSlug]/{ProductClient.tsx,page.tsx}`

------
https://chatgpt.com/codex/tasks/task_e_6861b31d604c8323941dcf394b60c973