### PR TITLE
Improve card editor context menu

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -1,36 +1,43 @@
 'use client'
 
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
-  Plus,
   Scissors,
   Copy,
   ClipboardPaste,
   CopyPlus,
   Trash2,
   Crop,
-  Lock,
+  Layers,
+  AlignCenter,
+  ArrowUpToLine,
+  ArrowDownToLine,
+  ChevronsUp,
+  ChevronsDown,
 } from 'lucide-react';
+import Popover from './toolbar/Popover';
 
 export type MenuAction =
-  | 'add'
   | 'cut'
   | 'copy'
   | 'paste'
   | 'duplicate'
+  | 'bring-forward'
+  | 'send-backward'
+  | 'bring-to-front'
+  | 'send-to-back'
+  | 'align'
   | 'delete'
-  | 'crop'
-  | 'lock';
+  | 'crop';
 
 interface Props {
   pos: { x: number; y: number };
-  locked: boolean;
   onAction: (a: MenuAction) => void;
   onClose: () => void;
 }
 
-export default function ContextMenu({ pos, locked, onAction, onClose }: Props) {
+export default function ContextMenu({ pos, onAction, onClose }: Props) {
   useEffect(() => {
     const close = () => onClose();
     const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
@@ -53,20 +60,52 @@ export default function ContextMenu({ pos, locked, onAction, onClose }: Props) {
     </button>
   );
 
+  const Divider = () => (
+    <div className="my-1 h-px bg-[rgba(0,91,85,.15)]" />
+  );
+
+  const [layerOpen, setLayerOpen] = useState(false);
+  const layerRef = useRef<HTMLButtonElement>(null);
+
   return createPortal(
     <div
       style={{ top: pos.y, left: pos.x }}
-      className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded shadow-lg pointer-events-auto"
+      className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded-xl shadow-lg pointer-events-auto min-w-44"
     >
       <div className="flex flex-col py-1">
-        <Item Icon={Plus}          label="Add"        action="add" />
+        {/* group 1 */}
         <Item Icon={Scissors}      label="Cut"        action="cut" />
         <Item Icon={Copy}          label="Copy"       action="copy" />
         <Item Icon={ClipboardPaste} label="Paste"      action="paste" />
         <Item Icon={CopyPlus}      label="Duplicate"  action="duplicate" />
-        <Item Icon={Trash2}        label="Delete"     action="delete" />
+
+        <Divider />
+
+        {/* group 2 */}
+        <div className="relative">
+          <button
+            ref={layerRef}
+            type="button"
+            onClick={() => setLayerOpen(o => !o)}
+            className="flex w-full items-center gap-2 px-3 py-1 text-[--walty-teal] hover:bg-[--walty-orange]/10"
+          >
+            <Layers className="w-4 h-4" />
+            <span className="text-sm">Layer</span>
+          </button>
+          <Popover anchor={layerRef.current} open={layerOpen} onClose={() => setLayerOpen(false)}>
+            <Item Icon={ArrowUpToLine}   label="Bring forward"  action="bring-forward" />
+            <Item Icon={ArrowDownToLine} label="Send backward"  action="send-backward" />
+            <Item Icon={ChevronsUp}     label="Bring to front" action="bring-to-front" />
+            <Item Icon={ChevronsDown}   label="Send to back"   action="send-to-back" />
+          </Popover>
+        </div>
+        <Item Icon={AlignCenter} label="Align to Page" action="align" />
+
+        <Divider />
+
+        {/* group 3 */}
         <Item Icon={Crop}          label="Crop"       action="crop" />
-        <Item Icon={Lock}          label={locked ? 'Unlock' : 'Lock'} action="lock" />
+        <Item Icon={Trash2}        label="Delete"     action="delete" />
       </div>
     </div>,
     document.body,

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -49,14 +49,21 @@ export default function ContextMenu({ pos, onAction, onClose }: Props) {
     };
   }, [onClose]);
 
-  const Item = ({ Icon, label, action }: { Icon: any; label: string; action: MenuAction }) => (
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
+  const Item = ({ Icon, label, action, shortcut }: { Icon: any; label: string; action: MenuAction; shortcut?: string }) => (
     <button
       type="button"
       onClick={() => onAction(action)}
-      className="flex items-center gap-2 px-3 py-1 text-[--walty-teal] hover:bg-[--walty-orange]/10"
+      className="flex items-center gap-2 px-4 py-2 text-[--walty-teal] hover:bg-[--walty-orange]/10"
     >
-      <Icon className="w-4 h-4" />
-      <span className="text-sm">{label}</span>
+      <Icon className="w-5 h-5" />
+      <span className="text-base flex-1 text-left">{label}</span>
+      {shortcut && (
+        <span className="ml-auto text-xs text-gray-500">
+          {isMac ? shortcut.replace('Ctrl', '⌘') : shortcut}
+        </span>
+      )}
     </button>
   );
 
@@ -70,14 +77,14 @@ export default function ContextMenu({ pos, onAction, onClose }: Props) {
   return createPortal(
     <div
       style={{ top: pos.y, left: pos.x }}
-      className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded-xl shadow-lg pointer-events-auto min-w-44"
+      className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded-xl shadow-lg pointer-events-auto min-w-56"
     >
-      <div className="flex flex-col py-1">
+      <div className="flex flex-col py-2">
         {/* group 1 */}
-        <Item Icon={Scissors}      label="Cut"        action="cut" />
-        <Item Icon={Copy}          label="Copy"       action="copy" />
-        <Item Icon={ClipboardPaste} label="Paste"      action="paste" />
-        <Item Icon={CopyPlus}      label="Duplicate"  action="duplicate" />
+        <Item Icon={Scissors}      label="Cut"        action="cut"       shortcut="Ctrl+X" />
+        <Item Icon={Copy}          label="Copy"       action="copy"      shortcut="Ctrl+C" />
+        <Item Icon={ClipboardPaste} label="Paste"      action="paste"     shortcut="Ctrl+V" />
+        <Item Icon={CopyPlus}      label="Duplicate"  action="duplicate" shortcut="Ctrl+D" />
 
         <Divider />
 
@@ -87,10 +94,10 @@ export default function ContextMenu({ pos, onAction, onClose }: Props) {
             ref={layerRef}
             type="button"
             onClick={() => setLayerOpen(o => !o)}
-            className="flex w-full items-center gap-2 px-3 py-1 text-[--walty-teal] hover:bg-[--walty-orange]/10"
+            className="flex w-full items-center gap-2 px-4 py-2 text-[--walty-teal] hover:bg-[--walty-orange]/10"
           >
-            <Layers className="w-4 h-4" />
-            <span className="text-sm">Layer</span>
+            <Layers className="w-5 h-5" />
+            <span className="text-base">Layer</span>
           </button>
           <Popover anchor={layerRef.current} open={layerOpen} onClose={() => setLayerOpen(false)}>
             <Item Icon={ArrowUpToLine}   label="Bring forward"  action="bring-forward" />
@@ -105,7 +112,7 @@ export default function ContextMenu({ pos, onAction, onClose }: Props) {
 
         {/* group 3 */}
         <Item Icon={Crop}          label="Crop"       action="crop" />
-        <Item Icon={Trash2}        label="Delete"     action="delete" />
+        <Item Icon={Trash2}        label="Delete"     action="delete"     shortcut="Del" />
       </div>
     </div>,
     document.body,

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -506,9 +506,6 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
     if (!fc) return
     const active = fc.getActiveObject() as fabric.Object | undefined
     switch (a) {
-      case 'add':
-        useEditor.getState().addText()
-        break
       case 'cut':
         if (active) {
           clip.json = [active.toJSON(PROPS)]
@@ -570,6 +567,46 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
           }, '')
         }
         break
+      case 'bring-forward':
+        if (active) {
+          fc.bringForward(active)
+          fc.requestRenderAll()
+          syncLayersFromCanvas(fc, pageIdx)
+        }
+        break
+      case 'send-backward':
+        if (active) {
+          fc.sendBackwards(active)
+          fc.requestRenderAll()
+          syncLayersFromCanvas(fc, pageIdx)
+        }
+        break
+      case 'bring-to-front':
+        if (active) {
+          fc.bringToFront(active)
+          fc.requestRenderAll()
+          syncLayersFromCanvas(fc, pageIdx)
+        }
+        break
+      case 'send-to-back':
+        if (active) {
+          fc.sendToBack(active)
+          fc.requestRenderAll()
+          syncLayersFromCanvas(fc, pageIdx)
+        }
+        break
+      case 'align':
+        if (active) {
+          const zoom = fc.viewportTransform?.[0] ?? 1
+          const fcH = (fc.getHeight() ?? 0) / zoom
+          const fcW = (fc.getWidth()  ?? 0) / zoom
+          const { width, height } = active.getBoundingRect(true, true)
+          active.set({ left: fcW / 2 - width / 2, top: fcH / 2 - height / 2 })
+          active.setCoords()
+          fc.requestRenderAll()
+          syncLayersFromCanvas(fc, pageIdx)
+        }
+        break
       case 'delete':
         if (active) {
           allObjs(active).forEach(o => fc.remove(o))
@@ -578,21 +615,6 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
         break
       case 'crop':
         document.dispatchEvent(new Event('start-crop'))
-        break
-      case 'lock':
-        if (active) {
-          const next = !(active as any).locked
-          ;(active as any).locked = next
-          active.set({
-            lockMovementX: next,
-            lockMovementY: next,
-            lockScalingX : next,
-            lockScalingY : next,
-            lockRotation : next,
-          })
-          fc.requestRenderAll()
-          updateLayer(pageIdx, (active as any).layerIdx, { locked: next })
-        }
         break
     }
     setMenuPos(null)
@@ -1644,7 +1666,6 @@ doSync = () =>
       {menuPos && (
         <ContextMenu
           pos={menuPos}
-          locked={!!(fcRef.current?.getActiveObject() as any)?.locked}
           onAction={handleMenuAction}
           onClose={() => setMenuPos(null)}
         />

--- a/app/components/toolbar/Popover.tsx
+++ b/app/components/toolbar/Popover.tsx
@@ -53,7 +53,7 @@ export default function Popover({ anchor, open, onClose, children }: Props) {
     <div
       ref={ref}
       style={style}
-      className="min-w-40 rounded-xl bg-white
+      className="min-w-48 rounded-xl bg-white
                  px-3 py-2 shadow-lg ring-1 ring-walty-brown/15
                  animate-pop"
     >


### PR DESCRIPTION
## Summary
- restyle card editor context menu with wider rounded layout
- organize actions into groups
- add layer submenu with ordering controls
- support align to page action in canvas

## Testing
- `npm run lint` *(fails: React Hooks and other errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68664c75f3688323b5c9992401116a5f