### PR TITLE
Align DOM overlays with Fabric styles

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -612,7 +612,7 @@ useEffect(() => {
   selDomRef.current = selEl;
 
   const cropEl = document.createElement('div');
-  cropEl.className = 'sel-overlay interactive';
+  cropEl.className = 'crop-overlay interactive';
   cropEl.style.display = 'none';
   document.body.appendChild(cropEl);
   cropDomRef.current = cropEl;
@@ -629,9 +629,9 @@ useEffect(() => {
   (selEl as any)._handles = handleMap;
 
   const cropHandles: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  ['tl','tr','br','bl'].forEach(c => {
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : ''} ${c}`;
+    h.className = `handle ${c}`;
     h.dataset.corner = c;
     cropEl.appendChild(h);
     cropHandles[c] = h;
@@ -927,14 +927,14 @@ const drawOverlay = (
     const h = el._handles
     const midX = width / 2
     const midY = height / 2
-    h.tl.style.left = '0px';      h.tl.style.top = '0px'
-    h.tr.style.left = `${width}px`; h.tr.style.top = '0px'
-    h.br.style.left = `${width}px`; h.br.style.top = `${height}px`
-    h.bl.style.left = '0px';      h.bl.style.top = `${height}px`
-    h.ml.style.left = '0px';      h.ml.style.top = `${midY}px`
-    h.mr.style.left = `${width}px`; h.mr.style.top = `${midY}px`
-    h.mt.style.left = `${midX}px`; h.mt.style.top = '0px'
-    h.mb.style.left = `${midX}px`; h.mb.style.top = `${height}px`
+    if (h.tl) { h.tl.style.left = '0px';      h.tl.style.top = '0px' }
+    if (h.tr) { h.tr.style.left = `${width}px`; h.tr.style.top = '0px' }
+    if (h.br) { h.br.style.left = `${width}px`; h.br.style.top = `${height}px` }
+    if (h.bl) { h.bl.style.left = '0px';      h.bl.style.top = `${height}px` }
+    if (h.ml) { h.ml.style.left = '0px';      h.ml.style.top = `${midY}px` }
+    if (h.mr) { h.mr.style.left = `${width}px`; h.mr.style.top = `${midY}px` }
+    if (h.mt) { h.mt.style.left = `${midX}px`; h.mt.style.top = '0px' }
+    if (h.mb) { h.mb.style.left = `${midX}px`; h.mb.style.top = `${height}px` }
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -94,7 +94,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:1px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -108,6 +108,7 @@ html {
     border-radius:50%;
     transform:translate(-50%,-50%);
     pointer-events:auto;
+    box-shadow:0 0 2px rgba(0,0,0,0.15);
   }
   .sel-overlay .handle.side {
     width:4px;
@@ -122,4 +123,32 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+}
+
+/* --- crop window DOM overlay --- */
+@layer utilities {
+  .crop-overlay {
+    @apply absolute pointer-events-none box-border z-40;
+    border:1px solid #2EC4B6;
+  }
+  .crop-overlay.interactive { @apply pointer-events-auto; }
+  .crop-overlay .handle {
+    position:absolute;
+    width:8px;
+    height:8px;
+    box-sizing:border-box;
+    border:2px solid #fff;
+    border-right:none;
+    border-bottom:none;
+    transform:translate(-50%,-50%);
+    box-shadow:0 0 3px rgba(0,0,0,0.35);
+    pointer-events:auto;
+  }
+  .crop-overlay .handle.tr { transform:translate(-50%,-50%) rotate(90deg); }
+  .crop-overlay .handle.br { transform:translate(-50%,-50%) rotate(180deg); }
+  .crop-overlay .handle.bl { transform:translate(-50%,-50%) rotate(270deg); }
+  .crop-overlay .handle.tl,
+  .crop-overlay .handle.br { cursor:nwse-resize; }
+  .crop-overlay .handle.tr,
+  .crop-overlay .handle.bl { cursor:nesw-resize; }
 }


### PR DESCRIPTION
## Summary
- make DOM overlay borders solid teal
- add drop-shadow to overlay handles
- give crop overlays dedicated styles
- use L-shaped handles for crop overlays

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862ff6e61088323bbc0d4a412c6aac9