### PR TITLE
Clean up legacy canvas outlines

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -477,7 +477,6 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
   const canvasRef    = useRef<HTMLCanvasElement>(null)
   const fcRef        = useRef<fabric.Canvas | null>(null)
   const maskRectsRef = useRef<fabric.Rect[]>([]);
-  const hoverRef     = useRef<fabric.Rect | null>(null)
   const hydrating    = useRef(false)
   const isEditing    = useRef(false)
 
@@ -996,18 +995,6 @@ if (container) {
 
  
 
-/* ── 2 ▸ Hover overlay only ─────────────────────────────── */
-const hoverHL = new fabric.Rect({
-  originX:'left', originY:'top', strokeUniform:true,
-  fill:'transparent',
-  stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
-  strokeDashArray:[],
-  selectable:false, evented:false, visible:false,
-  excludeFromExport:true,
-})
-fc.add(hoverHL)
-hoverRef.current = hoverHL
 
 /* ── 3 ▸ Selection lifecycle (DOM overlay) ─────────── */
 let scrollHandler: (() => void) | null = null
@@ -1096,7 +1083,6 @@ const syncHover = () => {
 }
 
 fc.on('selection:created', () => {
-  hoverHL.visible = false
   fc.requestRenderAll()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
@@ -1132,13 +1118,12 @@ const handleAfterRender = () => {
   syncHover()
 }
 
-fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
-  .on('object:scaling',  () => { hoverHL.visible = false; syncSel() })
+fc.on('object:moving',   () => { syncSel() })
+  .on('object:scaling',  () => { syncSel() })
   .on('object:scaled',   () => {
-    hoverHL.visible = false
     requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
-  .on('object:rotating', () => { hoverHL.visible = false; syncSel() })
+  .on('object:rotating', () => { syncSel() })
   .on('object:modified', () =>
     requestAnimationFrame(() => requestAnimationFrame(syncSel)))
   .on('after:render',    handleAfterRender)
@@ -1146,7 +1131,7 @@ fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
 /* ── 4 ▸ Hover outline (only when NOT the active object) ─── */
 fc.on('mouse:over', e => {
   const t = e.target as fabric.Object | undefined
-  if (!t || (t as any)._guide || t === hoverHL) return
+  if (!t || (t as any)._guide) return
   if (fc.getActiveObject() === t) return           // skip active selection
   hoverDomRef.current && (() => {
     drawOverlay(t, hoverDomRef.current as HTMLDivElement & { _object?: fabric.Object | null })
@@ -1162,7 +1147,6 @@ fc.on('mouse:over', e => {
   })()
 })
 .on('mouse:out', () => {
-  hoverHL.visible = false
   hoverDomRef.current && (() => {
     hoverDomRef.current.style.display = 'none'
     ;(hoverDomRef.current as any)._object = null
@@ -1173,7 +1157,6 @@ fc.on('mouse:over', e => {
       hoverScrollHandler = null
     }
   })()
-  fc.requestRenderAll()
 })
 
 addGuides(fc, mode)                           // add guides based on mode
@@ -1447,7 +1430,6 @@ window.addEventListener('keydown', onKey)
     hydrating.current = true
     fc.clear();
     fc.setBackgroundColor('#fff', fc.renderAll.bind(fc));
-    hoverRef.current && fc.add(hoverRef.current)
 
     /* bottom ➜ top keeps original z-order */
     for (let idx = 0; idx < page.layers.length; idx++) {
@@ -1621,7 +1603,6 @@ doSync = () =>
     }
 
     addGuides(fc, mode)
-    hoverRef.current?.bringToFront()
     fc.requestRenderAll();
     hydrating.current = false
     document.dispatchEvent(

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -527,9 +527,7 @@ export class CropTool {
       this.fc.off('object:modified', modifiedHandler)
     );
 
-    /* ④ dual‑handle rendering + clamping */
-    // draw both control sets every frame
-    this.fc.on('after:render', this.renderBoth)
+
 
     /* ------------------------------------------------------------------
      *  Whenever the user presses the mouse, ensure that whichever object
@@ -734,7 +732,6 @@ export class CropTool {
     this.cleanup.forEach(fn => fn());
     this.cleanup = [];
 
-    this.fc.off('after:render', this.renderBoth)
     if (this.frame) this.fc.remove(this.frame)
     this.masks.forEach(r => this.fc.remove(r));
     this.masks = [];
@@ -770,9 +767,7 @@ export class CropTool {
       this.scrollLeft = 0
       this.scrollTop = 0
     }
-    // ensure any leftover overlay is cleared
-    const ctx = (this.fc as any).contextTop
-    if (ctx) this.fc.clearContext(ctx)
+
 
     if (this.img) {
       this.img.lockMovementX = false
@@ -889,39 +884,4 @@ export class CropTool {
       return Math.max(needW / img.width!, needH / img.height!);
     }
 
-  /* draw controls for both objects each frame */
-  private renderBoth = () => {
-    if (!this.img || !this.frame) return
-
-    // Always refresh corner caches before drawing controls so they track
-    // live transforms even after repeated scale gestures.
-    this.img.setCoords();
-    this.frame.setCoords();
-
-        const ctx = (this.fc as any).contextTop
-        if (!ctx) return;            // canvas disposed or not yet initialised
-        /* Fabric doesn’t always wipe contextTop if it draws nothing of its own.
-           Clear it ourselves before redrawing both control sets. */
-        this.fc.clearContext(ctx)
-
-    ctx.save()
-    const vpt = this.fc.viewportTransform;
-    if (vpt) {
-      //          a     b     c     d     e     f
-      ctx.transform(vpt[0], vpt[1], vpt[2], vpt[3], vpt[4], vpt[5]);
-    }      // draw in the same space as Fabric
-    /* ---- Persistent bitmap outline while cropping ---- */
-    if (this.isActive && this.img) {
-      const br = this.img.getBoundingRect(true, true);
-      ctx.save();
-      ctx.strokeStyle = this.SEL;
-      ctx.lineWidth   = 1 / this.SCALE;
-      ctx.setLineDash([]);                 // solid
-      ctx.strokeRect(br.left, br.top, br.width, br.height);
-      ctx.restore();
-    }
-    if (this.img?.hasControls)   this.img.drawControls(ctx);
-    if (this.frame?.hasControls) this.frame.drawControls(ctx);
-    ctx.restore()
-  }
 }


### PR DESCRIPTION
## Summary
- drop obsolete Fabric hover outline logic
- remove dual canvas outline rendering from `CropTool`

## Testing
- `npm run lint` *(fails: React hook rule errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6865afc91abc832390ad3fe97100160f