### PR TITLE
Improve page selection UX

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -159,12 +159,11 @@ export default function CardEditor({
   const redo = useEditor(s => s.redo)
 
 
-  /* 3 ─ visible section ------------------------------------------ */
-  const [section, setSection] = useState<Section>('front')
-  const activeIdx: PageIdx =
-    section === 'front'  ? 0 :
-    section === 'inside' ? 1 :
-    3                                                        // back
+  /* 3 ─ page selection ------------------------------------------ */
+  const [activeIdx, setActiveIdx] = useState<PageIdx>(0)
+  const section: Section =
+    activeIdx === 0 ? 'front' :
+    activeIdx === 3 ? 'back'  : 'inside'
   useEffect(() => { setActive(activeIdx) }, [activeIdx, setActive])
 
   /* 4 ─ Fabric canvases ------------------------------------------ */
@@ -751,7 +750,7 @@ const handleProofAll = async () => {
   }
 
   const boxWidth = previewW() * zoom
-  const box = `flex-shrink-0`
+  const box = `flex-shrink-0 relative`
 
   /* ---------------- UI ------------------------------------------ */
   return (
@@ -854,7 +853,11 @@ const handleProofAll = async () => {
           >
             
             {/* front */}
-            <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
+            <div
+              className={section === 'front' ? box : 'hidden'}
+              style={{ width: boxWidth }}
+              onClick={() => setActiveIdx(0)}
+            >
               <FabricCanvas
                 pageIdx={0}
                 page={pages[0]}
@@ -864,10 +867,17 @@ const handleProofAll = async () => {
                 zoom={zoom}
                 mode={mode}
               />
+              {activeIdx !== 0 && (
+                <div className="absolute inset-0 bg-black/30 cursor-pointer" />
+              )}
             </div>
             {/* inside */}
             <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
-              <div className={box} style={{ width: boxWidth }}>
+              <div
+                className={box}
+                style={{ width: boxWidth }}
+                onClick={() => setActiveIdx(1)}
+              >
                 <FabricCanvas
                   pageIdx={1}
                   page={pages[1]}
@@ -877,8 +887,15 @@ const handleProofAll = async () => {
                   zoom={zoom}
                   mode={mode}
                 />
+                {activeIdx !== 1 && (
+                  <div className="absolute inset-0 bg-black/30 cursor-pointer" />
+                )}
               </div>
-              <div className={box} style={{ width: boxWidth }}>
+              <div
+                className={box}
+                style={{ width: boxWidth }}
+                onClick={() => setActiveIdx(2)}
+              >
                 <FabricCanvas
                   pageIdx={2}
                   page={pages[2]}
@@ -888,10 +905,17 @@ const handleProofAll = async () => {
                   zoom={zoom}
                   mode={mode}
                 />
+                {activeIdx !== 2 && (
+                  <div className="absolute inset-0 bg-black/30 cursor-pointer" />
+                )}
               </div>
             </div>
             {/* back */}
-            <div className={section === 'back' ? box : 'hidden'} style={{ width: boxWidth }}>
+            <div
+              className={section === 'back' ? box : 'hidden'}
+              style={{ width: boxWidth }}
+              onClick={() => setActiveIdx(3)}
+            >
               <FabricCanvas
                 pageIdx={3}
                 page={pages[3]}
@@ -901,6 +925,9 @@ const handleProofAll = async () => {
                 zoom={zoom}
                 mode={mode}
               />
+              {activeIdx !== 3 && (
+                <div className="absolute inset-0 bg-black/30 cursor-pointer" />
+              )}
             </div>
           </div>
 
@@ -909,26 +936,18 @@ const handleProofAll = async () => {
             {(['FRONT', 'INNER-L', 'INNER-R', 'BACK'] as const).map((lbl, i) => (
               <button
                 key={lbl}
-                className={`thumb ${
-                  (section === 'front' && i === 0) ||
-                  (section === 'inside' && (i === 1 || i === 2)) ||
-                  (section === 'back' && i === 3)
-                    ? 'thumb-active'
-                    : ''
-                }`}
-                onClick={() =>
-                  setSection(i === 0 ? 'front' : i === 3 ? 'back' : 'inside')
-                }
+                className={`thumb ${activeIdx === i ? 'thumb-active' : ''}`}
+                onClick={() => setActiveIdx(i as PageIdx)}
               >
                 {thumbs[i] ? (
                   <img
                     src={thumbs[i]}
                     alt={lbl}
                     className="h-full w-full object-cover"
-                  />
-                ) : (
-                  lbl
-                )}
+                />
+              ) : (
+                lbl
+              )}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- allow selecting individual pages inside CardEditor
- fade inactive canvases and overlay click handler
- update thumbnail selection

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_68659a8770c88323b1ede568d65cb5e4