### PR TITLE
Add rotation handle to card editor

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,18 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rot {
+    cursor:grab;
+  }
+  .sel-overlay .handle.rot::after {
+    content: "\21bb";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 10px;
+    color: #555;
+  }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -98,6 +98,13 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
 
+// place rotation handle below the object
+export const ROT_HANDLE_OFFSET = 24;
+const mtr = (fabric.Object.prototype as any).controls.mtr;
+mtr.x = 0;
+mtr.y = 0.5;
+mtr.offsetY = ROT_HANDLE_OFFSET;
+
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {
   (fabric.Object.prototype as any).controls[pos].render =


### PR DESCRIPTION
## Summary
- expose rotation handle offset constant and move built-in `mtr` control below the object
- render an extra `rot` handle for selection overlays
- display a rotate icon on the handle via CSS

## Testing
- `npm run lint` *(fails: React hook errors etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866d1b3c22c8323adcda7c58951bb24