### PR TITLE
Enable full-image visibility in crop mode

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -658,7 +658,11 @@ const handleProofAll = async () => {
         />
       )}
       
-      <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
+      <div
+        className={`flex flex-1 relative bg-[--walty-cream] mx-auto ${
+          isCropMode ? '' : 'lg:max-w-6xl'
+        }`}
+      >
         {/* global overlays */}
         <CoachMark
           anchor={anchor}
@@ -685,7 +689,11 @@ const handleProofAll = async () => {
         {!isCropMode && <LayerPanel />}
 
         {/* main */}
-        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[868px]">
+        <div
+          className={`flex flex-col flex-1 min-h-0 mx-auto ${
+            isCropMode ? 'max-w-none' : 'max-w-[868px]'
+          }`}
+        >
           {!isCropMode && (activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}
@@ -711,7 +719,11 @@ const handleProofAll = async () => {
           ))}
 
                     {/* canvases */}
-          <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
+          <div
+            className={`flex-1 flex justify-center items-start bg-[--walty-cream] pt-6 gap-6 ${
+              isCropMode ? 'overflow-visible' : 'overflow-auto'
+            }`}
+          >
             {/* front */}
             <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -696,6 +696,9 @@ useEffect(() => {
   // create a reusable crop helper and keep it in a ref
   const crop = new CropTool(fc, SCALE, SEL_COLOR, state => {
     croppingRef.current = state
+    if (state && selDomRef.current) {
+      selDomRef.current.style.display = 'none'
+    }
     onCroppingChange?.(state)
   })
   cropToolRef.current = crop;
@@ -904,11 +907,13 @@ let scrollHandler: (() => void) | null = null
 
 const syncSel = () => {
   const obj = fc.getActiveObject() as fabric.Object | undefined
+  if (croppingRef.current) return
   if (!obj || !selDomRef.current || !canvasRef.current) return
   const box = obj.getBoundingRect(true, true)
   const rect = canvasRef.current.getBoundingClientRect()
-  const left   = rect.left + box.left * SCALE
-  const top    = rect.top  + box.top  * SCALE
+  const vt = fc.viewportTransform || [1,0,0,1,0,0]
+  const left   = rect.left + vt[4] + box.left * SCALE
+  const top    = rect.top  + vt[5] + box.top  * SCALE
   const width  = box.width  * SCALE
   const height = box.height * SCALE
   const overlay = selDomRef.current as HTMLDivElement & { _handles?: Record<string, HTMLDivElement> }
@@ -934,12 +939,14 @@ const syncSel = () => {
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
-  selDomRef.current && (selDomRef.current.style.display = 'block')
-  syncSel()
-  requestAnimationFrame(syncSel)
-  scrollHandler = () => syncSel()
-  window.addEventListener('scroll', scrollHandler, { passive:true })
-  window.addEventListener('resize', scrollHandler)
+  if (!croppingRef.current) {
+    selDomRef.current && (selDomRef.current.style.display = 'block')
+    syncSel()
+    requestAnimationFrame(syncSel)
+    scrollHandler = () => syncSel()
+    window.addEventListener('scroll', scrollHandler, { passive:true })
+    window.addEventListener('resize', scrollHandler)
+  }
 })
 .on('selection:updated', syncSel)
 .on('selection:cleared', () => {
@@ -959,9 +966,10 @@ fc.on('mouse:over', e => {
   if (fc.getActiveObject() === t) return           // skip active selection
   const box = t.getBoundingRect(true, true)
   const rect = canvasRef.current!.getBoundingClientRect()
+  const vt = fc.viewportTransform || [1,0,0,1,0,0]
   hoverDomRef.current && (() => {
-    hoverDomRef.current.style.left = `${rect.left + (box.left - PAD) * SCALE}px`
-    hoverDomRef.current.style.top = `${rect.top + (box.top - PAD) * SCALE}px`
+    hoverDomRef.current.style.left = `${rect.left + vt[4] + (box.left - PAD) * SCALE}px`
+    hoverDomRef.current.style.top = `${rect.top + vt[5] + (box.top - PAD) * SCALE}px`
     hoverDomRef.current.style.width = `${(box.width + PAD * 2) * SCALE}px`
     hoverDomRef.current.style.height = `${(box.height + PAD * 2) * SCALE}px`
     hoverDomRef.current.style.display = 'block'

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -25,6 +25,8 @@ export class CropTool {
   /** canvas size before cropping */
   private baseW = 0;
   private baseH = 0;
+  private panX = 0;
+  private panY = 0;
   private wrapStyles: { w:string; h:string; mw:string; mh:string } | null = null;
   /** clean‑up callbacks to run on `teardown()` */
   private cleanup: Array<() => void> = [];
@@ -130,8 +132,18 @@ export class CropTool {
       }
     }
     const br = img.getBoundingRect(true, true)
-    const needW = Math.max(this.baseW, (br.left + br.width) * this.SCALE)
-    const needH = Math.max(this.baseH, (br.top + br.height) * this.SCALE)
+
+    const offsetX = Math.max(0, -br.left) * this.SCALE
+    const offsetY = Math.max(0, -br.top)  * this.SCALE
+
+    if (offsetX || offsetY) {
+      this.fc.relativePan(new fabric.Point(offsetX, offsetY))
+      this.panX = offsetX
+      this.panY = offsetY
+    }
+
+    const needW = Math.max(this.baseW, offsetX + (br.left + br.width) * this.SCALE)
+    const needH = Math.max(this.baseH, offsetY + (br.top + br.height) * this.SCALE)
     if (needW > this.baseW || needH > this.baseH) {
       this.fc.setWidth(needW)
       this.fc.setHeight(needH)
@@ -729,6 +741,11 @@ export class CropTool {
       this.baseW = 0
       this.baseH = 0
       this.wrapStyles = null
+    }
+    if (this.panX || this.panY) {
+      this.fc.relativePan(new fabric.Point(-this.panX, -this.panY))
+      this.panX = 0
+      this.panY = 0
     }
     // ensure any leftover overlay is cleared
     const ctx = (this.fc as any).contextTop


### PR DESCRIPTION
## Summary
- ensure off-canvas portions of an image are visible when entering crop mode
- restore viewport offset after cropping completes
- allow the canvas area to expand without introducing scrollbars while cropping
- keep DOM crop overlays aligned with the canvas while panning
- hide the selection overlay during crop sessions so the crop window can't exceed the image

## Testing
- `npm run lint` *(fails: multiple ESLint errors)*
- `npx tsc -p tsconfig.json` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861ad7e3f288323bb260b6bbba1a455