### PR TITLE
Fix crop overlay drag handles

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -668,6 +668,8 @@ useEffect(() => {
 
   const bridge = (e: PointerEvent) => {
     const down = new MouseEvent('mousedown', forward(e))
+    const corner = (e.target as HTMLElement | null)?.dataset?.corner
+    if (corner) (down as any).corner = corner
     fc.upperCanvasEl.dispatchEvent(down)
     const move = (ev: PointerEvent) =>
       fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(ev)))


### PR DESCRIPTION
## Summary
- ensure overlay-generated mousedown events include the selected corner

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68631346e8248323840c7234ccee45f7