### PR TITLE
Improve crop handles and outline appearance

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,7 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const SEL_BORDER = 2
+const SEL_BORDER = 4
 
 recompute()
 
@@ -1002,7 +1002,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,
@@ -1064,9 +1064,12 @@ const syncSel = () => {
   if (croppingRef.current && tool?.isActive && tool.img && tool.frame) {
     const img   = tool.img as fabric.Object
     const frame = tool.frame as fabric.Object
-    // whichever is active uses selEl; the other uses cropEl
+    // whichever object isn't active should stay on top so its handles remain
+    // accessible without an extra click
+    // keep the inactive overlay above the active one so its handles remain
+    // clickable without changing focus first
     selEl.style.zIndex = '41'
-    cropEl && (cropEl.style.zIndex = '40')
+    cropEl && (cropEl.style.zIndex = '42')
     if (obj === frame) {
       drawOverlay(frame, selEl)
       selEl._object = frame

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,7 +59,7 @@ html {
     pointer-events: none;
 
     /* thin dashed outline */
-    outline: 1px dashed #7c3aed;
+    outline: 2px dashed #7c3aed;
     outline-offset: -1px;
 
     border: 0;
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:4px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -114,7 +114,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:50%;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform:translate(-50%,-50%);
@@ -145,7 +145,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform-origin:4px 4px;


### PR DESCRIPTION
## Summary
- keep inactive crop overlay on top so handles are easier to grab
- increase selection border constant
- double overlay borders and handle outlines
- thicken AI ghost outline
- widen hover highlight stroke

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68666cc41cfc8323a105e562a308f268