### PR TITLE
Fix duplicate handles in card editor

### DIFF
--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -11,11 +11,12 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerSize        = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).touchCornerSize   = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).borderScaleFactor = 1;
-(fabric.Object.prototype as any).borderColor       = SEL_COLOR;
+(fabric.Object.prototype as any).borderColor       = 'transparent';
 (fabric.Object.prototype as any).borderDashArray   = [];
-(fabric.Object.prototype as any).cornerStrokeColor = '#fff';
-(fabric.Object.prototype as any).cornerColor       = '#fff';
-(fabric.Object.prototype as any).transparentCorners= false;
+(fabric.Object.prototype as any).cornerStrokeColor = 'transparent';
+(fabric.Object.prototype as any).cornerColor       = 'transparent';
+(fabric.Object.prototype as any).transparentCorners= true;
+(fabric.Object.prototype as any).hasBorders        = false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
 
 /* ───────────────── helpers ──────────────────────────────── */


### PR DESCRIPTION
## Summary
- disable Fabric.js built‑in borders and corner handles

## Testing
- `npm run lint` *(fails: react-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b749327083239b49555fd34844d8