### PR TITLE
Add rotate handle for DOM overlays

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -630,9 +630,11 @@ useEffect(() => {
   cropDomRef.current = cropEl;
   (cropEl as any)._object = null;
 
-  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const selCorners = ['tl','tr','br','bl','ml','mr','mt','mb','mtr'] as const;
+  const cropCorners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+
   const handleMap: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  selCorners.forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : ''} ${c}`;
     h.dataset.corner = c;
@@ -642,7 +644,7 @@ useEffect(() => {
   (selEl as any)._handles = handleMap;
 
   const cropHandles: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  cropCorners.forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : ''} ${c}`;
     h.dataset.corner = c;
@@ -1006,7 +1008,7 @@ const hoverHL = new fabric.Rect({
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,
 })
-fc.add(hoverHL)
+//fc.add(hoverHL) // temporarily hide canvas hover outline
 hoverRef.current = hoverHL
 
 /* ── 3 ▸ Selection lifecycle (DOM overlay) ─────────── */
@@ -1045,6 +1047,11 @@ const drawOverlay = (
     h.mr.style.left = `${width}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`; h.mt.style.top = '0px'
     h.mb.style.left = `${midX}px`; h.mb.style.top = `${height}px`
+    if (h.mtr) {
+      const rotOff = ((obj.rotatingPointOffset ?? 40) + PAD) * scale
+      h.mtr.style.left = `${midX}px`
+      h.mtr.style.top  = `${-rotOff}px`
+    }
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,4 +131,5 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+  .sel-overlay .handle.mtr { cursor:grab; }
 }

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -17,6 +17,7 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerColor       = '#fff';
 (fabric.Object.prototype as any).transparentCorners= false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
+(fabric.Object.prototype as any).hasBorders        = false;
 
 /* ───────────────── helpers ──────────────────────────────── */
 
@@ -81,24 +82,8 @@ const pillControlV: fabric.Control['render'] = function (
 
 const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 
-// top & bottom – horizontal pill
-['mt','mb'].forEach(pos => {
-  (fabric.Object.prototype as any).controls[pos].render =
-    withShadow(pillControl);
-});
-
-// left & right – 90° pill
-['ml','mr'].forEach(pos => {
-  (fabric.Object.prototype as any).controls[pos].render =
-    withShadow(pillControlV);
-});
-
-// rotation handle
-(fabric.Object.prototype as any).controls.mtr.render =
-  withShadow(utils.renderCircleControl);
-
-// corner circles
-['tl','tr','bl','br'].forEach(pos => {
-  (fabric.Object.prototype as any).controls[pos].render =
-    withShadow(utils.renderCircleControl);
+// Hide Fabric's native outlines (DOM overlays will replace them)
+const hide: fabric.Control['render'] = () => {};
+['mt','mb','ml','mr','mtr','tl','tr','bl','br'].forEach(pos => {
+  (fabric.Object.prototype as any).controls[pos].render = hide;
 });


### PR DESCRIPTION
## Summary
- create rotate handles in DOM overlays
- hide Fabric hover outline
- hide old Fabric control rendering so DOM handles stand out

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865a97480fc8323a03cfc0808cbe496