### PR TITLE
Improve crop window handles

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,7 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const SEL_BORDER = 2
+const SEL_BORDER = 3
 
 recompute()
 
@@ -1036,13 +1036,12 @@ const drawOverlay = (
   el._object = obj
   if (el._handles) {
     const h = el._handles
-    const half  = SEL_BORDER / 2
     const midX  = Math.round(width  / 2)
     const midY  = Math.round(height / 2)
-    const leftX = Math.round(half)
-    const rightX = Math.round(width - half)
-    const topY   = Math.round(half)
-    const botY   = Math.round(height - half)
+    const leftX = 0
+    const rightX = Math.round(width)
+    const topY   = 0
+    const botY   = Math.round(height)
     h.tl.style.left = `${leftX}px`;  h.tl.style.top = `${topY}px`
     h.tr.style.left = `${rightX}px`; h.tr.style.top = `${topY}px`
     h.br.style.left = `${rightX}px`; h.br.style.top = `${botY}px`

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:3px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -142,17 +142,17 @@ html {
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {
-    width:16px;
-    height:16px;
+    width:20px;
+    height:20px;
     background:#fff;
     border:1px solid rgba(128,128,128,0.5);
     border-radius:3px;
     box-shadow:0 1px 2px rgba(0,0,0,0.25);
-    transform-origin:4px 4px;
-    clip-path:polygon(0 0,100% 0,100% 4px,4px 4px,4px 100%,0 100%);
-    transform:translate(-4px,-4px);
+    transform-origin:5px 5px;
+    clip-path:polygon(0 0,100% 0,100% 5px,5px 5px,5px 100%,0 100%);
+    transform:translate(-5px,-5px);
   }
-  .sel-overlay.crop-window .handle.tr { transform:translate(-4px,-4px) rotate(90deg); }
-  .sel-overlay.crop-window .handle.br { transform:translate(-4px,-4px) rotate(180deg); }
-  .sel-overlay.crop-window .handle.bl { transform:translate(-4px,-4px) rotate(270deg); }
+  .sel-overlay.crop-window .handle.tr { transform:translate(-5px,-5px) rotate(90deg); }
+  .sel-overlay.crop-window .handle.br { transform:translate(-5px,-5px) rotate(180deg); }
+  .sel-overlay.crop-window .handle.bl { transform:translate(-5px,-5px) rotate(270deg); }
 }

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -240,8 +240,8 @@ export class CropTool {
         x, y,
         offsetX: 0, offsetY: 0,
         // enlarge hit‑box for easier grabbing
-        sizeX: 12 / this.SCALE,
-        sizeY: 12 / this.SCALE,
+        sizeX: 16 / this.SCALE,
+        sizeY: 16 / this.SCALE,
         // use Fabric helpers (cast to `any` to silence TS)
         cursorStyleHandler: (fabric as any).controlsUtils.scaleCursorStyleHandler,
         actionHandler     : (fabric as any).controlsUtils.scalingEqually,


### PR DESCRIPTION
## Summary
- enlarge crop window handle hit area
- tweak handle CSS to hug crop window
- thicken selection outlines
- adjust DOM overlay handle positions

## Testing
- `npm run lint` *(fails: react-hooks/exhaustive-deps and other pre-existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6866a44fc74883238cd7d53acd623ca1