### PR TITLE
Update product page paths and footer

### DIFF
--- a/app/[productSlug]/[templateSlug]/page.tsx
+++ b/app/[productSlug]/[templateSlug]/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from 'next/navigation'
+import ProductClient from '@/app/products/[productSlug]/[templateSlug]/ProductClient'
+import { sanityPreview } from '@/sanity/lib/client'
+import { urlFor } from '@/sanity/lib/image'
+
+export default async function ProductPage({
+  params,
+}: {
+  params: { productSlug: string; templateSlug: string }
+}) {
+  const { templateSlug } = params
+  const data = await sanityPreview.fetch(
+    `*[_type=="cardTemplate" && slug.current==$slug][0]{
+      title,
+      slug,
+      description,
+      pages[]{ layers[]{ _type, src, srcUrl, bgImage } },
+      coverImage,
+      "variants": products[]->variants[]->{ title, blurb, price, variantHandle, "slug": slug.current }
+    }`,
+    { slug: templateSlug }
+  )
+
+  if (!data) return notFound()
+
+  const images: string[] = []
+  if (Array.isArray(data.pages)) {
+    for (const p of data.pages) {
+      const layer = p?.layers?.find((l: any) => l?.src || l?.bgImage)
+      if (layer?.src) images.push(urlFor(layer.src).width(420).height(580).url())
+      else if (layer?.bgImage) images.push(urlFor(layer.bgImage).width(420).height(580).url())
+    }
+  }
+  if (!images.length && data.coverImage) {
+    images.push(urlFor(data.coverImage).width(420).height(580).url())
+  }
+
+  return (
+    <ProductClient
+      title={data.title}
+      slug={data.slug.current}
+      description={data.description}
+      images={images}
+      variants={data.variants || []}
+    />
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 // app/page.tsx
 import Image from "next/image";
 import Link from "next/link";
+import Footer from "@/components/site/Footer";
 import { Pencil, Truck, Star } from "lucide-react";
 import { recoleta } from "@/lib/fonts"; // ① <— brings in your local Recoleta
 import { sanityFetch } from "@/lib/sanityClient";
@@ -138,13 +139,7 @@ export default async function HomePage() {
       </section>
 
       {/* FOOTER */}
-      <footer className="py-10 text-center text-sm" style={{ backgroundColor: teal, color: cream }}>
-        © {new Date().getFullYear()} Walty Ltd. All rights reserved.
-        {' '}
-        <Link href="/products/digital/test-27-jun-2025" className="underline ml-2">
-          Test product page
-        </Link>
-      </footer>
+      <Footer />
     </main>
   );
 }

--- a/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
+++ b/app/products/[productSlug]/[templateSlug]/ProductClient.tsx
@@ -2,6 +2,8 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import Footer from '@/components/site/Footer'
 
 const ICONS: Record<string, string> = {
   'gc-mini': '/icons/mini_card_icon.svg',
@@ -36,15 +38,33 @@ export default function ProductClient({
 
   return (
     <main className="p-6 space-y-6 max-w-4xl mx-auto">
-      <div className="grid md:grid-cols-[auto_1fr] gap-6 items-start">
+      <div className="grid md:grid-cols-[auto_1fr] gap-12 items-start">
         <div className="space-y-2 flex flex-col items-center">
-          <Image
-            src={images[pageIdx]}
-            width={300}
-            height={420}
-            alt={`page ${pageIdx + 1}`}
-            className="rounded shadow w-[300px] h-auto"
-          />
+          <div className="relative">
+            <button
+              onClick={() =>
+                setPageIdx((pageIdx + images.length - 1) % images.length)
+              }
+              className="absolute left-0 top-1/2 -translate-y-1/2 bg-white/70 rounded-full p-1 shadow"
+            >
+              <span className="sr-only">Previous page</span>
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <Image
+              src={images[pageIdx]}
+              width={300}
+              height={420}
+              alt={`page ${pageIdx + 1}`}
+              className="rounded shadow w-[300px] h-auto"
+            />
+            <button
+              onClick={() => setPageIdx((pageIdx + 1) % images.length)}
+              className="absolute right-0 top-1/2 -translate-y-1/2 bg-white/70 rounded-full p-1 shadow"
+            >
+              <span className="sr-only">Next page</span>
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </div>
           <div className="flex gap-2 mt-2">
             {images.map((src, i) => (
               <button
@@ -69,21 +89,21 @@ export default function ProductClient({
             {variants.map(v => (
               <li key={v.variantHandle}>
                 <label
-                  className={`flex items-center gap-4 p-3 border rounded-md cursor-pointer ${selected === v.variantHandle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
+                  className={`flex items-center gap-4 p-3 border-2 rounded-md cursor-pointer w-[65%] ${selected === v.variantHandle ? 'border-[--walty-orange] bg-[#f3dea8]' : 'border-gray-300 bg-[#F7F3EC]'}`}
                 >
                   <Image
                     src={ICONS[v.variantHandle] ?? '/icons/classic_card_icon.svg'}
                     alt=""
-                    width={40}
-                    height={40}
+                    width={52}
+                    height={52}
                   />
-                  <div className="flex-1">
-                    <div className="font-medium">{v.title}</div>
+                  <div className="flex-1 flex flex-col space-y-1">
+                    <div className="font-bold">{v.title}</div>
                     {v.blurb && (
                       <p className="text-sm text-gray-600">{v.blurb}</p>
                     )}
                     {typeof v.price === 'number' && (
-                      <div className="mt-1 font-semibold">£{v.price.toFixed(2)}</div>
+                      <div className="font-normal">£{v.price.toFixed(2)}</div>
                     )}
                   </div>
                   <input
@@ -100,7 +120,7 @@ export default function ProductClient({
           </ul>
           <Link
             href={`/cards/${slug}/customise`}
-            className="block bg-[--walty-orange] text-white px-6 py-3 rounded text-center w-full mt-4"
+            className="block bg-[--walty-orange] text-white px-6 py-3 rounded text-center w-[65%] mt-4"
           >
             Personalise →
           </Link>
@@ -128,6 +148,7 @@ export default function ProductClient({
           <p className="mt-4">Delivery information coming soon.</p>
         )}
       </div>
+      <Footer />
     </main>
   )
 }

--- a/components/site/Footer.tsx
+++ b/components/site/Footer.tsx
@@ -1,0 +1,15 @@
+'use client'
+import Link from 'next/link'
+
+export default function Footer() {
+  const cream = '#F7F3EC'
+  const teal = '#005B55'
+  return (
+    <footer className="py-10 text-center text-sm" style={{ backgroundColor: teal, color: cream }}>
+      © {new Date().getFullYear()} Walty Ltd. All rights reserved.{' '}
+      <Link href="/greetings-cards/test-27-jun-2025" className="underline ml-2">
+        Test product page
+      </Link>
+    </footer>
+  )
+}

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -18,7 +18,7 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
 
-    /* slug used in URLs (/products/{slug}) */
+    /* slug used in URLs (/<product-slug>/...) */
     defineField({
       name : 'slug',
       type : 'slug',


### PR DESCRIPTION
## Summary
- expose product pages at root-level `[productSlug]/[templateSlug]`
- add shared `Footer` component
- include footer on product pages
- update example link on home page
- clarify product slug comment in schema

## Testing
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862cefa1aac8323946f863ab458c6a4