### PR TITLE
Fix crop handles misalignment

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -477,6 +477,8 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
   const selDomRef    = useRef<HTMLDivElement | null>(null)
   const cropDomRef   = useRef<HTMLDivElement | null>(null)
 
+  const containerRef = useRef<HTMLElement | null>(null)
+
   const cropToolRef = useRef<CropTool | null>(null)
   const croppingRef = useRef(false)
 
@@ -731,6 +733,7 @@ useEffect(() => {
     container.style.height = `${PREVIEW_H}px`;
     container.style.maxWidth  = `${PREVIEW_W}px`;
     container.style.maxHeight = `${PREVIEW_H}px`;
+    containerRef.current = container;
   }
   addBackdrop(fc);
   // keep the preview scaled to the configured width
@@ -742,6 +745,7 @@ useEffect(() => {
   updateOffset();
   window.addEventListener('scroll', updateOffset, { passive: true });
   window.addEventListener('resize', updateOffset);
+  containerRef.current?.addEventListener('scroll', updateOffset, { passive: true });
 
   const isolateCrop = (active: boolean) => {
     const map = savedInteractivityRef.current
@@ -1016,12 +1020,14 @@ fc.on('selection:created', () => {
   scrollHandler = () => syncSel()
   window.addEventListener('scroll', scrollHandler, { passive:true })
   window.addEventListener('resize', scrollHandler)
+  containerRef.current?.addEventListener('scroll', scrollHandler, { passive:true })
 })
 .on('selection:updated', syncSel)
 .on('selection:cleared', () => {
   if (scrollHandler) {
     window.removeEventListener('scroll', scrollHandler)
     window.removeEventListener('resize', scrollHandler)
+    containerRef.current?.removeEventListener('scroll', scrollHandler)
     scrollHandler = null
   }
   selDomRef.current && (selDomRef.current.style.display = 'none')
@@ -1246,6 +1252,7 @@ window.addEventListener('keydown', onKey)
       if (scrollHandler) window.removeEventListener('scroll', scrollHandler)
       window.removeEventListener('scroll', updateOffset)
       window.removeEventListener('resize', updateOffset)
+      containerRef.current?.removeEventListener('scroll', updateOffset)
       // tidy up crop‑tool listeners
       fc.off('mouse:dblclick', dblHandler);
       window.removeEventListener('keydown', keyCropHandler);
@@ -1267,6 +1274,7 @@ window.addEventListener('keydown', onKey)
       if (scrollHandler) {
         window.removeEventListener('scroll', scrollHandler)
         window.removeEventListener('resize', scrollHandler)
+        containerRef.current?.removeEventListener('scroll', scrollHandler)
       }
     }
 // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -28,6 +28,9 @@ export class CropTool {
   private panX = 0;
   private panY = 0;
   private wrapStyles: { w:string; h:string; mw:string; mh:string } | null = null;
+  private wrapper: HTMLElement | null = null;
+  private scrollLeft = 0;
+  private scrollTop = 0;
   /** clean‑up callbacks to run on `teardown()` */
   private cleanup: Array<() => void> = [];
 
@@ -124,6 +127,9 @@ export class CropTool {
     this.baseH = this.fc.getHeight()
     const wrapper = (this.fc as any).wrapperEl as HTMLElement | undefined
     if (wrapper) {
+      this.wrapper = wrapper
+      this.scrollLeft = wrapper.scrollLeft
+      this.scrollTop = wrapper.scrollTop
       this.wrapStyles = {
         w : wrapper.style.width,
         h : wrapper.style.height,
@@ -140,10 +146,16 @@ export class CropTool {
       this.fc.relativePan(new fabric.Point(offsetX, offsetY))
       this.panX = offsetX
       this.panY = offsetY
+      if (wrapper) {
+        wrapper.scrollLeft += offsetX
+        wrapper.scrollTop  += offsetY
+      }
     }
 
-    const needW = Math.max(this.baseW, offsetX + (br.left + br.width) * this.SCALE)
-    const needH = Math.max(this.baseH, offsetY + (br.top + br.height) * this.SCALE)
+    const needW = Math.max(this.baseW + offsetX,
+                           offsetX + (br.left + br.width) * this.SCALE)
+    const needH = Math.max(this.baseH + offsetY,
+                           offsetY + (br.top + br.height) * this.SCALE)
     if (needW > this.baseW || needH > this.baseH) {
       this.fc.setWidth(needW)
       this.fc.setHeight(needH)
@@ -744,8 +756,15 @@ export class CropTool {
     }
     if (this.panX || this.panY) {
       this.fc.relativePan(new fabric.Point(-this.panX, -this.panY))
+      if (this.wrapper) {
+        this.wrapper.scrollLeft = this.scrollLeft
+        this.wrapper.scrollTop  = this.scrollTop
+      }
       this.panX = 0
       this.panY = 0
+      this.wrapper = null
+      this.scrollLeft = 0
+      this.scrollTop = 0
     }
     // ensure any leftover overlay is cleared
     const ctx = (this.fc as any).contextTop


### PR DESCRIPTION
## Summary
- keep Fabric canvas outlines positioned when container scrolls
- prevent canvas jump on crop start by storing and restoring scroll offsets
- extend canvas size correctly for negative offsets during crop

## Testing
- `npm run lint` *(fails: React Hook and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863b4c0861c832382041031b00b56be