### PR TITLE
Add rotation handle to editor

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,10 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rot {
+    background:#fff url('/rotate.svg') center/12px 12px no-repeat;
+    cursor:grab;
+  }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,

--- a/public/rotate.svg
+++ b/public/rotate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/>
+  <path d="M21 3v5h-5"/>
+</svg>


### PR DESCRIPTION
## Summary
- support new rotation handle overlay on canvas
- style rotation handle with icon
- include rotation icon asset
- rotate selection outline to match object
- fix rotation handle hit detection
- correct rotation direction when dragging handle and move handle farther from object

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6866d9e860a4832384b39e48719e82a7