### PR TITLE
Fix overlay handle centering

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,6 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
+const SEL_BORDER = 2
 
 recompute()
 
@@ -624,7 +625,7 @@ useEffect(() => {
   (selEl as any)._object = null;
 
   const cropEl = document.createElement('div');
-  cropEl.className = 'sel-overlay interactive';
+  cropEl.className = 'sel-overlay crop interactive';
   cropEl.style.display = 'none';
   document.body.appendChild(cropEl);
   cropDomRef.current = cropEl;
@@ -1035,16 +1036,21 @@ const drawOverlay = (
   el._object = obj
   if (el._handles) {
     const h = el._handles
-    const midX = width / 2
-    const midY = height / 2
-    h.tl.style.left = '0px';      h.tl.style.top = '0px'
-    h.tr.style.left = `${width}px`; h.tr.style.top = '0px'
-    h.br.style.left = `${width}px`; h.br.style.top = `${height}px`
-    h.bl.style.left = '0px';      h.bl.style.top = `${height}px`
-    h.ml.style.left = '0px';      h.ml.style.top = `${midY}px`
-    h.mr.style.left = `${width}px`; h.mr.style.top = `${midY}px`
-    h.mt.style.left = `${midX}px`; h.mt.style.top = '0px'
-    h.mb.style.left = `${midX}px`; h.mb.style.top = `${height}px`
+    const half  = SEL_BORDER / 2
+    const midX  = Math.round(width  / 2)
+    const midY  = Math.round(height / 2)
+    const leftX = Math.round(half)
+    const rightX = Math.round(width - half)
+    const topY   = Math.round(half)
+    const botY   = Math.round(height - half)
+    h.tl.style.left = `${leftX}px`;  h.tl.style.top = `${topY}px`
+    h.tr.style.left = `${rightX}px`; h.tr.style.top = `${topY}px`
+    h.br.style.left = `${rightX}px`; h.br.style.top = `${botY}px`
+    h.bl.style.left = `${leftX}px`;  h.bl.style.top = `${botY}px`
+    h.ml.style.left = `${leftX}px`;  h.ml.style.top = `${midY}px`
+    h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
+    h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
+    h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
   }
 }
 
@@ -1078,6 +1084,10 @@ const syncSel = () => {
         cropEl._object = frame
       }
     }
+    if (selEl._handles)
+      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+    if (cropEl && cropEl._handles)
+      ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
     return
   }
@@ -1086,6 +1096,8 @@ const syncSel = () => {
   if (!obj) return
   drawOverlay(obj, selEl)
   selEl._object = obj
+  if (selEl._handles)
+    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,25 +103,33 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:2px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;
-    width:8px;
-    height:8px;
+    box-sizing:border-box;
+    width:16px;
+    height:16px;
     background:#fff;
-    border:1px solid #2EC4B6;
+    border:1px solid rgba(128,128,128,0.5);
     border-radius:50%;
+    box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform:translate(-50%,-50%);
     pointer-events:auto;
   }
   .sel-overlay .handle.side {
-    width:4px;
-    height:12px;
-    border-radius:2px;
+    width:7px;
+    height:21px;
+    border-radius:3px;
+  }
+  .sel-overlay .handle.mt,
+  .sel-overlay .handle.mb {
+    width:21px;
+    height:7px;
+    border-radius:3px;
   }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
@@ -131,4 +139,27 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+
+  .sel-overlay.crop .handle {
+    background:#fff;
+    border:none;
+    border-radius:0;
+    box-shadow:0 1px 2px rgba(0,0,0,0.25);
+  }
+  .sel-overlay.crop .handle.tl {
+    border-top:1px solid rgba(128,128,128,0.5);
+    border-left:1px solid rgba(128,128,128,0.5);
+  }
+  .sel-overlay.crop .handle.tr {
+    border-top:1px solid rgba(128,128,128,0.5);
+    border-right:1px solid rgba(128,128,128,0.5);
+  }
+  .sel-overlay.crop .handle.br {
+    border-bottom:1px solid rgba(128,128,128,0.5);
+    border-right:1px solid rgba(128,128,128,0.5);
+  }
+  .sel-overlay.crop .handle.bl {
+    border-bottom:1px solid rgba(128,128,128,0.5);
+    border-left:1px solid rgba(128,128,128,0.5);
+  }
 }


### PR DESCRIPTION
## Summary
- round overlay handle positions to avoid subpixel offsets
- ensure handle dimensions include border for accurate transforms
- show crop handles as L-shaped corners instead of circles

## Testing
- `npm run lint` *(fails: React hook rule errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865c43aaf288323938217d853dd251f