### PR TITLE
Fix crop overlay handle switching

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -665,6 +665,21 @@ useEffect(() => {
   });
 
   const bridge = (e: PointerEvent) => {
+    // during cropping, clicking the secondary overlay should immediately
+    // activate its object so the drag begins without an extra click
+    if (croppingRef.current && cropDomRef.current && cropToolRef.current) {
+      if (e.currentTarget === cropDomRef.current) {
+        const tool = cropToolRef.current as any
+        const active = fc.getActiveObject()
+        if (tool?.isActive && tool.img && tool.frame) {
+          const other = active === tool.frame ? tool.img : tool.frame
+          if (other) {
+            fc.setActiveObject(other)
+            syncSel()
+          }
+        }
+      }
+    }
     const down = new MouseEvent('mousedown', forward(e))
     fc.upperCanvasEl.dispatchEvent(down)
     const move = (ev: PointerEvent) =>


### PR DESCRIPTION
## Summary
- allow dragging handles for either element in crop mode without extra click

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Domine`)*

------
https://chatgpt.com/codex/tasks/task_e_686309fedf74832393c70aa6181efdc8