### PR TITLE
Update product variant buttons

### DIFF
--- a/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
+++ b/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 const ICONS: Record<string, string> = {
   'gc-mini': '/icons/mini_card_icon.svg',
@@ -36,15 +37,33 @@ export default function ProductClient({
 
   return (
     <main className="p-6 space-y-6 max-w-4xl mx-auto">
-      <div className="grid md:grid-cols-[auto_1fr] gap-6 items-start">
+      <div className="grid md:grid-cols-[auto_1fr] gap-12 items-start">
         <div className="space-y-2 flex flex-col items-center">
-          <Image
-            src={images[pageIdx]}
-            width={300}
-            height={420}
-            alt={`page ${pageIdx + 1}`}
-            className="rounded shadow w-[300px] h-auto"
-          />
+          <div className="relative">
+            <button
+              onClick={() =>
+                setPageIdx((pageIdx + images.length - 1) % images.length)
+              }
+              className="absolute left-0 top-1/2 -translate-y-1/2 bg-white/70 rounded-full p-1 shadow"
+            >
+              <span className="sr-only">Previous page</span>
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <Image
+              src={images[pageIdx]}
+              width={300}
+              height={420}
+              alt={`page ${pageIdx + 1}`}
+              className="rounded shadow w-[300px] h-auto"
+            />
+            <button
+              onClick={() => setPageIdx((pageIdx + 1) % images.length)}
+              className="absolute right-0 top-1/2 -translate-y-1/2 bg-white/70 rounded-full p-1 shadow"
+            >
+              <span className="sr-only">Next page</span>
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </div>
           <div className="flex gap-2 mt-2">
             {images.map((src, i) => (
               <button
@@ -69,21 +88,21 @@ export default function ProductClient({
             {variants.map(v => (
               <li key={v.variantHandle}>
                 <label
-                  className={`flex items-center gap-4 p-3 border rounded-md cursor-pointer ${selected === v.variantHandle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
+                  className={`flex items-center gap-4 p-3 border-2 rounded-md cursor-pointer w-[65%] ${selected === v.variantHandle ? 'border-[--walty-orange] bg-[#f3dea8]' : 'border-gray-300 bg-[#F7F3EC]'}`}
                 >
                   <Image
                     src={ICONS[v.variantHandle] ?? '/icons/classic_card_icon.svg'}
                     alt=""
-                    width={40}
-                    height={40}
+                    width={52}
+                    height={52}
                   />
-                  <div className="flex-1">
-                    <div className="font-medium">{v.title}</div>
+                  <div className="flex-1 flex flex-col space-y-1">
+                    <div className="font-bold">{v.title}</div>
                     {v.blurb && (
                       <p className="text-sm text-gray-600">{v.blurb}</p>
                     )}
                     {typeof v.price === 'number' && (
-                      <div className="mt-1 font-semibold">£{v.price.toFixed(2)}</div>
+                      <div className="font-normal">£{v.price.toFixed(2)}</div>
                     )}
                   </div>
                   <input
@@ -100,7 +119,7 @@ export default function ProductClient({
           </ul>
           <Link
             href={`/cards/${slug}/customise`}
-            className="block bg-[--walty-orange] text-white px-6 py-3 rounded text-center w-full mt-4"
+            className="block bg-[--walty-orange] text-white px-6 py-3 rounded text-center w-[65%] mt-4"
           >
             Personalise →
           </Link>


### PR DESCRIPTION
## Summary
- increase spacing between template image and variant controls
- white background for unselected variant buttons
- highlight selected variant button with `#f3dea8`
- match Personalise CTA width with variant buttons
- add previous/next buttons for page preview and adjust colours

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_6862cefa1aac8323946f863ab458c6a4