### PR TITLE
Fix duplicate handles in card editor

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -920,8 +920,12 @@ export class CropTool {
       ctx.strokeRect(br.left, br.top, br.width, br.height);
       ctx.restore();
     }
-    if (this.img?.hasControls)   this.img.drawControls(ctx);
-    if (this.frame?.hasControls) this.frame.drawControls(ctx);
+    // Fabric will still recognise control interactions even if we skip
+    // drawing the handles here.  The DOM overlay mirrors the handles and
+    // forwards pointer events, so we avoid double visuals by not rendering
+    // Fabric's built‑in controls.
+    // if (this.img?.hasControls)   this.img.drawControls(ctx);
+    // if (this.frame?.hasControls) this.frame.drawControls(ctx);
     ctx.restore()
   }
 }

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -11,11 +11,12 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerSize        = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).touchCornerSize   = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).borderScaleFactor = 1;
-(fabric.Object.prototype as any).borderColor       = SEL_COLOR;
+(fabric.Object.prototype as any).borderColor       = 'transparent';
 (fabric.Object.prototype as any).borderDashArray   = [];
-(fabric.Object.prototype as any).cornerStrokeColor = '#fff';
-(fabric.Object.prototype as any).cornerColor       = '#fff';
-(fabric.Object.prototype as any).transparentCorners= false;
+(fabric.Object.prototype as any).cornerStrokeColor = 'transparent';
+(fabric.Object.prototype as any).cornerColor       = 'transparent';
+(fabric.Object.prototype as any).transparentCorners= true;
+(fabric.Object.prototype as any).hasBorders        = false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
 
 /* ───────────────── helpers ──────────────────────────────── */


### PR DESCRIPTION
## Summary
- disable Fabric.js built-in borders and corner handles
- hide Fabric controls during crop so only custom overlay is visible

## Testing
- `npm run lint` *(fails: react-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b749327083239b49555fd34844d8