### PR TITLE
Replace Inter and Domine with AmbitRegular

### DIFF
--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -80,7 +80,7 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
           leaveTo="opacity-0 scale-95"
         >
           <Dialog.Panel className="relative z-10 bg-white rounded shadow-lg w-[min(90vw,420px)] p-6 space-y-6">
-            <h2 className="font-domine text-xl text-[--walty-teal]">Choose an option</h2>
+            <h2 className="font-display text-xl text-[--walty-teal]">Choose an option</h2>
             <ul className="space-y-2">
               {options.map((opt) => (
                 <li key={opt.handle}>

--- a/app/components/toolbar/FontFamilySelect.tsx
+++ b/app/components/toolbar/FontFamilySelect.tsx
@@ -15,9 +15,8 @@ const BASE_FONTS: Font[] = [
   { name: "Arial", family: "Arial, Helvetica, sans-serif" },
   { name: "Georgia", family: "Georgia, serif" },
   {
-    name: "Domine",
-    family: "Domine, serif",
-    url: "https://fonts.googleapis.com/css2?family=Domine:wght@400;700&display=swap",
+    name: "AmbitRegular",
+    family: "var(--font-ambit), sans-serif",
   },
   {
     name: "Recoleta",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,10 @@
 // app/layout.tsx
 import React from "react";
 import "./globals.css";
-import { Domine, Inter } from "next/font/google";
-import { recoleta } from "@/lib/fonts"; // local font
+import { ambit, recoleta } from "@/lib/fonts"; // local fonts
 import WaltyNavWrapper from "@/components/site/WaltyNavWrapper"; // shows/hides navbar
 import { BasketProvider } from "@/lib/useBasket";
 import { AddressBookProvider } from "@/lib/useAddressBook";
-
-export const domine = Domine({
-  weight: ["400", "700"],
-  subsets: ["latin"],
-  variable: "--font-domine",
-});
-export const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-});
 
 export const metadata = { title: "Walty" };
 
@@ -28,7 +17,7 @@ export default function RootLayout({
     <html lang="en">
       {/* use back-ticks so the template literals are evaluated */}
       <body
-        className={`${inter.variable} ${domine.variable} ${recoleta.variable}`}
+        className={`${ambit.variable} ${recoleta.variable}`}
       >
         <AddressBookProvider>
           <BasketProvider>

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -14,3 +14,12 @@ export const recoleta = localFont({
     { path: "../app/fonts/Recoleta-SemiBold.woff", weight: "600", style: "normal" },
   ],
 });
+
+export const ambit = localFont({
+  variable: "--font-ambit",
+  display: "swap",
+  src: [
+    { path: "../app/fonts/Ambit Regular.otf",    weight: "400", style: "normal" },
+    { path: "../app/fonts/Ambit SemiBold.otf",   weight: "600", style: "normal" },
+  ],
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,12 +23,12 @@ module.exports = {
       /* ——— Fonts (match CSS vars set by next/font) ——— */
       fontFamily: {
         // generic
-        sans:    ["var(--font-inter)", "Inter", "ui-sans-serif", "system-ui"],
-        display: ["var(--font-domine)", "Domine", "serif"],
+        sans:    ["var(--font-ambit)", "AmbitRegular", "ui-sans-serif", "system-ui"],
+        display: ["var(--font-recoleta)", "Recoleta", "serif"],
         serif:   ["var(--font-recoleta)", "ui-serif", "serif"],
 
-        // handy shortcuts — use `font-recoleta` or `font-domine` directly
-        domine:   ["var(--font-domine)"],
+        // handy shortcuts — use `font-recoleta` or `font-ambit` directly
+        ambit:    ["var(--font-ambit)"],
         recoleta: ["var(--font-recoleta)"],
       },
 


### PR DESCRIPTION
## Summary
- load AmbitRegular as a local font
- use AmbitRegular and Recoleta in app layout
- update font families in Tailwind config
- fix AddToBasketDialog heading font
- update toolbar font picker

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68642bd00354832384a2b22375d321b1