### PR TITLE
Fix duplicate handles in crop mode

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1058,26 +1058,16 @@ const syncSel = () => {
   if (croppingRef.current && tool?.isActive && tool.img && tool.frame) {
     const img   = tool.img as fabric.Object
     const frame = tool.frame as fabric.Object
-    // whichever is active uses selEl; the other uses cropEl
+
     selEl.style.zIndex = '41'
-    cropEl && (cropEl.style.zIndex = '40')
     if (obj === frame) {
       drawOverlay(frame, selEl)
       selEl._object = frame
-      if (cropEl) {
-        cropEl.style.display = 'block'
-        drawOverlay(img, cropEl)
-        cropEl._object = img
-      }
     } else {
       drawOverlay(img, selEl)
       selEl._object = img
-      if (cropEl) {
-        cropEl.style.display = 'block'
-        drawOverlay(frame, cropEl)
-        cropEl._object = frame
-      }
     }
+    cropEl && (cropEl.style.display = 'none', cropEl._object = null)
     selEl.style.display = 'block'
     return
   }

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -195,7 +195,7 @@ export class CropTool {
         fill:'',
         perPixelTargetFind:false,   // relax pixel-perfect hit-testing
         evented:false,
-        stroke:this.SEL, strokeWidth:1/this.SCALE,
+        stroke:'transparent', strokeWidth:1/this.SCALE,
         strokeUniform:true }),
     ],{
       left:fx, top:fy, originX:'left', originY:'top',
@@ -920,8 +920,8 @@ export class CropTool {
       ctx.strokeRect(br.left, br.top, br.width, br.height);
       ctx.restore();
     }
-    if (this.img?.hasControls)   this.img.drawControls(ctx);
-    if (this.frame?.hasControls) this.frame.drawControls(ctx);
+    // DOM overlays handle visible controls; avoid duplicate canvas handles
+    // by skipping Fabric's built‑in renderers here.
     ctx.restore()
   }
 }

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -11,11 +11,12 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).cornerSize        = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).touchCornerSize   = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).borderScaleFactor = 1;
-(fabric.Object.prototype as any).borderColor       = SEL_COLOR;
+(fabric.Object.prototype as any).borderColor       = 'transparent';
 (fabric.Object.prototype as any).borderDashArray   = [];
-(fabric.Object.prototype as any).cornerStrokeColor = '#fff';
-(fabric.Object.prototype as any).cornerColor       = '#fff';
-(fabric.Object.prototype as any).transparentCorners= false;
+(fabric.Object.prototype as any).cornerStrokeColor = 'transparent';
+(fabric.Object.prototype as any).cornerColor       = 'transparent';
+(fabric.Object.prototype as any).transparentCorners= true;
+(fabric.Object.prototype as any).hasBorders        = false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
 
 /* ───────────────── helpers ──────────────────────────────── */


### PR DESCRIPTION
## Summary
- hide crop frame stroke and skip Fabric handle rendering
- show DOM overlay only for the active crop object

## Testing
- `npm run lint` *(fails: react-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b749327083239b49555fd34844d8