### PR TITLE
Fix crop handle usability

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,7 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const SEL_BORDER = 2
+const SEL_BORDER = 4
 
 recompute()
 
@@ -700,12 +700,26 @@ useEffect(() => {
     e.preventDefault()
   }
   const onSelDown = (e: PointerEvent) => {
-    const obj = (selEl as any)._object as fabric.Object | null
+    let obj = (selEl as any)._object as fabric.Object | null
+    if (croppingRef.current && cropDomRef.current) {
+      selEl.style.pointerEvents = 'none'
+      const under = document.elementFromPoint(e.clientX, e.clientY)
+      selEl.style.pointerEvents = 'auto'
+      if (under && cropDomRef.current.contains(under))
+        obj = (cropDomRef.current as any)._object as fabric.Object | null
+    }
     if (obj) fc.setActiveObject(obj)
     bridge(e)
   }
   const onCropDown = (e: PointerEvent) => {
-    const obj = (cropEl as any)._object as fabric.Object | null
+    let obj = (cropEl as any)._object as fabric.Object | null
+    if (croppingRef.current && selDomRef.current) {
+      cropEl.style.pointerEvents = 'none'
+      const under = document.elementFromPoint(e.clientX, e.clientY)
+      cropEl.style.pointerEvents = 'auto'
+      if (under && selDomRef.current.contains(under))
+        obj = (selDomRef.current as any)._object as fabric.Object | null
+    }
     if (obj) fc.setActiveObject(obj)
     bridge(e)
   }
@@ -1002,7 +1016,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,8 +59,8 @@ html {
     pointer-events: none;
 
     /* thin dashed outline */
-    outline: 1px dashed #7c3aed;
-    outline-offset: -1px;
+    outline: 2px dashed #7c3aed;
+    outline-offset: -2px;
 
     border: 0;
     background: transparent !important;
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:4px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -114,7 +114,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:50%;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform:translate(-50%,-50%);
@@ -145,7 +145,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform-origin:4px 4px;

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -221,7 +221,7 @@ export class CropTool {
       ctx.save();
       ctx.translate(left, top);
       ctx.rotate(rot);
-      ctx.lineWidth   = 0.5 / this.SCALE;
+      ctx.lineWidth   = 1 / this.SCALE;
       ctx.strokeStyle = '#ffffff';
       ctx.shadowColor = 'rgba(0,0,0,0.35)';          // subtle outline
       ctx.shadowBlur  = 3 / this.SCALE;


### PR DESCRIPTION
## Summary
- make crop handles usable even when image overlay is on top
- double element outline width

## Testing
- `npm run lint` *(fails: react-hooks lint errors)*
- `npm run build` *(fails: compile errors from ESLint rules)*


------
https://chatgpt.com/codex/tasks/task_e_68666cc41cfc8323a105e562a308f268