### PR TITLE
Fix DOM overlay styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -94,25 +94,33 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:1px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;
-    width:8px;
-    height:8px;
+    width:13px;
+    height:13px;
     background:#fff;
     border:1px solid #2EC4B6;
     border-radius:50%;
     transform:translate(-50%,-50%);
     pointer-events:auto;
+    box-shadow:0 0 4px rgba(0,0,0,0.15);
   }
-  .sel-overlay .handle.side {
-    width:4px;
-    height:12px;
-    border-radius:2px;
+  .sel-overlay .handle.mt,
+  .sel-overlay .handle.mb {
+    width:21px;
+    height:5px;
+    border-radius:2.5px;
+  }
+  .sel-overlay .handle.ml,
+  .sel-overlay .handle.mr {
+    width:5px;
+    height:21px;
+    border-radius:2.5px;
   }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }


### PR DESCRIPTION
## Summary
- ensure DOM overlays use solid outlines
- match handle and crop window style with original Fabric.js shapes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862ff6e61088323bbc0d4a412c6aac9