### PR TITLE
Fix inner page selection UX

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -161,10 +161,11 @@ export default function CardEditor({
 
   /* 3 ─ visible section ------------------------------------------ */
   const [section, setSection] = useState<Section>('front')
+  const [insidePage, setInsidePage] = useState<'left' | 'right'>('left')
   const activeIdx: PageIdx =
-    section === 'front'  ? 0 :
-    section === 'inside' ? 1 :
-    3                                                        // back
+    section === 'front' ? 0 :
+    section === 'back'  ? 3 :
+    insidePage === 'left' ? 1 : 2
   useEffect(() => { setActive(activeIdx) }, [activeIdx, setActive])
 
   /* 4 ─ Fabric canvases ------------------------------------------ */
@@ -854,7 +855,10 @@ const handleProofAll = async () => {
           >
             
             {/* front */}
-            <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
+            <div
+              className={section === 'front' ? `${box} page-active` : 'hidden'}
+              style={{ width: boxWidth }}
+            >
               <FabricCanvas
                 pageIdx={0}
                 page={pages[0]}
@@ -867,7 +871,11 @@ const handleProofAll = async () => {
             </div>
             {/* inside */}
             <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
-              <div className={box} style={{ width: boxWidth }}>
+              <div
+                className={`${box} ${insidePage === 'left' ? 'page-active' : 'page-inactive'}`}
+                style={{ width: boxWidth }}
+                onClick={() => setInsidePage('left')}
+              >
                 <FabricCanvas
                   pageIdx={1}
                   page={pages[1]}
@@ -878,7 +886,11 @@ const handleProofAll = async () => {
                   mode={mode}
                 />
               </div>
-              <div className={box} style={{ width: boxWidth }}>
+              <div
+                className={`${box} ${insidePage === 'right' ? 'page-active' : 'page-inactive'}`}
+                style={{ width: boxWidth }}
+                onClick={() => setInsidePage('right')}
+              >
                 <FabricCanvas
                   pageIdx={2}
                   page={pages[2]}
@@ -891,7 +903,10 @@ const handleProofAll = async () => {
               </div>
             </div>
             {/* back */}
-            <div className={section === 'back' ? box : 'hidden'} style={{ width: boxWidth }}>
+            <div
+              className={section === 'back' ? `${box} page-active` : 'hidden'}
+              style={{ width: boxWidth }}
+            >
               <FabricCanvas
                 pageIdx={3}
                 page={pages[3]}
@@ -909,16 +924,12 @@ const handleProofAll = async () => {
             {(['FRONT', 'INNER-L', 'INNER-R', 'BACK'] as const).map((lbl, i) => (
               <button
                 key={lbl}
-                className={`thumb ${
-                  (section === 'front' && i === 0) ||
-                  (section === 'inside' && (i === 1 || i === 2)) ||
-                  (section === 'back' && i === 3)
-                    ? 'thumb-active'
-                    : ''
-                }`}
-                onClick={() =>
-                  setSection(i === 0 ? 'front' : i === 3 ? 'back' : 'inside')
-                }
+                className={`thumb ${activeIdx === i ? 'thumb-active' : ''}`}
+                onClick={() => {
+                  if (i === 0) { setSection('front'); }
+                  else if (i === 3) { setSection('back'); }
+                  else { setSection('inside'); setInsidePage(i === 1 ? 'left' : 'right'); }
+                }}
               >
                 {thumbs[i] ? (
                   <img

--- a/app/globals.css
+++ b/app/globals.css
@@ -79,6 +79,14 @@ html {
   overflow: visible !important;
 }
 
+.page-active {
+  @apply ring-4 ring-blue-600;
+}
+
+.page-inactive {
+  @apply opacity-50;
+}
+
 /* Center icon + helper text */
 .ai-ghost__center {
   display:flex;


### PR DESCRIPTION
## Summary
- allow selecting inside left or right pages individually
- fade inactive pages and show an active ring
- tweak thumbnail click logic to activate correct page

## Testing
- `npm run lint` *(fails: react hooks rules, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68659a8770c88323b1ede568d65cb5e4