### PR TITLE
Improve crop handles and outline visibility

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -726,13 +726,13 @@ useEffect(() => {
 
   const raiseSel = () => {
     if (!croppingRef.current || !cropDomRef.current) return
-    selEl.style.zIndex = '41'
-    cropDomRef.current.style.zIndex = '40'
+    selEl.style.zIndex = '42'
+    cropDomRef.current.style.zIndex = '41'
   }
   const raiseCrop = () => {
     if (!croppingRef.current || !cropDomRef.current) return
-    cropDomRef.current.style.zIndex = '41'
-    selEl.style.zIndex = '40'
+    cropDomRef.current.style.zIndex = '42'
+    selEl.style.zIndex = '41'
   }
   selEl.addEventListener('pointerenter', raiseSel)
   cropEl.addEventListener('pointerenter', raiseCrop)
@@ -1002,7 +1002,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,
@@ -1064,9 +1064,9 @@ const syncSel = () => {
   if (croppingRef.current && tool?.isActive && tool.img && tool.frame) {
     const img   = tool.img as fabric.Object
     const frame = tool.frame as fabric.Object
-    // whichever is active uses selEl; the other uses cropEl
-    selEl.style.zIndex = '41'
-    cropEl && (cropEl.style.zIndex = '40')
+    // non-active overlay stays on top for easier access
+    selEl.style.zIndex = '40'
+    cropEl && (cropEl.style.zIndex = '41')
     if (obj === frame) {
       drawOverlay(frame, selEl)
       selEl._object = frame

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,8 +59,8 @@ html {
     pointer-events: none;
 
     /* thin dashed outline */
-    outline: 1px dashed #7c3aed;
-    outline-offset: -1px;
+    outline: 2px dashed #7c3aed;
+    outline-offset: -2px;
 
     border: 0;
     background: transparent !important;
@@ -103,10 +103,10 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:4px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
-    @apply pointer-events-auto;
+    pointer-events:none;
   }
   .sel-overlay .handle {
     position:absolute;
@@ -114,7 +114,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:50%;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform:translate(-50%,-50%);
@@ -145,7 +145,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform-origin:4px 4px;

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -187,7 +187,7 @@ export class CropTool {
     const fw =  width    * (img.scaleX ?? 1)
     const fh =  height   * (img.scaleY ?? 1)
 
-    const grid = { stroke:'#ffffff22', strokeWidth:1/this.SCALE,
+    const grid = { stroke:'#ffffff22', strokeWidth:2/this.SCALE,
                    selectable:false, evented:false }
 
     this.frame = new fabric.Group([
@@ -221,7 +221,7 @@ export class CropTool {
       ctx.save();
       ctx.translate(left, top);
       ctx.rotate(rot);
-      ctx.lineWidth   = 0.5 / this.SCALE;
+      ctx.lineWidth   = 1 / this.SCALE;
       ctx.strokeStyle = '#ffffff';
       ctx.shadowColor = 'rgba(0,0,0,0.35)';          // subtle outline
       ctx.shadowBlur  = 3 / this.SCALE;


### PR DESCRIPTION
## Summary
- make crop handles easier to grab by keeping the crop overlay above the active image
- allow canvas events to pass through overlay backgrounds and thicken all selection outlines

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68666cc41cfc8323a105e562a308f268