### PR TITLE
Fix canvas jump on crop

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -143,13 +143,9 @@ export class CropTool {
     const offsetY = Math.max(0, -br.top)  * this.SCALE
 
     if (offsetX || offsetY) {
-      this.fc.relativePan(new fabric.Point(offsetX, offsetY))
-      this.panX = offsetX
-      this.panY = offsetY
-      if (wrapper) {
-        wrapper.scrollLeft += offsetX
-        wrapper.scrollTop  += offsetY
-      }
+      // Ensure the canvas is large enough for visibility
+      // without shifting its on‑screen position.
+      this.panX = this.panY = 0
     }
 
     const needW = Math.max(this.baseW + offsetX,


### PR DESCRIPTION
## Summary
- remove panning when the crop tool starts so the canvas position stays fixed

## Testing
- `npm run lint` *(fails: React hooks lint errors, unescaped entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864215d701c83238e54e2dd6298341a