### PR TITLE
Fix DOM overlay styles

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -612,7 +612,7 @@ useEffect(() => {
   selDomRef.current = selEl;
 
   const cropEl = document.createElement('div');
-  cropEl.className = 'sel-overlay interactive';
+  cropEl.className = 'sel-overlay crop interactive';
   cropEl.style.display = 'none';
   document.body.appendChild(cropEl);
   cropDomRef.current = cropEl;
@@ -927,14 +927,25 @@ const drawOverlay = (
     const h = el._handles
     const midX = width / 2
     const midY = height / 2
-    h.tl.style.left = '0px';      h.tl.style.top = '0px'
-    h.tr.style.left = `${width}px`; h.tr.style.top = '0px'
-    h.br.style.left = `${width}px`; h.br.style.top = `${height}px`
-    h.bl.style.left = '0px';      h.bl.style.top = `${height}px`
-    h.ml.style.left = '0px';      h.ml.style.top = `${midY}px`
-    h.mr.style.left = `${width}px`; h.mr.style.top = `${midY}px`
-    h.mt.style.left = `${midX}px`; h.mt.style.top = '0px'
-    h.mb.style.left = `${midX}px`; h.mb.style.top = `${height}px`
+    const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const
+    corners.forEach(pos => {
+      const handle = h[pos]
+      if (obj.controls && (obj.controls as any)[pos]) {
+        handle.style.display = 'block'
+        switch (pos) {
+          case 'tl': handle.style.left = '0px';       handle.style.top = '0px'; break
+          case 'tr': handle.style.left = `${width}px`; handle.style.top = '0px'; break
+          case 'br': handle.style.left = `${width}px`; handle.style.top = `${height}px`; break
+          case 'bl': handle.style.left = '0px';       handle.style.top = `${height}px`; break
+          case 'ml': handle.style.left = '0px';       handle.style.top = `${midY}px`; break
+          case 'mr': handle.style.left = `${width}px`; handle.style.top = `${midY}px`; break
+          case 'mt': handle.style.left = `${midX}px`; handle.style.top = '0px'; break
+          case 'mb': handle.style.left = `${midX}px`; handle.style.top = `${height}px`; break
+        }
+      } else {
+        handle.style.display = 'none'
+      }
+    })
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -94,26 +94,63 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:1px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;
-    width:8px;
-    height:8px;
+    width:13px;
+    height:13px;
     background:#fff;
     border:1px solid #2EC4B6;
     border-radius:50%;
     transform:translate(-50%,-50%);
     pointer-events:auto;
+    box-shadow:0 0 4px rgba(0,0,0,0.15);
   }
-  .sel-overlay .handle.side {
-    width:4px;
-    height:12px;
-    border-radius:2px;
+  .sel-overlay .handle::after {
+    content:"";
+    position:absolute;
+    left:-8px;
+    top:-8px;
+    right:-8px;
+    bottom:-8px;
   }
+  .sel-overlay .handle.mt,
+  .sel-overlay .handle.mb {
+    width:21px;
+    height:5px;
+    border-radius:2.5px;
+  }
+  .sel-overlay .handle.ml,
+  .sel-overlay .handle.mr {
+    width:5px;
+    height:21px;
+    border-radius:2.5px;
+  }
+  /* crop window L-shaped corners */
+  .sel-overlay.crop .handle {
+    width:16px;
+    height:16px;
+    background:transparent;
+    border:none;
+  }
+  .sel-overlay.crop .handle::before {
+    content:"";
+    position:absolute;
+    left:0;
+    top:0;
+    width:8px;
+    height:8px;
+    border-left:1px solid #ffffff;
+    border-top:1px solid #ffffff;
+    box-shadow:0 0 3px rgba(0,0,0,0.35);
+  }
+  .sel-overlay.crop .handle.tr::before { transform:rotate(90deg); transform-origin:0 0; }
+  .sel-overlay.crop .handle.br::before { transform:rotate(180deg); transform-origin:0 0; }
+  .sel-overlay.crop .handle.bl::before { transform:rotate(-90deg); transform-origin:0 0; }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,


### PR DESCRIPTION
## Summary
- ensure DOM overlays use solid outlines
- match handle and crop window style with original Fabric.js shapes
- enlarge handle hit boxes in crop mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6862ff6e61088323bbc0d4a412c6aac9