### PR TITLE
Enable overlays during crop mode

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -696,9 +696,6 @@ useEffect(() => {
   // create a reusable crop helper and keep it in a ref
   const crop = new CropTool(fc, SCALE, SEL_COLOR, state => {
     croppingRef.current = state
-    if (state && selDomRef.current) {
-      selDomRef.current.style.display = 'none'
-    }
     onCroppingChange?.(state)
   })
   cropToolRef.current = crop;
@@ -907,7 +904,6 @@ let scrollHandler: (() => void) | null = null
 
 const syncSel = () => {
   const obj = fc.getActiveObject() as fabric.Object | undefined
-  if (croppingRef.current) return
   if (!obj || !selDomRef.current || !canvasRef.current) return
   const box = obj.getBoundingRect(true, true)
   const rect = canvasRef.current.getBoundingClientRect()
@@ -939,14 +935,12 @@ const syncSel = () => {
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
-  if (!croppingRef.current) {
-    selDomRef.current && (selDomRef.current.style.display = 'block')
-    syncSel()
-    requestAnimationFrame(syncSel)
-    scrollHandler = () => syncSel()
-    window.addEventListener('scroll', scrollHandler, { passive:true })
-    window.addEventListener('resize', scrollHandler)
-  }
+  selDomRef.current && (selDomRef.current.style.display = 'block')
+  syncSel()
+  requestAnimationFrame(syncSel)
+  scrollHandler = () => syncSel()
+  window.addEventListener('scroll', scrollHandler, { passive:true })
+  window.addEventListener('resize', scrollHandler)
 })
 .on('selection:updated', syncSel)
 .on('selection:cleared', () => {


### PR DESCRIPTION
## Summary
- don't hide DOM overlay when entering crop mode
- update overlay logic to run even while cropping

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862ca71c3888323bd421686c678f911