### PR TITLE
Remove obsolete canvas outlines

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -477,7 +477,6 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
   const canvasRef    = useRef<HTMLCanvasElement>(null)
   const fcRef        = useRef<fabric.Canvas | null>(null)
   const maskRectsRef = useRef<fabric.Rect[]>([]);
-  const hoverRef     = useRef<fabric.Rect | null>(null)
   const hydrating    = useRef(false)
   const isEditing    = useRef(false)
 
@@ -993,22 +992,6 @@ if (container) {
   fc.on('before:transform', startCrop);
   fc.on('object:scaling', duringCrop);
   fc.on('object:scaled', endCrop);
-
- 
-
-/* ── 2 ▸ Hover overlay only ─────────────────────────────── */
-const hoverHL = new fabric.Rect({
-  originX:'left', originY:'top', strokeUniform:true,
-  fill:'transparent',
-  stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
-  strokeDashArray:[],
-  selectable:false, evented:false, visible:false,
-  excludeFromExport:true,
-})
-fc.add(hoverHL)
-hoverRef.current = hoverHL
-
 /* ── 3 ▸ Selection lifecycle (DOM overlay) ─────────── */
 let scrollHandler: (() => void) | null = null
 let hoverScrollHandler: (() => void) | null = null
@@ -1096,7 +1079,6 @@ const syncHover = () => {
 }
 
 fc.on('selection:created', () => {
-  hoverHL.visible = false
   fc.requestRenderAll()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
@@ -1132,13 +1114,12 @@ const handleAfterRender = () => {
   syncHover()
 }
 
-fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
-  .on('object:scaling',  () => { hoverHL.visible = false; syncSel() })
+fc.on('object:moving',   () => { syncSel() })
+  .on('object:scaling',  () => { syncSel() })
   .on('object:scaled',   () => {
-    hoverHL.visible = false
     requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
-  .on('object:rotating', () => { hoverHL.visible = false; syncSel() })
+  .on('object:rotating', () => { syncSel() })
   .on('object:modified', () =>
     requestAnimationFrame(() => requestAnimationFrame(syncSel)))
   .on('after:render',    handleAfterRender)
@@ -1146,7 +1127,7 @@ fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
 /* ── 4 ▸ Hover outline (only when NOT the active object) ─── */
 fc.on('mouse:over', e => {
   const t = e.target as fabric.Object | undefined
-  if (!t || (t as any)._guide || t === hoverHL) return
+  if (!t || (t as any)._guide) return
   if (fc.getActiveObject() === t) return           // skip active selection
   hoverDomRef.current && (() => {
     drawOverlay(t, hoverDomRef.current as HTMLDivElement & { _object?: fabric.Object | null })
@@ -1161,9 +1142,7 @@ fc.on('mouse:over', e => {
     containerRef.current?.addEventListener('scroll', hoverScrollHandler, { passive: true, capture: true })
   })()
 })
-.on('mouse:out', () => {
-  hoverHL.visible = false
-  hoverDomRef.current && (() => {
+.on('mouse:out', () => {  hoverDomRef.current && (() => {
     hoverDomRef.current.style.display = 'none'
     ;(hoverDomRef.current as any)._object = null
     if (hoverScrollHandler) {
@@ -1447,7 +1426,6 @@ window.addEventListener('keydown', onKey)
     hydrating.current = true
     fc.clear();
     fc.setBackgroundColor('#fff', fc.renderAll.bind(fc));
-    hoverRef.current && fc.add(hoverRef.current)
 
     /* bottom ➜ top keeps original z-order */
     for (let idx = 0; idx < page.layers.length; idx++) {
@@ -1621,7 +1599,6 @@ doSync = () =>
     }
 
     addGuides(fc, mode)
-    hoverRef.current?.bringToFront()
     fc.requestRenderAll();
     hydrating.current = false
     document.dispatchEvent(

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -195,7 +195,7 @@ export class CropTool {
         fill:'',
         perPixelTargetFind:false,   // relax pixel-perfect hit-testing
         evented:false,
-        stroke:this.SEL, strokeWidth:1/this.SCALE,
+        stroke:"", strokeWidth:1/this.SCALE,
         strokeUniform:true }),
     ],{
       left:fx, top:fy, originX:'left', originY:'top',
@@ -207,58 +207,6 @@ export class CropTool {
       transparentCorners:false,
       subTargetCheck: true,          // let clicks inside the rectangle fall through
     })
-    // ---- replace default controls with 4 small white “L” handles ----
-    // slightly larger "L" handles for easier grabbing
-    const sizePx = 4 / this.SCALE;
-
-    /** Draw a single L‑shape, rotated for each corner */
-    const drawL = (
-      ctx : CanvasRenderingContext2D,
-      left: number,
-      top : number,
-      rot : number,                                  // radians
-    ) => {
-      ctx.save();
-      ctx.translate(left, top);
-      ctx.rotate(rot);
-      ctx.lineWidth   = 0.5 / this.SCALE;
-      ctx.strokeStyle = '#ffffff';
-      ctx.shadowColor = 'rgba(0,0,0,0.35)';          // subtle outline
-      ctx.shadowBlur  = 3 / this.SCALE;
-      ctx.beginPath();
-      ctx.moveTo(0,  0);
-      ctx.lineTo(0,  sizePx * 0.8);    // vertical down from origin
-      ctx.moveTo(0,  0);
-      ctx.lineTo(sizePx * 0.8, 0);     // horizontal right
-      ctx.stroke();
-      ctx.restore();
-    };
-
-    /** corner control factory with proper orientation */
-    const mkCorner = (x: number, y: number, rot: number) =>
-      new fabric.Control({
-        x, y,
-        offsetX: 0, offsetY: 0,
-        // enlarge hit‑box for easier grabbing
-        sizeX: 12 / this.SCALE,
-        sizeY: 12 / this.SCALE,
-        // use Fabric helpers (cast to `any` to silence TS)
-        cursorStyleHandler: (fabric as any).controlsUtils.scaleCursorStyleHandler,
-        actionHandler     : (fabric as any).controlsUtils.scalingEqually,
-        actionName        : 'scale',   // ensure Fabric treats this as scaling, not drag
-        render            : (ctx, left, top) => drawL(ctx, left, top, rot),
-      });
-
-    // keep only the 4 corner controls; no sides, no rotation
-    (this.frame as any).controls = {
-      tl: mkCorner(-0.5, -0.5,  0),                // top‑left
-      tr: mkCorner( 0.5, -0.5,  Math.PI / 2),      // top‑right
-      br: mkCorner( 0.5,  0.5,  Math.PI),          // bottom‑right
-      bl: mkCorner(-0.5,  0.5, -Math.PI / 2),      // bottom‑left
-    } as Record<string, fabric.Control>;
-
-    /* ③ add both to canvas and keep z‑order intuitive              */
-    this.fc.add(this.frame)
     /* 2‑b ─ dim everything outside the crop window -------------------- */
     const mkMask = () => new fabric.Rect({
       left: 0, top: 0, width: this.fc.width!, height: this.fc.height!,
@@ -527,9 +475,6 @@ export class CropTool {
       this.fc.off('object:modified', modifiedHandler)
     );
 
-    /* ④ dual‑handle rendering + clamping */
-    // draw both control sets every frame
-    this.fc.on('after:render', this.renderBoth)
 
     /* ------------------------------------------------------------------
      *  Whenever the user presses the mouse, ensure that whichever object
@@ -734,7 +679,6 @@ export class CropTool {
     this.cleanup.forEach(fn => fn());
     this.cleanup = [];
 
-    this.fc.off('after:render', this.renderBoth)
     if (this.frame) this.fc.remove(this.frame)
     this.masks.forEach(r => this.fc.remove(r));
     this.masks = [];
@@ -889,39 +833,4 @@ export class CropTool {
       return Math.max(needW / img.width!, needH / img.height!);
     }
 
-  /* draw controls for both objects each frame */
-  private renderBoth = () => {
-    if (!this.img || !this.frame) return
-
-    // Always refresh corner caches before drawing controls so they track
-    // live transforms even after repeated scale gestures.
-    this.img.setCoords();
-    this.frame.setCoords();
-
-        const ctx = (this.fc as any).contextTop
-        if (!ctx) return;            // canvas disposed or not yet initialised
-        /* Fabric doesn’t always wipe contextTop if it draws nothing of its own.
-           Clear it ourselves before redrawing both control sets. */
-        this.fc.clearContext(ctx)
-
-    ctx.save()
-    const vpt = this.fc.viewportTransform;
-    if (vpt) {
-      //          a     b     c     d     e     f
-      ctx.transform(vpt[0], vpt[1], vpt[2], vpt[3], vpt[4], vpt[5]);
-    }      // draw in the same space as Fabric
-    /* ---- Persistent bitmap outline while cropping ---- */
-    if (this.isActive && this.img) {
-      const br = this.img.getBoundingRect(true, true);
-      ctx.save();
-      ctx.strokeStyle = this.SEL;
-      ctx.lineWidth   = 1 / this.SCALE;
-      ctx.setLineDash([]);                 // solid
-      ctx.strokeRect(br.left, br.top, br.width, br.height);
-      ctx.restore();
-    }
-    if (this.img?.hasControls)   this.img.drawControls(ctx);
-    if (this.frame?.hasControls) this.frame.drawControls(ctx);
-    ctx.restore()
-  }
 }


### PR DESCRIPTION
## Summary
- drop Fabric hover outline object and related code
- strip CropTool of canvas-based handles and rendering

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865afc91abc832390ad3fe97100160f