### PR TITLE
Disable auto-panning when entering crop mode

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -780,7 +780,7 @@ useEffect(() => {
     croppingRef.current = state
     isolateCrop(state)
     onCroppingChange?.(state)
-  })
+  }, false)
   cropToolRef.current = crop;
   ;(fc as any)._cropTool = crop;
   (fc as any)._syncLayers = () => syncLayersFromCanvas(fc, pageIdx);


### PR DESCRIPTION
## Summary
- add an optional `fitInView` parameter to `CropTool`
- allow FabricCanvas to create a crop tool that doesn't reposition the canvas

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@dnd-kit/core' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68641d652374832399374ac95b7c92d6