### PR TITLE
Fix hover overlay when selecting objects

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1097,6 +1097,16 @@ const syncHover = () => {
 
 fc.on('selection:created', () => {
   hoverHL.visible = false
+  hoverDomRef.current && (() => {
+    hoverDomRef.current!.style.display = 'none'
+    ;(hoverDomRef.current as any)._object = null
+    if (hoverScrollHandler) {
+      window.removeEventListener('scroll', hoverScrollHandler)
+      window.removeEventListener('resize', hoverScrollHandler)
+      containerRef.current?.removeEventListener('scroll', hoverScrollHandler)
+      hoverScrollHandler = null
+    }
+  })()
   fc.requestRenderAll()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {


### PR DESCRIPTION
## Summary
- hide hover overlay when an object becomes active so only the transform box remains

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b4b1753c8323b8d2c443172262f9