### PR TITLE
Add margin for crop controls

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -132,9 +132,10 @@ export class CropTool {
       }
     }
     const br = img.getBoundingRect(true, true)
+    const margin = 40 / this.SCALE
 
-    const offsetX = Math.max(0, -br.left) * this.SCALE
-    const offsetY = Math.max(0, -br.top)  * this.SCALE
+    const offsetX = Math.max(0, -br.left + margin) * this.SCALE
+    const offsetY = Math.max(0, -br.top  + margin) * this.SCALE
 
     if (offsetX || offsetY) {
       this.fc.relativePan(new fabric.Point(offsetX, offsetY))
@@ -142,8 +143,8 @@ export class CropTool {
       this.panY = offsetY
     }
 
-    const needW = Math.max(this.baseW, offsetX + (br.left + br.width) * this.SCALE)
-    const needH = Math.max(this.baseH, offsetY + (br.top + br.height) * this.SCALE)
+    const needW = Math.max(this.baseW, offsetX + (br.left + br.width + margin) * this.SCALE)
+    const needH = Math.max(this.baseH, offsetY + (br.top  + br.height + margin) * this.SCALE)
     if (needW > this.baseW || needH > this.baseH) {
       this.fc.setWidth(needW)
       this.fc.setHeight(needH)


### PR DESCRIPTION
## Summary
- add extra margin around cropped images so crop handles stay visible

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861c6cf338c8323ad387769979ad53a