### PR TITLE
Add rotation handle to editor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -631,7 +631,7 @@ useEffect(() => {
   cropDomRef.current = cropEl;
   (cropEl as any)._object = null;
 
-  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const corners = ['tl','tr','br','bl','ml','mr','mt','mb','rot'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
@@ -643,7 +643,7 @@ useEffect(() => {
   (selEl as any)._handles = handleMap;
 
   const cropHandles: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  corners.filter(c => c !== 'rot').forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c;
@@ -683,8 +683,16 @@ useEffect(() => {
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
-    const dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+    let dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
+    let dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+
+    if (corner === 'rot' && selDomRef.current) {
+      const obj  = fc.getActiveObject()
+      const rect = selDomRef.current.getBoundingClientRect()
+      const h = obj ? (obj.getScaledHeight() + PAD * 2) * scale : rect.height
+      const mtrOff = -((obj?.controls?.mtr?.offsetY ?? -40) * scale)
+      dy = -(h + 20 * scale + mtrOff)
+    }
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)
@@ -1018,21 +1026,25 @@ const drawOverlay = (
   obj: fabric.Object,
   el: HTMLDivElement & { _handles?: Record<string, HTMLDivElement>; _object?: fabric.Object | null }
 ) => {
-  const box  = obj.getBoundingRect(true, true)
-  const rect = canvasRef.current!.getBoundingClientRect()
-  const vt   = fc.viewportTransform || [1,0,0,1,0,0]
+  obj.setCoords()
+  const rect  = canvasRef.current!.getBoundingClientRect()
+  const vt    = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
   const scale = vt[0]
-  const c = containerRef.current
-  const scrollX = (c?.scrollLeft ?? 0)
-  const scrollY = (c?.scrollTop  ?? 0)
-  const left   = window.scrollX + scrollX + rect.left + vt[4] + (box.left - PAD) * scale
-  const top    = window.scrollY + scrollY + rect.top  + vt[5] + (box.top - PAD) * scale
-  const width  = (box.width  + PAD * 2) * scale
-  const height = (box.height + PAD * 2) * scale
-  el.style.left   = `${left}px`
-  el.style.top    = `${top}px`
+  const c     = containerRef.current
+  const scrollX = c?.scrollLeft ?? 0
+  const scrollY = c?.scrollTop  ?? 0
+
+  const center = obj.getCenterPoint()
+  const cx = window.scrollX + scrollX + rect.left + vt[4] + center.x * scale
+  const cy = window.scrollY + scrollY + rect.top  + vt[5] + center.y * scale
+
+  const width  = (obj.getScaledWidth()  + PAD * 2) * scale
+  const height = (obj.getScaledHeight() + PAD * 2) * scale
+  el.style.left   = `${cx}px`
+  el.style.top    = `${cy}px`
   el.style.width  = `${width}px`
   el.style.height = `${height}px`
+  el.style.transform = `translate(-50%, -50%) rotate(${obj.angle || 0}deg)`
   el._object = obj
   if (el._handles) {
     const h = el._handles
@@ -1043,6 +1055,7 @@ const drawOverlay = (
     const rightX = Math.round(width - half)
     const topY   = Math.round(half)
     const botY   = Math.round(height - half)
+    const rotY   = Math.round(height + 20 * scale)
     h.tl.style.left = `${leftX}px`;  h.tl.style.top = `${topY}px`
     h.tr.style.left = `${rightX}px`; h.tr.style.top = `${topY}px`
     h.br.style.left = `${rightX}px`; h.br.style.top = `${botY}px`
@@ -1051,6 +1064,7 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.rot) { h.rot.style.left = `${midX}px`; h.rot.style.top = `${rotY}px` }
   }
 }
 
@@ -1089,9 +1103,9 @@ const syncSel = () => {
       }
     }
     if (selEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k].style.display = 'none')
     if (cropEl && cropEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','rot'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
     return
   }
@@ -1104,7 +1118,7 @@ const syncSel = () => {
   drawOverlay(obj, selEl)
   selEl._object = obj
   if (selEl._handles)
-    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
+    ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k].style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,6 +104,7 @@ html {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
     border:2px solid #2EC4B6; /* SEL_COLOR */
+    transform-origin:center;
   }
   .sel-overlay.interactive {
     @apply pointer-events-none;
@@ -130,6 +131,10 @@ html {
     width:21px;
     height:7px;
     border-radius:3px;
+  }
+  .sel-overlay .handle.rot {
+    background:#fff url('/rotate.svg') center/12px 12px no-repeat;
+    cursor:grab;
   }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }

--- a/public/rotate.svg
+++ b/public/rotate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/>
+  <path d="M21 3v5h-5"/>
+</svg>


### PR DESCRIPTION
## Summary
- support new rotation handle overlay on canvas
- style rotation handle with icon
- include rotation icon asset
- fix overlay bounding box rotation so the outline stays fixed around the object

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and others)*


------
https://chatgpt.com/codex/tasks/task_e_6866d9e860a4832384b39e48719e82a7