### PR TITLE
Enable inner page selection

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -159,12 +159,12 @@ export default function CardEditor({
   const redo = useEditor(s => s.redo)
 
 
-  /* 3 ─ visible section ------------------------------------------ */
-  const [section, setSection] = useState<Section>('front')
-  const activeIdx: PageIdx =
-    section === 'front'  ? 0 :
-    section === 'inside' ? 1 :
-    3                                                        // back
+  /* 3 ─ active page & section ----------------------------------- */
+  const [activeIdx, setActiveIdx] = useState<PageIdx>(0)
+  const section: Section =
+    activeIdx === 0 ? 'front' :
+    activeIdx === 3 ? 'back'  :
+    'inside'
   useEffect(() => { setActive(activeIdx) }, [activeIdx, setActive])
 
   /* 4 ─ Fabric canvases ------------------------------------------ */
@@ -867,7 +867,11 @@ const handleProofAll = async () => {
             </div>
             {/* inside */}
             <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
-              <div className={box} style={{ width: boxWidth }}>
+              <div
+                className={`${box} relative ${activeIdx === 1 ? '' : 'opacity-50'}`}
+                style={{ width: boxWidth }}
+                onMouseDown={() => setActiveIdx(1 as PageIdx)}
+              >
                 <FabricCanvas
                   pageIdx={1}
                   page={pages[1]}
@@ -878,7 +882,11 @@ const handleProofAll = async () => {
                   mode={mode}
                 />
               </div>
-              <div className={box} style={{ width: boxWidth }}>
+              <div
+                className={`${box} relative ${activeIdx === 2 ? '' : 'opacity-50'}`}
+                style={{ width: boxWidth }}
+                onMouseDown={() => setActiveIdx(2 as PageIdx)}
+              >
                 <FabricCanvas
                   pageIdx={2}
                   page={pages[2]}
@@ -909,16 +917,8 @@ const handleProofAll = async () => {
             {(['FRONT', 'INNER-L', 'INNER-R', 'BACK'] as const).map((lbl, i) => (
               <button
                 key={lbl}
-                className={`thumb ${
-                  (section === 'front' && i === 0) ||
-                  (section === 'inside' && (i === 1 || i === 2)) ||
-                  (section === 'back' && i === 3)
-                    ? 'thumb-active'
-                    : ''
-                }`}
-                onClick={() =>
-                  setSection(i === 0 ? 'front' : i === 3 ? 'back' : 'inside')
-                }
+                className={`thumb ${activeIdx === i ? 'thumb-active' : ''}`}
+                onClick={() => setActiveIdx(i as PageIdx)}
               >
                 {thumbs[i] ? (
                   <img


### PR DESCRIPTION
## Summary
- manage the active page directly so inside left/right can be selected
- allow clicking inner canvases or thumbnails to set the active page
- visually fade the inactive inner canvas

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@dnd-kit/core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68659a8770c88323b1ede568d65cb5e4