### PR TITLE
Fix context menu overlay interactions

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -47,8 +47,12 @@ interface Props {
 }
 
 export default function ContextMenu({ pos, onAction, onClose }: Props) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
-    const close = () => onClose();
+    const close = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) onClose();
+    };
     const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
     window.addEventListener('mousedown', close);
     window.addEventListener('keydown', esc);
@@ -81,6 +85,7 @@ export default function ContextMenu({ pos, onAction, onClose }: Props) {
 
   return createPortal(
     <div
+      ref={menuRef}
       style={{ top: pos.y, left: pos.x }}
       className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded-xl shadow-lg pointer-events-auto min-w-[14rem]"
     >

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -761,9 +761,13 @@ useEffect(() => {
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    const target = fc.findTarget(e, true) as fabric.Object | null;
+    if (target) fc.setActiveObject(target);
     setMenuPos({ x: e.clientX, y: e.clientY });
   };
   fc.upperCanvasEl.addEventListener('contextmenu', ctxMenu);
+  selEl.addEventListener('contextmenu', ctxMenu);
+  cropEl.addEventListener('contextmenu', ctxMenu);
  
 /* --- keep Fabric’s wrapper the same size as the visible preview --- */
 const container = canvasRef.current!.parentElement as HTMLElement | null;


### PR DESCRIPTION
## Summary
- don't close menu on mousedown inside menu
- right-click always selects target and works even with overlays

## Testing
- `npm run lint` *(fails: React hooks and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866dc271c5c8323a34bced734bc4231