### PR TITLE
Improve crop window controls

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -114,7 +114,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const SEL_BORDER = 2
+const SEL_BORDER = 3
 
 recompute()
 
@@ -1039,10 +1039,11 @@ const drawOverlay = (
     const half  = SEL_BORDER / 2
     const midX  = Math.round(width  / 2)
     const midY  = Math.round(height / 2)
-    const leftX = Math.round(half)
-    const rightX = Math.round(width - half)
-    const topY   = Math.round(half)
-    const botY   = Math.round(height - half)
+    const crop  = el.classList.contains('crop-window')
+    const leftX = Math.round(crop ? 0      : half)
+    const rightX= Math.round(crop ? width  : width - half)
+    const topY  = Math.round(crop ? 0      : half)
+    const botY  = Math.round(crop ? height : height - half)
     h.tl.style.left = `${leftX}px`;  h.tl.style.top = `${topY}px`
     h.tr.style.left = `${rightX}px`; h.tr.style.top = `${topY}px`
     h.br.style.left = `${rightX}px`; h.br.style.top = `${botY}px`

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,7 +103,7 @@ html {
 @layer utilities {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
-    border:2px solid #2EC4B6; /* SEL_COLOR */
+    border:3px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
     @apply pointer-events-auto;
@@ -142,8 +142,8 @@ html {
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {
-    width:16px;
-    height:16px;
+    width:20px;
+    height:20px;
     background:#fff;
     border:1px solid rgba(128,128,128,0.5);
     border-radius:3px;

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -240,8 +240,8 @@ export class CropTool {
         x, y,
         offsetX: 0, offsetY: 0,
         // enlarge hit‑box for easier grabbing
-        sizeX: 12 / this.SCALE,
-        sizeY: 12 / this.SCALE,
+        sizeX: 20 / this.SCALE,
+        sizeY: 20 / this.SCALE,
         // use Fabric helpers (cast to `any` to silence TS)
         cursorStyleHandler: (fabric as any).controlsUtils.scaleCursorStyleHandler,
         actionHandler     : (fabric as any).controlsUtils.scalingEqually,


### PR DESCRIPTION
## Summary
- make selection overlays thicker
- enlarge crop window handles
- snap crop handle corners to crop window

## Testing
- `npm run build` *(fails: React Hook violations and image warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6866a44fc74883238cd7d53acd623ca1