### PR TITLE
Add rotation handle to card editor images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,13 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rotate {
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:12px;
+    cursor:grab;
+  }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,


### PR DESCRIPTION
## Summary
- add CSS for rotation handles
- add rotation handle to image selection overlay
- rotate overlay DOM to stay aligned with rotated object

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules, type errors)*
- `npm run lint` *(fails: React Hook errors, lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6866ee9110c48323935570b23db8e9bc