### PR TITLE
Improve crop handles and overlay styling

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,7 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const SEL_BORDER = 2
+const SEL_BORDER = 3
 
 recompute()
 
@@ -1002,7 +1002,7 @@ const hoverHL = new fabric.Rect({
   originX:'left', originY:'top', strokeUniform:true,
   fill:'transparent',
   stroke:SEL_COLOR,
-  strokeWidth:1 / SCALE,
+  strokeWidth:2 / SCALE,
   strokeDashArray:[],
   selectable:false, evented:false, visible:false,
   excludeFromExport:true,

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:3px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -150,9 +150,9 @@ html {
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
     transform-origin:4px 4px;
     clip-path:polygon(0 0,100% 0,100% 4px,4px 4px,4px 100%,0 100%);
-    transform:translate(-4px,-4px);
+    transform:translate(-2.5px,-2.5px);
   }
-  .sel-overlay.crop-window .handle.tr { transform:translate(-4px,-4px) rotate(90deg); }
-  .sel-overlay.crop-window .handle.br { transform:translate(-4px,-4px) rotate(180deg); }
-  .sel-overlay.crop-window .handle.bl { transform:translate(-4px,-4px) rotate(270deg); }
+  .sel-overlay.crop-window .handle.tr { transform:translate(-2.5px,-2.5px) rotate(90deg); }
+  .sel-overlay.crop-window .handle.br { transform:translate(-2.5px,-2.5px) rotate(180deg); }
+  .sel-overlay.crop-window .handle.bl { transform:translate(-2.5px,-2.5px) rotate(270deg); }
 }

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -240,8 +240,8 @@ export class CropTool {
         x, y,
         offsetX: 0, offsetY: 0,
         // enlarge hit‑box for easier grabbing
-        sizeX: 12 / this.SCALE,
-        sizeY: 12 / this.SCALE,
+        sizeX: 20 / this.SCALE,
+        sizeY: 20 / this.SCALE,
         // use Fabric helpers (cast to `any` to silence TS)
         cursorStyleHandler: (fabric as any).controlsUtils.scaleCursorStyleHandler,
         actionHandler     : (fabric as any).controlsUtils.scalingEqually,


### PR DESCRIPTION
## Summary
- thicken selection outlines
- adjust crop handle overlay positions
- enlarge crop window handle hit box
- adjust hover outline width

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6866a44fc74883238cd7d53acd623ca1