### PR TITLE
Add rotation handle to CardEditor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -115,6 +115,7 @@ let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
 const SEL_BORDER = 2
+const ROT_OFFSET = 30
 
 recompute()
 
@@ -632,11 +633,15 @@ useEffect(() => {
   (cropEl as any)._object = null;
 
   const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const selCorners = [...corners, 'rot'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  selCorners.forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
-    h.dataset.corner = c;
+    h.dataset.corner = c === 'rot' ? 'mtr' : c;
+    if (c === 'rot') {
+      h.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>';
+    }
     selEl.appendChild(h);
     handleMap[c] = h;
   });
@@ -1018,21 +1023,23 @@ const drawOverlay = (
   obj: fabric.Object,
   el: HTMLDivElement & { _handles?: Record<string, HTMLDivElement>; _object?: fabric.Object | null }
 ) => {
-  const box  = obj.getBoundingRect(true, true)
   const rect = canvasRef.current!.getBoundingClientRect()
   const vt   = fc.viewportTransform || [1,0,0,1,0,0]
   const scale = vt[0]
   const c = containerRef.current
   const scrollX = (c?.scrollLeft ?? 0)
   const scrollY = (c?.scrollTop  ?? 0)
-  const left   = window.scrollX + scrollX + rect.left + vt[4] + (box.left - PAD) * scale
-  const top    = window.scrollY + scrollY + rect.top  + vt[5] + (box.top - PAD) * scale
-  const width  = (box.width  + PAD * 2) * scale
-  const height = (box.height + PAD * 2) * scale
+  const center = obj.getCenterPoint()
+  const left   = window.scrollX + scrollX + rect.left + vt[4] + center.x * scale
+  const top    = window.scrollY + scrollY + rect.top  + vt[5] + center.y * scale
+  const width  = obj.getScaledWidth()  * scale
+  const height = obj.getScaledHeight() * scale
   el.style.left   = `${left}px`
   el.style.top    = `${top}px`
   el.style.width  = `${width}px`
   el.style.height = `${height}px`
+  el.style.transform = `translate(-50%,-50%) rotate(${obj.angle || 0}deg)`
+  el.style.transformOrigin = '50% 50%'
   el._object = obj
   if (el._handles) {
     const h = el._handles
@@ -1051,6 +1058,10 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.rot) {
+      h.rot.style.left = `${midX}px`
+      h.rot.style.top  = `${botY + ROT_OFFSET * scale}px`
+    }
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,16 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rot {
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    cursor:grab;
+  }
+  .sel-overlay .handle.rot svg {
+    width:12px;
+    height:12px;
+  }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -97,6 +97,8 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 // rotation handle
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
+(fabric.Object.prototype as any).controls.mtr.y = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = 30;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- update Fabric defaults so rotation control sits below objects
- add rotation handle with icon in selection overlay
- rotate DOM overlays to track object rotation
- style rotation handle icon

## Testing
- `npm run lint` *(fails: Next telemetry message only)*

------
https://chatgpt.com/codex/tasks/task_e_6866ee9110c48323935570b23db8e9bc