### PR TITLE
Improve crop overlay usability

### DIFF
--- a/app/components/CardStage.tsx
+++ b/app/components/CardStage.tsx
@@ -203,7 +203,7 @@ export default function CardStage({
               height: undefined,
             }}
             stroke="deepskyblue"
-            strokeWidth={2}
+            strokeWidth={4}
             listening={false}
           />
           <Transformer

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1002,7 +1002,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,
@@ -1064,10 +1064,10 @@ const syncSel = () => {
   if (croppingRef.current && tool?.isActive && tool.img && tool.frame) {
     const img   = tool.img as fabric.Object
     const frame = tool.frame as fabric.Object
-    // whichever is active uses selEl; the other uses cropEl
-    selEl.style.zIndex = '41'
-    cropEl && (cropEl.style.zIndex = '40')
     if (obj === frame) {
+      // when the crop frame is active keep its overlay on top
+      selEl.style.zIndex = '41'
+      cropEl && (cropEl.style.zIndex = '40')
       drawOverlay(frame, selEl)
       selEl._object = frame
       selEl.classList.add('crop-window')
@@ -1078,6 +1078,9 @@ const syncSel = () => {
         cropEl.classList.remove('crop-window')
       }
     } else {
+      // when the photo is active raise the crop window overlay
+      selEl.style.zIndex = '40'
+      cropEl && (cropEl.style.zIndex = '41')
       drawOverlay(img, selEl)
       selEl._object = img
       selEl.classList.remove('crop-window')

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,8 +59,8 @@ html {
     pointer-events: none;
 
     /* thin dashed outline */
-    outline: 1px dashed #7c3aed;
-    outline-offset: -1px;
+    outline: 2px dashed #7c3aed;
+    outline-offset: -2px;
 
     border: 0;
     background: transparent !important;
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:4px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -114,7 +114,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:50%;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform:translate(-50%,-50%);
@@ -145,7 +145,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform-origin:4px 4px;


### PR DESCRIPTION
## Summary
- tweak z-index logic for crop window vs active photo so handles stay accessible
- double outline thickness for selection overlays and ghost elements
- update hover outline and Konva preview to match thicker outlines

## Testing
- `npm run lint` *(fails: React hooks warnings and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68666cc41cfc8323a105e562a308f268