### PR TITLE
Fix crop handles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -142,17 +142,17 @@ html {
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {
-    width:16px;
-    height:16px;
+    width:24px;
+    height:24px;
     background:#fff;
     border:1px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
-    transform-origin:4px 4px;
-    clip-path:polygon(0 0,100% 0,100% 4px,4px 4px,4px 100%,0 100%);
-    transform:translate(-4px,-4px);
+    transform-origin:8px 8px;
+    clip-path:polygon(0 0,100% 0,100% 8px,8px 8px,8px 100%,0 100%);
+    transform:translate(-8px,-8px);
   }
-  .sel-overlay.crop-window .handle.tr { transform:translate(-4px,-4px) rotate(90deg); }
-  .sel-overlay.crop-window .handle.br { transform:translate(-4px,-4px) rotate(180deg); }
-  .sel-overlay.crop-window .handle.bl { transform:translate(-4px,-4px) rotate(270deg); }
+  .sel-overlay.crop-window .handle.tr { transform:translate(-8px,-8px) rotate(90deg); }
+  .sel-overlay.crop-window .handle.br { transform:translate(-8px,-8px) rotate(180deg); }
+  .sel-overlay.crop-window .handle.bl { transform:translate(-8px,-8px) rotate(270deg); }
 }


### PR DESCRIPTION
## Summary
- adjust CSS for crop window handles so they're easier to grab even when the image is active

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866a1a86ec083238914dd184db3f747