### PR TITLE
Update right-click menu UI

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
-  Plus,
   Scissors,
   Copy,
   ClipboardPaste,
@@ -11,17 +10,22 @@ import {
   Trash2,
   Crop,
   Lock,
+  Layers,
+  ChevronRight,
 } from 'lucide-react';
+import { AlignToPageVertical } from './toolbar/AlignToPage';
 
 export type MenuAction =
-  | 'add'
   | 'cut'
   | 'copy'
   | 'paste'
   | 'duplicate'
-  | 'delete'
+  | 'bringForward'
+  | 'sendBackward'
+  | 'lock'
+  | 'align'
   | 'crop'
-  | 'lock';
+  | 'delete';
 
 interface Props {
   pos: { x: number; y: number };
@@ -42,31 +46,60 @@ export default function ContextMenu({ pos, locked, onAction, onClose }: Props) {
     };
   }, [onClose]);
 
-  const Item = ({ Icon, label, action }: { Icon: any; label: string; action: MenuAction }) => (
+  const [showLayer, setShowLayer] = useState(false);
+
+  const Item = (
+    { Icon, label, action, onClick }:
+      { Icon: any; label: string; action?: MenuAction; onClick?: () => void },
+  ) => (
     <button
       type="button"
-      onClick={() => onAction(action)}
-      className="flex items-center gap-2 px-3 py-1 text-[--walty-teal] hover:bg-[--walty-orange]/10"
+      onClick={() => (onClick ? onClick() : action && onAction(action))}
+      className="flex items-center gap-2 px-3 py-1 text-[--walty-teal] hover:bg-[--walty-orange]/10 w-full text-left"
     >
       <Icon className="w-4 h-4" />
-      <span className="text-sm">{label}</span>
+      <span className="text-sm flex-1">{label}</span>
     </button>
   );
 
   return createPortal(
     <div
       style={{ top: pos.y, left: pos.x }}
-      className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded shadow-lg pointer-events-auto"
+      className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded-xl shadow-lg pointer-events-auto min-w-[200px]"
     >
       <div className="flex flex-col py-1">
-        <Item Icon={Plus}          label="Add"        action="add" />
+        {/* group 1 */}
         <Item Icon={Scissors}      label="Cut"        action="cut" />
         <Item Icon={Copy}          label="Copy"       action="copy" />
         <Item Icon={ClipboardPaste} label="Paste"      action="paste" />
         <Item Icon={CopyPlus}      label="Duplicate"  action="duplicate" />
-        <Item Icon={Trash2}        label="Delete"     action="delete" />
+
+        <hr className="my-1 border-t border-[rgba(0,91,85,.1)]" />
+
+        {/* group 2 */}
+        <div className="relative">
+          <Item
+            Icon={Layers}
+            label="Layer"
+            onClick={() => setShowLayer(v => !v)}
+          />
+          {showLayer && (
+            <div
+              className="absolute left-full top-0 ml-2 flex flex-col bg-white border border-[rgba(0,91,85,.2)] rounded-xl shadow-lg"
+            >
+              <Item Icon={ChevronRight} label="Bring forward" action="bringForward" />
+              <Item Icon={ChevronRight} label="Send backward" action="sendBackward" />
+              <Item Icon={Lock} label={locked ? 'Unlock' : 'Lock'} action="lock" />
+            </div>
+          )}
+        </div>
+        <Item Icon={AlignToPageVertical} label="Align to Page" action="align" />
+
+        <hr className="my-1 border-t border-[rgba(0,91,85,.1)]" />
+
+        {/* group 3 */}
         <Item Icon={Crop}          label="Crop"       action="crop" />
-        <Item Icon={Lock}          label={locked ? 'Unlock' : 'Lock'} action="lock" />
+        <Item Icon={Trash2}        label="Delete"     action="delete" />
       </div>
     </div>,
     document.body,

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -500,6 +500,9 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
 
   const setPageLayers = useEditor(s => s.setPageLayers)
   const updateLayer   = useEditor(s => s.updateLayer)
+  const reorder       = useEditor(s => s.reorder)
+  const activePage    = useEditor(s => s.activePage)
+  const layerCount    = useEditor(s => s.pages[s.activePage]?.layers.length || 0)
 
   const handleMenuAction = (a: import('./ContextMenu').MenuAction) => {
     const fc = fcRef.current
@@ -566,8 +569,32 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
               fc.setActiveObject(root)
             }
             fc.requestRenderAll()
-            syncLayersFromCanvas(fc, pageIdx)
-          }, '')
+          syncLayersFromCanvas(fc, pageIdx)
+        }, '')
+      }
+        break
+      case 'bringForward':
+        if (active) {
+          const idx = (active as any).layerIdx ?? 0
+          if (idx > 0 && idx <= layerCount - 1) reorder(idx, idx - 1)
+        }
+        break
+      case 'sendBackward':
+        if (active) {
+          const idx = (active as any).layerIdx ?? 0
+          if (idx < layerCount - 1) reorder(idx, idx + 1)
+        }
+        break
+      case 'align':
+        if (active) {
+          const zoom = fc.viewportTransform?.[0] ?? 1
+          const fcH  = (fc.getHeight() ?? 0) / zoom
+          const fcW  = (fc.getWidth()  ?? 0) / zoom
+          const { width, height } = active.getBoundingRect(true, true)
+          active.set({ left: fcW / 2 - width / 2, top: fcH / 2 - height / 2 })
+          active.setCoords()
+          fc.requestRenderAll()
+          syncLayersFromCanvas(fc, pageIdx)
         }
         break
       case 'delete':


### PR DESCRIPTION
## Summary
- widen and restyle the ContextMenu
- add layer submenu and align action
- wire up bring forward, send backward and align handlers

## Testing
- `npm run lint` *(fails: react-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68664c75f3688323b5c9992401116a5f