### PR TITLE
Fix duplicate handles in card editor

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -195,7 +195,7 @@ export class CropTool {
         fill:'',
         perPixelTargetFind:false,   // relax pixel-perfect hit-testing
         evented:false,
-        stroke:this.SEL, strokeWidth:1/this.SCALE,
+        stroke:'transparent', strokeWidth:0,
         strokeUniform:true }),
     ],{
       left:fx, top:fy, originX:'left', originY:'top',
@@ -235,7 +235,7 @@ export class CropTool {
     };
 
     /** corner control factory with proper orientation */
-    const mkCorner = (x: number, y: number, rot: number) =>
+    const mkCorner = (x: number, y: number) =>
       new fabric.Control({
         x, y,
         offsetX: 0, offsetY: 0,
@@ -246,15 +246,15 @@ export class CropTool {
         cursorStyleHandler: (fabric as any).controlsUtils.scaleCursorStyleHandler,
         actionHandler     : (fabric as any).controlsUtils.scalingEqually,
         actionName        : 'scale',   // ensure Fabric treats this as scaling, not drag
-        render            : (ctx, left, top) => drawL(ctx, left, top, rot),
+        render            : () => {},  // hide canvas handles – DOM overlay shows them
       });
 
     // keep only the 4 corner controls; no sides, no rotation
     (this.frame as any).controls = {
-      tl: mkCorner(-0.5, -0.5,  0),                // top‑left
-      tr: mkCorner( 0.5, -0.5,  Math.PI / 2),      // top‑right
-      br: mkCorner( 0.5,  0.5,  Math.PI),          // bottom‑right
-      bl: mkCorner(-0.5,  0.5, -Math.PI / 2),      // bottom‑left
+      tl: mkCorner(-0.5, -0.5),
+      tr: mkCorner( 0.5, -0.5),
+      br: mkCorner( 0.5,  0.5),
+      bl: mkCorner(-0.5,  0.5),
     } as Record<string, fabric.Control>;
 
     /* ③ add both to canvas and keep z‑order intuitive              */

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -11,11 +11,12 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerSize        = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).touchCornerSize   = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).borderScaleFactor = 1;
-(fabric.Object.prototype as any).borderColor       = SEL_COLOR;
+(fabric.Object.prototype as any).borderColor       = 'transparent';
 (fabric.Object.prototype as any).borderDashArray   = [];
-(fabric.Object.prototype as any).cornerStrokeColor = '#fff';
-(fabric.Object.prototype as any).cornerColor       = '#fff';
-(fabric.Object.prototype as any).transparentCorners= false;
+(fabric.Object.prototype as any).cornerStrokeColor = 'transparent';
+(fabric.Object.prototype as any).cornerColor       = 'transparent';
+(fabric.Object.prototype as any).transparentCorners= true;
+(fabric.Object.prototype as any).hasBorders        = false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
 
 /* ───────────────── helpers ──────────────────────────────── */


### PR DESCRIPTION
## Summary
- disable Fabric.js built‑in borders and corner handles
- hide Fabric handles during crop so only DOM overlay shows

## Testing
- `npm run lint` *(fails: react-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b749327083239b49555fd34844d8