### PR TITLE
Add rotation handle for card editor

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -139,6 +139,18 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+  .sel-overlay .handle.rot {
+    cursor: grab;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+  }
+  .sel-overlay .handle.rot svg {
+    width:10px;
+    height:10px;
+    stroke-width:2;
+    pointer-events:none;
+  }
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {


### PR DESCRIPTION
## Summary
- add constant for rotation handle distance in FabricCanvas
- create rotation handle element and icon
- position rotation handle below object
- hide/show rotation handle with others
- style rotation handle in globals.css

## Testing
- `npm run lint`
- `npm run build` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866d1b3c22c8323adcda7c58951bb24