### PR TITLE
Fix paste only active page

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1252,6 +1252,7 @@ addGuides(fc, mode)                           // add guides based on mode
 /* ───────────────── clipboard & keyboard shortcuts ────────────────── */
 
 const onKey = (e: KeyboardEvent) => {
+  if (useEditor.getState().activePage !== pageIdx) return
   const active = fc.getActiveObject() as fabric.Object | undefined
   const cmd    = e.metaKey || e.ctrlKey
 


### PR DESCRIPTION
## Summary
- ensure each Fabric canvas only handles shortcuts when active

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865a78083988323ad84083563494387