### PR TITLE
Use native L corner handles for crop window

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1036,13 +1036,12 @@ const drawOverlay = (
   el._object = obj
   if (el._handles) {
     const h = el._handles
-    const half  = SEL_BORDER / 2
     const midX  = Math.round(width  / 2)
     const midY  = Math.round(height / 2)
-    const leftX = Math.round(half)
-    const rightX = Math.round(width - half)
-    const topY   = Math.round(half)
-    const botY   = Math.round(height - half)
+    const leftX = 0
+    const rightX = Math.round(width)
+    const topY   = 0
+    const botY   = Math.round(height)
     h.tl.style.left = `${leftX}px`;  h.tl.style.top = `${topY}px`
     h.tr.style.left = `${rightX}px`; h.tr.style.top = `${topY}px`
     h.br.style.left = `${rightX}px`; h.br.style.top = `${botY}px`

--- a/app/globals.css
+++ b/app/globals.css
@@ -142,34 +142,13 @@ html {
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {
-    width:20px;
-    height:20px;
-    background:none;
+    width:16px;
+    height:16px;
+    background:#fff;
     border:none;
     border-radius:0;
-    box-shadow:none;
-  }
-  .sel-overlay.crop-window .handle.corner::before,
-  .sel-overlay.crop-window .handle.corner::after {
-    content:'';
-    position:absolute;
-    box-sizing:border-box;
-    background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
-    border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
-  }
-  .sel-overlay.crop-window .handle.corner::before {
-    width:6px;
-    height:20px;
-    left:0;
-    top:0;
-  }
-  .sel-overlay.crop-window .handle.corner::after {
-    width:20px;
-    height:6px;
-    left:0;
-    top:0;
+    clip-path:polygon(0 0,100% 0,100% 2px,2px 2px,2px 100%,0 100%);
   }
   .sel-overlay.crop-window .handle.tr { transform:translate(-50%,-50%) rotate(90deg); }
   .sel-overlay.crop-window .handle.br { transform:translate(-50%,-50%) rotate(180deg); }


### PR DESCRIPTION
## Summary
- simplify crop handle CSS and reduce thickness
- align crop window corner handles with the outline

## Testing
- `npm run lint` *(fails: React hook violations)*
- `npm run build` *(fails: React hook violations)*


------
https://chatgpt.com/codex/tasks/task_e_68665b4e344483238c32a3762ca5fbb9