### PR TITLE
Fix proof export race

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -544,6 +544,16 @@ const generateProofURL = async (variantHandle: string): Promise<string | null> =
   const product = products.find(p => p.variantHandle === variantHandle)
   const sku = product?.slug ?? variantHandle
   const showGuides = product?.showProofSafeArea ?? false
+  if (typeof document !== 'undefined') {
+    try {
+      if (document.fonts?.status !== 'loaded') {
+        await document.fonts.ready
+      }
+      await new Promise(r => requestAnimationFrame(() => r(null)))
+    } catch {
+      /* ignore */
+    }
+  }
   const { pages, pageImages } = collectProofData(showGuides)
   const blob = await fetchProofBlob(sku, `${variantHandle}.jpg`, pages, pageImages)
   if (!blob) return null
@@ -580,6 +590,17 @@ const generateProofURLs = async (
 const handleProofAll = async () => {
   if (!products.length) return
   const JSZip = (await import('jszip')).default
+
+  if (typeof document !== 'undefined') {
+    try {
+      if (document.fonts?.status !== 'loaded') {
+        await document.fonts.ready
+      }
+      await new Promise(r => requestAnimationFrame(() => r(null)))
+    } catch {
+      /* ignore */
+    }
+  }
 
   const zip = new JSZip()
   for (const p of products) {


### PR DESCRIPTION
## Summary
- wait for loaded fonts when exporting proofs
- ensure fonts are loaded for `Proof All` export as well

## Testing
- `npm run lint` *(fails: react-hooks rules of hooks, display-name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68630e7eca808323a5b0a11ade465c54