### PR TITLE
Fix crop overlay drag selection

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -681,7 +681,17 @@ useEffect(() => {
     e.preventDefault()
   }
   const onSelDown = (e: PointerEvent) => {
-    const obj = (selEl as any)._object as fabric.Object | null
+    let obj = (selEl as any)._object as fabric.Object | null
+    if (croppingRef.current && cropEl) {
+      const other = (cropEl as any)._object as fabric.Object | null
+      if (other) {
+        const r = cropEl.getBoundingClientRect()
+        if (e.clientX >= r.left && e.clientX <= r.right &&
+            e.clientY >= r.top  && e.clientY <= r.bottom) {
+          obj = other
+        }
+      }
+    }
     if (obj) fc.setActiveObject(obj)
     bridge(e)
   }


### PR DESCRIPTION
## Summary
- ensure crop overlay doesn't block switching between photo and window handles

## Testing
- `npm run lint` *(fails: react lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68631346e8248323840c7234ccee45f7