### PR TITLE
Improve crop usability and thicker outlines

### DIFF
--- a/app/components/CardStage.tsx
+++ b/app/components/CardStage.tsx
@@ -203,7 +203,7 @@ export default function CardStage({
               height: undefined,
             }}
             stroke="deepskyblue"
-            strokeWidth={2}
+            strokeWidth={4}
             listening={false}
           />
           <Transformer

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -719,8 +719,24 @@ useEffect(() => {
     fc.upperCanvasEl.dispatchEvent(new MouseEvent('dblclick', forwardMouse(e)))
   })
 
-  const relayMove = (ev: PointerEvent) =>
+  const nearCropHandle = (x: number, y: number) => {
+    if (!cropDomRef.current) return false
+    const r = cropDomRef.current.getBoundingClientRect()
+    const m = 12
+    if (x < r.left - m || x > r.right + m || y < r.top - m || y > r.bottom + m)
+      return false
+    return (
+      x <= r.left + m || x >= r.right - m || y <= r.top + m || y >= r.bottom - m
+    )
+  }
+
+  const relayMove = (ev: PointerEvent) => {
+    if (croppingRef.current) {
+      if (nearCropHandle(ev.clientX, ev.clientY)) raiseCrop()
+      else raiseSel()
+    }
     fc.upperCanvasEl.dispatchEvent(new MouseEvent('mousemove', forward(ev)))
+  }
   selEl.addEventListener('pointermove', relayMove)
   cropEl.addEventListener('pointermove', relayMove)
 

--- a/app/components/SelfieDrawer.tsx
+++ b/app/components/SelfieDrawer.tsx
@@ -365,7 +365,7 @@ const PickerPlaceholder = () => (
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeWidth={2}
+        strokeWidth={4}
         d="M3 7h3l2-3h6l2 3h3a2 2 0 012 2v9a2 2 0 01-2 2H3a2 2 0 01-2-2V9a2 2 0 012-2z"
       />
       <circle cx="12" cy="13" r="4" />

--- a/app/components/toolbar/AlignToPage.tsx
+++ b/app/components/toolbar/AlignToPage.tsx
@@ -14,7 +14,7 @@ function SvgBase(
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={2}
+      strokeWidth={4}
       strokeLinecap="round"
       strokeLinejoin="round"
       {...props}

--- a/app/components/toolbar/icons.tsx
+++ b/app/components/toolbar/icons.tsx
@@ -4,7 +4,7 @@ import type { SVGProps } from "react";
 
 /* mirror / flip */
 export const MirrorH = (props: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} fill="none" {...props}>
+  <svg viewBox="0 0 24 24" stroke="currentColor" strokeWidth={4} fill="none" {...props}>
     <path d="M8 5 3 12l5 7" strokeLinecap="round" strokeLinejoin="round" />
     <path d="M16 5l5 7-5 7" strokeLinecap="round" strokeLinejoin="round" />
     <line x1="12" y1="4" x2="12" y2="20" />
@@ -12,7 +12,7 @@ export const MirrorH = (props: SVGProps<SVGSVGElement>) => (
 );
 
 export const MirrorV = (props: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} fill="none" {...props}>
+  <svg viewBox="0 0 24 24" stroke="currentColor" strokeWidth={4} fill="none" {...props}>
     <path d="M5 8 12 3l7 5" strokeLinecap="round" strokeLinejoin="round" />
     <path d="M5 16l7 5 7-5" strokeLinecap="round" strokeLinejoin="round" />
     <line x1="4" y1="12" x2="20" y2="12" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:4px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -114,7 +114,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:50%;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform:translate(-50%,-50%);
@@ -145,7 +145,7 @@ html {
     width:16px;
     height:16px;
     background:#fff;
-    border:1px solid rgba(128,128,128,0.5);
+    border:2px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform-origin:4px 4px;


### PR DESCRIPTION
## Summary
- enhance crop-mode pointer handling so crop handles are easier to grab
- double outline thickness in global styles
- update icon and preview stroke widths

## Testing
- `npm run lint` *(fails: react-hooks rules and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68669f0f92988323953989390b601765