### PR TITLE
Fix crop overlay scroll sync

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1017,7 +1017,14 @@ fc.on('selection:created', () => {
   window.addEventListener('scroll', scrollHandler, { passive:true })
   window.addEventListener('resize', scrollHandler)
 })
-.on('selection:updated', syncSel)
+.on('selection:updated', () => {
+  syncSel()
+  if (!scrollHandler) {
+    scrollHandler = () => syncSel()
+    window.addEventListener('scroll', scrollHandler, { passive:true })
+    window.addEventListener('resize', scrollHandler)
+  }
+})
 .on('selection:cleared', () => {
   if (scrollHandler) {
     window.removeEventListener('scroll', scrollHandler)


### PR DESCRIPTION
## Summary
- update FabricCanvas to attach scroll listeners during both `selection:created` and `selection:updated` events

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863b09e5cb883238e6293a1fb92ea20