### PR TITLE
Fix double selection outlines

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1509,7 +1509,7 @@ if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
           if (raw._type === 'aiLayer') {
             const spec = raw.source
             const locked = !!ly.locked
-            img.set({ selectable: !locked, evented: !locked, hasControls: !locked })
+            img.set({ selectable: !locked, evented: !locked, hasControls: false })
 
  
             // ─── open the Selfie Drawer on click ─────────────────────────

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -17,6 +17,8 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerColor       = '#fff';
 (fabric.Object.prototype as any).transparentCorners= false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
+(fabric.Object.prototype as any).hasBorders        = false;
+(fabric.Object.prototype as any).hasControls       = false;
 
 /* ───────────────── helpers ──────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- disable Fabric selection borders and controls by default
- never enable Fabric controls for AI placeholders

## Testing
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b749327083239b49555fd34844d8