### PR TITLE
Fix DOM overlays position on zoom

### DIFF
--- a/app/components/syncGhost.ts
+++ b/app/components/syncGhost.ts
@@ -8,7 +8,7 @@
     * @param img     The Fabric.Image instance
     * @param ghost   The overlay <div> (already appended to document.body)
     * @param canvas  The <canvas> element for this page
-    * @param scale   Canvas → preview scale (SCALE from FabricCanvas)
+    * @param scale   Canvas → screen scale (SCALE * zoom from FabricCanvas)
     */
    export function syncGhost(
      img    : fabric.Image,
@@ -21,8 +21,8 @@
      const canvasRect = canvas.getBoundingClientRect();
 
      // 2 - apply to the overlay div  (canvas-space ➜ screen-space)
-     ghost.style.left   = `${canvasRect.left + left   * scale}px`;
-     ghost.style.top    = `${canvasRect.top  + top    * scale}px`;
-     ghost.style.width  = `${width  * scale}px`;
-     ghost.style.height = `${height * scale}px`;
+    ghost.style.left   = `${canvasRect.left + left   * scale}px`;
+    ghost.style.top    = `${canvasRect.top  + top    * scale}px`;
+    ghost.style.width  = `${width  * scale}px`;
+    ghost.style.height = `${height * scale}px`;
    }


### PR DESCRIPTION
## Summary
- adjust selection and hover overlay calculations to use current zoom level
- re-sync ghost overlays on zoom change and store zoom in a ref
- clarify scale meaning in `syncGhost`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865205be0ac832392e170bd1a9233a0