### PR TITLE
Fix duplicate selection handles

### DIFF
--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -17,6 +17,8 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerColor       = '#fff';
 (fabric.Object.prototype as any).transparentCorners= false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
+(fabric.Object.prototype as any).hasBorders        = false;
+(fabric.Object.prototype as any).hasControls       = false;
 
 /* ───────────────── helpers ──────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- hide Fabric's built-in selection borders and controls

## Testing
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b749327083239b49555fd34844d8