### PR TITLE
Fix overlay handle centering

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,6 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
+const SEL_BORDER = 2
 
 recompute()
 
@@ -634,7 +635,7 @@ useEffect(() => {
   const handleMap: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : ''} ${c}`;
+    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c;
     selEl.appendChild(h);
     handleMap[c] = h;
@@ -644,7 +645,7 @@ useEffect(() => {
   const cropHandles: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : ''} ${c}`;
+    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c;
     cropEl.appendChild(h);
     cropHandles[c] = h;
@@ -1035,16 +1036,21 @@ const drawOverlay = (
   el._object = obj
   if (el._handles) {
     const h = el._handles
-    const midX = width / 2
-    const midY = height / 2
-    h.tl.style.left = '0px';      h.tl.style.top = '0px'
-    h.tr.style.left = `${width}px`; h.tr.style.top = '0px'
-    h.br.style.left = `${width}px`; h.br.style.top = `${height}px`
-    h.bl.style.left = '0px';      h.bl.style.top = `${height}px`
-    h.ml.style.left = '0px';      h.ml.style.top = `${midY}px`
-    h.mr.style.left = `${width}px`; h.mr.style.top = `${midY}px`
-    h.mt.style.left = `${midX}px`; h.mt.style.top = '0px'
-    h.mb.style.left = `${midX}px`; h.mb.style.top = `${height}px`
+    const half  = SEL_BORDER / 2
+    const midX  = Math.round(width  / 2)
+    const midY  = Math.round(height / 2)
+    const leftX = Math.round(half)
+    const rightX = Math.round(width - half)
+    const topY   = Math.round(half)
+    const botY   = Math.round(height - half)
+    h.tl.style.left = `${leftX}px`;  h.tl.style.top = `${topY}px`
+    h.tr.style.left = `${rightX}px`; h.tr.style.top = `${topY}px`
+    h.br.style.left = `${rightX}px`; h.br.style.top = `${botY}px`
+    h.bl.style.left = `${leftX}px`;  h.bl.style.top = `${botY}px`
+    h.ml.style.left = `${leftX}px`;  h.ml.style.top = `${midY}px`
+    h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
+    h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
+    h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
   }
 }
 
@@ -1064,28 +1070,41 @@ const syncSel = () => {
     if (obj === frame) {
       drawOverlay(frame, selEl)
       selEl._object = frame
+      selEl.classList.add('crop-window')
       if (cropEl) {
         cropEl.style.display = 'block'
         drawOverlay(img, cropEl)
         cropEl._object = img
+        cropEl.classList.remove('crop-window')
       }
     } else {
       drawOverlay(img, selEl)
       selEl._object = img
+      selEl.classList.remove('crop-window')
       if (cropEl) {
         cropEl.style.display = 'block'
         drawOverlay(frame, cropEl)
         cropEl._object = frame
+        cropEl.classList.add('crop-window')
       }
     }
+    if (selEl._handles)
+      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+    if (cropEl && cropEl._handles)
+      ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
     return
   }
+
+  selEl.classList.remove('crop-window')
+  cropEl && cropEl.classList.remove('crop-window')
 
   cropEl && (cropEl.style.display = 'none', cropEl._object = null)
   if (!obj) return
   drawOverlay(obj, selEl)
   selEl._object = obj
+  if (selEl._handles)
+    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,25 +103,33 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:1px dashed #2EC4B6; /* SEL_COLOR */
+    border:2px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;
-    width:8px;
-    height:8px;
+    box-sizing:border-box;
+    width:16px;
+    height:16px;
     background:#fff;
-    border:1px solid #2EC4B6;
+    border:1px solid rgba(128,128,128,0.5);
     border-radius:50%;
+    box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform:translate(-50%,-50%);
     pointer-events:auto;
   }
   .sel-overlay .handle.side {
-    width:4px;
-    height:12px;
-    border-radius:2px;
+    width:7px;
+    height:21px;
+    border-radius:3px;
+  }
+  .sel-overlay .handle.mt,
+  .sel-overlay .handle.mb {
+    width:21px;
+    height:7px;
+    border-radius:3px;
   }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
@@ -131,4 +139,38 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+
+  /* crop window corner "L" handles */
+  .sel-overlay.crop-window .handle.corner {
+    width:16px;
+    height:16px;
+    background:none;
+    border:none;
+    border-radius:0;
+    box-shadow:none;
+  }
+  .sel-overlay.crop-window .handle.corner::before,
+  .sel-overlay.crop-window .handle.corner::after {
+    content:'';
+    position:absolute;
+    box-sizing:border-box;
+    background:#fff;
+    border:1px solid rgba(128,128,128,0.5);
+    box-shadow:0 1px 2px rgba(0,0,0,0.25);
+  }
+  .sel-overlay.crop-window .handle.corner::before {
+    width:4px;
+    height:16px;
+    left:0;
+    top:0;
+  }
+  .sel-overlay.crop-window .handle.corner::after {
+    width:16px;
+    height:4px;
+    left:0;
+    top:0;
+  }
+  .sel-overlay.crop-window .handle.tr { transform:translate(-50%,-50%) rotate(90deg); }
+  .sel-overlay.crop-window .handle.br { transform:translate(-50%,-50%) rotate(180deg); }
+  .sel-overlay.crop-window .handle.bl { transform:translate(-50%,-50%) rotate(270deg); }
 }


### PR DESCRIPTION
## Summary
- round overlay handle positions to avoid subpixel offsets
- ensure handle dimensions include border for accurate transforms
- add corner class to overlay handles
- add crop-window class switching so the crop frame shows "L" shaped handles
- style crop window with rotated L handles

## Testing
- `npm run lint` *(fails: React hook rule errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865c43aaf288323938217d853dd251f