### PR TITLE
Fix crop overlay handle offset

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -648,11 +648,11 @@ useEffect(() => {
   });
   (cropEl as any)._handles = cropHandles;
 
-  const forward = (ev: PointerEvent) => ({
-    clientX   : ev.clientX,
-    clientY   : ev.clientY,
+  const forward = (ev: PointerEvent | MouseEvent, dx = 0, dy = 0) => ({
+    clientX   : ev.clientX + dx,
+    clientY   : ev.clientY + dy,
     button    : ev.button,
-    buttons   : ev.buttons,
+    buttons   : 'buttons' in ev ? ev.buttons : 0,
     ctrlKey   : ev.ctrlKey,
     shiftKey  : ev.shiftKey,
     altKey    : ev.altKey,
@@ -675,12 +675,19 @@ useEffect(() => {
   });
 
   const bridge = (e: PointerEvent) => {
-    const down = new MouseEvent('mousedown', forward(e))
+    const corner = (e.target as HTMLElement | null)?.dataset.corner
+    const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
+    const scale = vt[0]
+    const offset = PAD * scale
+    const dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
+    const dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+
+    const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)
     const move = (ev: PointerEvent) =>
-      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(ev)))
+      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(ev, dx, dy)))
     const up = (ev: PointerEvent) => {
-      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mouseup', forward(ev)))
+      fc.upperCanvasEl.dispatchEvent(new MouseEvent('mouseup', forward(ev, dx, dy)))
       document.removeEventListener('pointermove', move)
       document.removeEventListener('pointerup', up)
     }
@@ -899,26 +906,50 @@ if (container) {
     if (corner === 'mr' || corner === 'ml') {
       if (corner === 'mr') {
         const maxW = st.startWidth + (st.natW - (st.startCropX + st.startWidth));
-        width = Math.min(newW, maxW);
+        if (newW <= maxW) {
+          width = newW;
+        } else {
+          width = maxW;
+          scaleX = st.startScaleX * (newW / maxW);
+        }
       } else {
         const maxW = st.startWidth + st.startCropX;
-        const clamped = Math.min(newW, maxW);
-        const diff = st.startWidth - clamped;
-        cropX = st.startCropX + diff;
-        width = clamped;
-        left  = st.startLeft + diff * st.startScaleX;
+        if (newW <= maxW) {
+          const diff = st.startWidth - newW;
+          cropX = st.startCropX + diff;
+          width = newW;
+          left  = st.startLeft + diff * st.startScaleX;
+        } else {
+          const extra = newW - maxW;
+          width = maxW;
+          cropX = 0;
+          scaleX = st.startScaleX * (newW / maxW);
+          left = st.startLeft - extra * st.startScaleX;
+        }
       }
     } else if (corner === 'mb' || corner === 'mt') {
       if (corner === 'mb') {
         const maxH = st.startHeight + (st.natH - (st.startCropY + st.startHeight));
-        height = Math.min(newH, maxH);
+        if (newH <= maxH) {
+          height = newH;
+        } else {
+          height = maxH;
+          scaleY = st.startScaleY * (newH / maxH);
+        }
       } else {
         const maxH = st.startHeight + st.startCropY;
-        const clamped = Math.min(newH, maxH);
-        const diff = st.startHeight - clamped;
-        cropY = st.startCropY + diff;
-        height = clamped;
-        top = st.startTop + diff * st.startScaleY;
+        if (newH <= maxH) {
+          const diff = st.startHeight - newH;
+          cropY = st.startCropY + diff;
+          height = newH;
+          top = st.startTop + diff * st.startScaleY;
+        } else {
+          const extra = newH - maxH;
+          height = maxH;
+          cropY = 0;
+          scaleY = st.startScaleY * (newH / maxH);
+          top = st.startTop - extra * st.startScaleY;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- adjust DOM overlay pointer events to match canvas coordinates
- ensure crop overlay side handles trigger cropping properly
- expand image when crop handles dragged outward

## Testing
- `npm run lint` *(fails: React hook rule errors)*
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68658a05bff48323a9eb3fecbbc060f2