### PR TITLE
Fix overlay positioning on scroll

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -267,16 +267,18 @@ const syncGhost = (
   img   : fabric.Image,
   ghost : HTMLDivElement,
   canvas: HTMLCanvasElement,
-  zoom  : number,
 ) => {
   const canvasRect = canvas.getBoundingClientRect()
   const { left, top, width, height } = img.getBoundingRect()
-
-  const s = SCALE * zoom
-  ghost.style.left   = `${canvasRect.left + left   * s}px`
-  ghost.style.top    = `${canvasRect.top  + top    * s}px`
-  ghost.style.width  = `${width  * s}px`
-  ghost.style.height = `${height * s}px`
+  const fc   = img.canvas as fabric.Canvas | null
+  const vt   = fc?.viewportTransform || [SCALE, 0, 0, SCALE, 0, 0]
+  const scale = vt[0]
+  const posX  = canvasRect.left + vt[4] + left * scale
+  const posY  = canvasRect.top  + vt[5] + top  * scale
+  ghost.style.left   = `${posX}px`
+  ghost.style.top    = `${posY}px`
+  ghost.style.width  = `${width  * scale}px`
+  ghost.style.height = `${height * scale}px`
 }
 
 const getSrcUrl = (raw: Layer): string | undefined => {
@@ -609,6 +611,7 @@ useEffect(() => {
   hoverEl.style.display = 'none';
   document.body.appendChild(hoverEl);
   hoverDomRef.current = hoverEl;
+  (hoverEl as any)._object = null;
 
   const selEl = document.createElement('div');
   selEl.className = 'sel-overlay interactive';
@@ -757,9 +760,10 @@ if (container) {
   /* keep event coordinates aligned with any scroll/resize */
   const updateOffset = () => fc.calcOffset();
   updateOffset();
-  window.addEventListener('scroll', updateOffset, { passive: true });
+  window.addEventListener('scroll', updateOffset, { passive: true, capture: true });
+  document.addEventListener('scroll', updateOffset, { passive: true, capture: true });
   window.addEventListener('resize', updateOffset);
-  containerRef.current?.addEventListener('scroll', updateOffset, { passive: true });
+  containerRef.current?.addEventListener('scroll', updateOffset, { passive: true, capture: true });
 
   const isolateCrop = (active: boolean) => {
     const map = savedInteractivityRef.current
@@ -950,6 +954,7 @@ hoverRef.current = hoverHL
 
 /* ── 3 ▸ Selection lifecycle (DOM overlay) ─────────── */
 let scrollHandler: (() => void) | null = null
+let hoverScrollHandler: (() => void) | null = null
 
 const drawOverlay = (
   obj: fabric.Object,
@@ -958,10 +963,11 @@ const drawOverlay = (
   const box  = obj.getBoundingRect(true, true)
   const rect = canvasRef.current!.getBoundingClientRect()
   const vt   = fc.viewportTransform || [1,0,0,1,0,0]
-  const left   = rect.left + vt[4] + (box.left - PAD) * SCALE
-  const top    = rect.top  + vt[5] + (box.top - PAD) * SCALE
-  const width  = (box.width  + PAD * 2) * SCALE
-  const height = (box.height + PAD * 2) * SCALE
+  const scale = vt[0]
+  const left   = rect.left + vt[4] + (box.left - PAD) * scale
+  const top    = rect.top  + vt[5] + (box.top - PAD) * scale
+  const width  = (box.width  + PAD * 2) * scale
+  const height = (box.height + PAD * 2) * scale
   el.style.left   = `${left}px`
   el.style.top    = `${top}px`
   el.style.width  = `${width}px`
@@ -1022,6 +1028,13 @@ const syncSel = () => {
   selEl._object = obj
 }
 
+const syncHover = () => {
+  if (!hoverDomRef.current || !canvasRef.current) return
+  const obj = (hoverDomRef.current as any)._object as fabric.Object | null
+  if (!obj) return
+  drawOverlay(obj, hoverDomRef.current as HTMLDivElement & { _object?: fabric.Object | null })
+}
+
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
@@ -1031,15 +1044,20 @@ fc.on('selection:created', () => {
   }
   syncSel()
   requestAnimationFrame(syncSel)
-  scrollHandler = () => syncSel()
-  window.addEventListener('scroll', scrollHandler, { passive:true })
+  scrollHandler = () => {
+    syncSel()
+    syncHover()
+  }
+  window.addEventListener('scroll', scrollHandler, { passive: true, capture: true })
+  document.addEventListener('scroll', scrollHandler, { passive: true, capture: true })
   window.addEventListener('resize', scrollHandler)
-  containerRef.current?.addEventListener('scroll', scrollHandler, { passive:true })
+  containerRef.current?.addEventListener('scroll', scrollHandler, { passive: true, capture: true })
 })
 .on('selection:updated', syncSel)
 .on('selection:cleared', () => {
   if (scrollHandler) {
     window.removeEventListener('scroll', scrollHandler)
+    document.removeEventListener('scroll', scrollHandler)
     window.removeEventListener('resize', scrollHandler)
     containerRef.current?.removeEventListener('scroll', scrollHandler)
     scrollHandler = null
@@ -1049,6 +1067,8 @@ fc.on('selection:created', () => {
 })
 
 /* also hide hover during any transform of the active object */
+const handleAfterRender = () => { syncSel(); syncHover() }
+
 fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
   .on('object:scaling',  () => { hoverHL.visible = false; syncSel() })
   .on('object:scaled',   () => {
@@ -1058,27 +1078,37 @@ fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
   .on('object:rotating', () => { hoverHL.visible = false; syncSel() })
   .on('object:modified', () =>
     requestAnimationFrame(() => requestAnimationFrame(syncSel)))
-  .on('after:render',    syncSel)
+  .on('after:render',    handleAfterRender)
 
 /* ── 4 ▸ Hover outline (only when NOT the active object) ─── */
 fc.on('mouse:over', e => {
   const t = e.target as fabric.Object | undefined
   if (!t || (t as any)._guide || t === hoverHL) return
   if (fc.getActiveObject() === t) return           // skip active selection
-  const box = t.getBoundingRect(true, true)
-  const rect = canvasRef.current!.getBoundingClientRect()
-  const vt = fc.viewportTransform || [1,0,0,1,0,0]
   hoverDomRef.current && (() => {
-    hoverDomRef.current.style.left = `${rect.left + vt[4] + (box.left - PAD) * SCALE}px`
-    hoverDomRef.current.style.top = `${rect.top + vt[5] + (box.top - PAD) * SCALE}px`
-    hoverDomRef.current.style.width = `${(box.width + PAD * 2) * SCALE}px`
-    hoverDomRef.current.style.height = `${(box.height + PAD * 2) * SCALE}px`
+    drawOverlay(t, hoverDomRef.current as HTMLDivElement & { _object?: fabric.Object | null })
+    ;(hoverDomRef.current as any)._object = t
     hoverDomRef.current.style.display = 'block'
+    hoverScrollHandler = () => syncHover()
+    window.addEventListener('scroll', hoverScrollHandler, { passive: true, capture: true })
+    document.addEventListener('scroll', hoverScrollHandler, { passive: true, capture: true })
+    window.addEventListener('resize', hoverScrollHandler)
+    containerRef.current?.addEventListener('scroll', hoverScrollHandler, { passive: true, capture: true })
   })()
 })
 .on('mouse:out', () => {
   hoverHL.visible = false
-  hoverDomRef.current && (hoverDomRef.current.style.display = 'none')
+  hoverDomRef.current && (() => {
+    hoverDomRef.current.style.display = 'none'
+    ;(hoverDomRef.current as any)._object = null
+    if (hoverScrollHandler) {
+      window.removeEventListener('scroll', hoverScrollHandler)
+      document.removeEventListener('scroll', hoverScrollHandler)
+      window.removeEventListener('resize', hoverScrollHandler)
+      containerRef.current?.removeEventListener('scroll', hoverScrollHandler)
+      hoverScrollHandler = null
+    }
+  })()
   fc.requestRenderAll()
 })
 
@@ -1265,6 +1295,7 @@ window.addEventListener('keydown', onKey)
       window.removeEventListener('keydown', onKey)
       if (scrollHandler) window.removeEventListener('scroll', scrollHandler)
       window.removeEventListener('scroll', updateOffset)
+      document.removeEventListener('scroll', updateOffset)
       window.removeEventListener('resize', updateOffset)
       containerRef.current?.removeEventListener('scroll', updateOffset)
       // tidy up crop‑tool listeners
@@ -1273,7 +1304,7 @@ window.addEventListener('keydown', onKey)
       fc.off('before:transform', startCrop);
       fc.off('object:scaling', duringCrop);
       fc.off('object:scaled', endCrop);
-      fc.off('after:render', syncSel);
+      fc.off('after:render', handleAfterRender);
       selEl.removeEventListener('pointerdown', onSelDown)
       cropEl.removeEventListener('pointerdown', onCropDown)
       selEl.removeEventListener('pointerenter', raiseSel)
@@ -1287,8 +1318,15 @@ window.addEventListener('keydown', onKey)
       cropDomRef.current?.remove()
       if (scrollHandler) {
         window.removeEventListener('scroll', scrollHandler)
+        document.removeEventListener('scroll', scrollHandler)
         window.removeEventListener('resize', scrollHandler)
         containerRef.current?.removeEventListener('scroll', scrollHandler)
+      }
+      if (hoverScrollHandler) {
+        window.removeEventListener('scroll', hoverScrollHandler)
+        document.removeEventListener('scroll', hoverScrollHandler)
+        window.removeEventListener('resize', hoverScrollHandler)
+        containerRef.current?.removeEventListener('scroll', hoverScrollHandler)
       }
     }
 // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1449,13 +1487,15 @@ img.on('mouseup', () => {
             }
 
 doSync = () =>
-  canvasRef.current && ghost && syncGhost(img, ghost, canvasRef.current, zoom)
+  canvasRef.current && ghost && syncGhost(img, ghost, canvasRef.current)
             doSync()
             img.on('moving',   doSync)
                .on('scaling',  doSync)
                .on('rotating', doSync)
-               window.addEventListener('scroll', doSync, { passive: true })
+               window.addEventListener('scroll', doSync, { passive: true, capture: true })
+               document.addEventListener('scroll', doSync, { passive: true, capture: true })
                window.addEventListener('resize', doSync)
+               fc.on('after:render', doSync)
                
 
             /* hide overlay when actively selected */
@@ -1471,7 +1511,9 @@ doSync = () =>
 
             img.on('removed', () => {
               window.removeEventListener('scroll', doSync)
+              document.removeEventListener('scroll', doSync)
               window.removeEventListener('resize', doSync)
+              fc.off('after:render', doSync)
               ghost?.remove()
             })
           }


### PR DESCRIPTION
## Summary
- listen to scroll events in the capture phase so overlays update when any parent element scrolls
- register scroll listeners on `document` to catch page-level scrolling

## Testing
- `npm run lint` *(fails: React Hooks rules and other lint errors)*
- `npm run build` *(fails due to ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865205be0ac832392e170bd1a9233a0