### PR TITLE
Fix crop overlay handle drag

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -171,11 +171,22 @@ export class CropTool {
       img.centeredScaling = prevCenteredScaling
       img.hasBorders      = prevHasBorders
     })
-    /* hide the rotate ("mtr") and side controls while cropping */
-    img.setControlsVisibility({
-      mtr: false,          // hide rotation
-      ml : false, mr : false,      // hide middle-left / middle-right
-      mt : false, mb : false       // hide middle-top / middle-bottom
+    /* hide the rotate ("mtr") while cropping.  Side handles remain active but
+       are rendered via the DOM overlay, so we suppress Fabric's own drawing */
+    img.setControlsVisibility({ mtr: false });
+    const hidden: Array<[string, any]> = [];
+    ['ml','mr','mt','mb'].forEach(c => {
+      const ctrl = (img as any).controls?.[c] as fabric.Control | undefined;
+      if (ctrl) {
+        hidden.push([c, ctrl.render]);
+        ctrl.render = () => {};
+      }
+    });
+    this.cleanup.push(() => {
+      hidden.forEach(([c, render]) => {
+        const ctrl = (img as any).controls?.[c];
+        if (ctrl) ctrl.render = render;
+      });
     });
     img.hasBorders  = false
     img.borderColor = this.SEL          // keep consistent style if shown


### PR DESCRIPTION
## Summary
- keep Fabric.js side controls active during cropping but hide drawing
- restore original control rendering after cropping ends

## Testing
- `npm run lint` *(fails: react-hooks rules, etc.)*
- `npm run build` *(fails: ESLint errors during build)*
- `npx tsc -p tsconfig.json` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68658a05bff48323a9eb3fecbbc060f2