### PR TITLE
Improve crop handle usability and thicker outlines

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,7 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const SEL_BORDER = 2
+const SEL_BORDER = 4
 
 recompute()
 
@@ -1002,7 +1002,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,
@@ -1066,7 +1066,7 @@ const syncSel = () => {
     const frame = tool.frame as fabric.Object
     // whichever is active uses selEl; the other uses cropEl
     selEl.style.zIndex = '41'
-    cropEl && (cropEl.style.zIndex = '40')
+    cropEl && (cropEl.style.zIndex = '41')
     if (obj === frame) {
       drawOverlay(frame, selEl)
       selEl._object = frame

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,8 +59,8 @@ html {
     pointer-events: none;
 
     /* thin dashed outline */
-    outline: 1px dashed #7c3aed;
-    outline-offset: -1px;
+    outline: 2px dashed #7c3aed;
+    outline-offset: -2px;
 
     border: 0;
     background: transparent !important;
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:4px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;


### PR DESCRIPTION
## Summary
- make crop window handles accessible by keeping crop overlay on top
- double border thickness for all UI outlines

## Testing
- `npm run lint` *(fails: React hooks issues)*

------
https://chatgpt.com/codex/tasks/task_e_68669f0f92988323953989390b601765