### PR TITLE
Improve selection overlay visuals

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1001,7 +1001,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:2px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -117,6 +117,12 @@ html {
     border-radius:50%;
     transform:translate(-50%,-50%);
     pointer-events:auto;
+  }
+  .sel-overlay .handle:not(.side) {
+    width:12px;
+    height:12px;
+    border:1px solid rgba(128,128,128,0.5);
+    box-shadow:0 1px 2px rgba(0,0,0,0.25);
   }
   .sel-overlay .handle.side {
     width:4px;


### PR DESCRIPTION
## Summary
- thicken hover overlay outline
- show solid teal border
- make corner handles bigger with grey border and drop shadows

## Testing
- `npm run lint` *(fails: react warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865c43aaf288323938217d853dd251f