### PR TITLE
Add rotation handle to card editor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -631,12 +631,12 @@ useEffect(() => {
   cropDomRef.current = cropEl;
   (cropEl as any)._object = null;
 
-  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const corners = ['tl','tr','br','bl','ml','mr','mt','mb','rot'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
-    h.dataset.corner = c;
+    h.dataset.corner = c === 'rot' ? 'mtr' : c;
     selEl.appendChild(h);
     handleMap[c] = h;
   });
@@ -646,7 +646,7 @@ useEffect(() => {
   corners.forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
-    h.dataset.corner = c;
+    h.dataset.corner = c === 'rot' ? 'mtr' : c;
     cropEl.appendChild(h);
     cropHandles[c] = h;
   });
@@ -1051,6 +1051,11 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.rot) {
+      const rotY = Math.round(botY + 40 * scale)
+      h.rot.style.left = `${midX}px`
+      h.rot.style.top  = `${rotY}px`
+    }
   }
 }
 
@@ -1089,9 +1094,9 @@ const syncSel = () => {
       }
     }
     if (selEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k].style.display = 'none')
     if (cropEl && cropEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','rot'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
     return
   }
@@ -1104,7 +1109,7 @@ const syncSel = () => {
   drawOverlay(obj, selEl)
   selEl._object = obj
   if (selEl._handles)
-    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
+    ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k].style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -125,6 +125,18 @@ html {
     height:21px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rot {
+    cursor:grab;
+  }
+  .sel-overlay .handle.rot::before {
+    content:"\21bb"; /* ↻ */
+    position:absolute;
+    top:50%;
+    left:50%;
+    transform:translate(-50%,-50%);
+    font-size:12px;
+    line-height:1;
+  }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb {
     width:21px;

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -97,6 +97,10 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 // rotation handle
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
+(fabric.Object.prototype as any).controls.mtr.offsetY = 40;
+if ((fabric as any).Textbox) {
+  ((fabric as any).Textbox.prototype as any).controls.mtr.offsetY = 40;
+}
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- style rotation handle and icon
- offset Fabric's rotation handle to the bottom
- create rotation handle DOM elements and position them
- show/hide rotation handle with cropping state

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866ee9110c48323935570b23db8e9bc