### PR TITLE
Fix crop window corner handle alignment

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -152,7 +152,7 @@ html {
     clip-path:polygon(0 0,100% 0,100% 4px,4px 4px,4px 100%,0 100%);
     transform:translate(-4px,-4px);
   }
-  .sel-overlay.crop-window .handle.tr { transform:translate(-4px,-4px) rotate(90deg); }
-  .sel-overlay.crop-window .handle.br { transform:translate(-4px,-4px) rotate(180deg); }
-  .sel-overlay.crop-window .handle.bl { transform:translate(-4px,-4px) rotate(270deg); }
+  .sel-overlay.crop-window .handle.tr { transform:rotate(90deg) translate(-4px,-4px); }
+  .sel-overlay.crop-window .handle.br { transform:rotate(180deg) translate(-4px,-4px); }
+  .sel-overlay.crop-window .handle.bl { transform:rotate(270deg) translate(-4px,-4px); }
 }


### PR DESCRIPTION
## Summary
- fix corner handle rotation order so crop handles align with crop window

## Testing
- `npm run lint` *(fails: React hook / display name / unescaped entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866aced1da083239cb16fa4e954853a