### PR TITLE
Improve crop window usability

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,7 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const SEL_BORDER = 2
+const SEL_BORDER = 3
 
 recompute()
 
@@ -1002,7 +1002,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:3px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -142,17 +142,17 @@ html {
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {
-    width:16px;
-    height:16px;
+    width:20px;
+    height:20px;
     background:#fff;
     border:1px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
-    transform-origin:4px 4px;
-    clip-path:polygon(0 0,100% 0,100% 4px,4px 4px,4px 100%,0 100%);
-    transform:translate(-4px,-4px);
+    transform-origin:5px 5px;
+    clip-path:polygon(0 0,100% 0,100% 3px,3px 3px,3px 100%,0 100%);
+    transform:translate(-5px,-5px);
   }
-  .sel-overlay.crop-window .handle.tr { transform:translate(-4px,-4px) rotate(90deg); }
-  .sel-overlay.crop-window .handle.br { transform:translate(-4px,-4px) rotate(180deg); }
-  .sel-overlay.crop-window .handle.bl { transform:translate(-4px,-4px) rotate(270deg); }
+  .sel-overlay.crop-window .handle.tr { transform:translate(-5px,-5px) rotate(90deg); }
+  .sel-overlay.crop-window .handle.br { transform:translate(-5px,-5px) rotate(180deg); }
+  .sel-overlay.crop-window .handle.bl { transform:translate(-5px,-5px) rotate(270deg); }
 }

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -209,7 +209,7 @@ export class CropTool {
     })
     // ---- replace default controls with 4 small white “L” handles ----
     // slightly larger "L" handles for easier grabbing
-    const sizePx = 4 / this.SCALE;
+    const sizePx = 5 / this.SCALE;
 
     /** Draw a single L‑shape, rotated for each corner */
     const drawL = (
@@ -221,7 +221,7 @@ export class CropTool {
       ctx.save();
       ctx.translate(left, top);
       ctx.rotate(rot);
-      ctx.lineWidth   = 0.5 / this.SCALE;
+      ctx.lineWidth   = 0.75 / this.SCALE;
       ctx.strokeStyle = '#ffffff';
       ctx.shadowColor = 'rgba(0,0,0,0.35)';          // subtle outline
       ctx.shadowBlur  = 3 / this.SCALE;
@@ -240,8 +240,8 @@ export class CropTool {
         x, y,
         offsetX: 0, offsetY: 0,
         // enlarge hit‑box for easier grabbing
-        sizeX: 12 / this.SCALE,
-        sizeY: 12 / this.SCALE,
+        sizeX: 20 / this.SCALE,
+        sizeY: 20 / this.SCALE,
         // use Fabric helpers (cast to `any` to silence TS)
         cursorStyleHandler: (fabric as any).controlsUtils.scaleCursorStyleHandler,
         actionHandler     : (fabric as any).controlsUtils.scalingEqually,


### PR DESCRIPTION
## Summary
- make selection borders 3px thick
- enlarge crop handle hit area
- tweak crop L handles to sit flush with the window
- increase hover outline stroke

## Testing
- `npm run lint` *(fails: React hook rules and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6866a44fc74883238cd7d53acd623ca1