### PR TITLE
Fix crop overlay handle switching

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -961,22 +961,26 @@ const syncSel = () => {
   if (croppingRef.current && tool?.isActive && tool.img && tool.frame) {
     const img   = tool.img as fabric.Object
     const frame = tool.frame as fabric.Object
-    // whichever is active uses selEl; the other uses cropEl
-    selEl.style.zIndex = '41'
-    cropEl && (cropEl.style.zIndex = '40')
+    // whichever element is active gets a higher z-index but both remain interactive
+    selEl.style.zIndex = obj === frame ? '41' : '40'
+    cropEl && (cropEl.style.zIndex = obj === frame ? '40' : '41')
     if (obj === frame) {
       drawOverlay(frame, selEl)
       selEl._object = frame
+      selEl.style.pointerEvents = 'auto'
       if (cropEl) {
         cropEl.style.display = 'block'
+        cropEl.style.pointerEvents = 'auto'
         drawOverlay(img, cropEl)
         cropEl._object = img
       }
     } else {
       drawOverlay(img, selEl)
       selEl._object = img
+      selEl.style.pointerEvents = 'auto'
       if (cropEl) {
         cropEl.style.display = 'block'
+        cropEl.style.pointerEvents = 'auto'
         drawOverlay(frame, cropEl)
         cropEl._object = frame
       }
@@ -985,7 +989,8 @@ const syncSel = () => {
     return
   }
 
-  cropEl && (cropEl.style.display = 'none', cropEl._object = null)
+  cropEl && (cropEl.style.display = 'none', cropEl._object = null, cropEl.style.pointerEvents = 'auto')
+  selEl.style.pointerEvents = 'auto'
   if (!obj) return
   drawOverlay(obj, selEl)
   selEl._object = obj


### PR DESCRIPTION
## Summary
- ensure both crop overlays remain interactive
- adjust z-index logic while cropping

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68631346e8248323840c7234ccee45f7