### PR TITLE
Add scaling info bubble

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -663,6 +663,12 @@ useEffect(() => {
   });
   (selEl as any)._handles = handleMap;
 
+  const sizeBubble = document.createElement('div');
+  sizeBubble.className = 'size-bubble';
+  sizeBubble.style.display = 'none';
+  selEl.appendChild(sizeBubble);
+  (selEl as any)._sizeBubble = sizeBubble;
+
   const cropHandles: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
@@ -1121,6 +1127,20 @@ const syncHover = () => {
   drawOverlay(obj, hoverDomRef.current as HTMLDivElement & { _object?: fabric.Object | null })
 }
 
+const showSizeBubble = (obj: fabric.Object | undefined) => {
+  if (!obj || !selDomRef.current) return
+  const bubble = (selDomRef.current as any)._sizeBubble as HTMLDivElement | undefined
+  if (!bubble) return
+  bubble.textContent = `w:${Math.round(obj.getScaledWidth())} h:${Math.round(obj.getScaledHeight())}`
+  bubble.style.display = 'block'
+}
+
+const hideSizeBubble = () => {
+  if (!selDomRef.current) return
+  const bubble = (selDomRef.current as any)._sizeBubble as HTMLDivElement | undefined
+  if (bubble) bubble.style.display = 'none'
+}
+
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
@@ -1149,6 +1169,7 @@ fc.on('selection:created', () => {
   }
   selDomRef.current && (selDomRef.current.style.display = 'none')
   cropDomRef.current && (cropDomRef.current.style.display = 'none')
+  hideSizeBubble()
 })
 
 /* also hide hover during any transform of the active object */
@@ -1158,10 +1179,11 @@ const handleAfterRender = () => {
   syncHover()
 }
 
-fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
-  .on('object:scaling',  () => { hoverHL.visible = false; syncSel() })
-  .on('object:scaled',   () => {
+fc.on('object:moving',   () => { hoverHL.visible = false; syncSel(); hideSizeBubble() })
+  .on('object:scaling',  e => { hoverHL.visible = false; syncSel(); showSizeBubble(e.target as fabric.Object) })
+  .on('object:scaled',   e => {
     hoverHL.visible = false
+    hideSizeBubble()
     requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
   .on('object:rotating', () => { hoverHL.visible = false; syncSel() })

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,4 +131,10 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+
+  .size-bubble {
+    @apply absolute text-white text-xs px-1 rounded bg-neutral-800/90 whitespace-nowrap pointer-events-none;
+    bottom:-20px;
+    left:0;
+  }
 }


### PR DESCRIPTION
## Summary
- show object size while scaling in the card editor
- style overlay bubble

## Testing
- `npm run lint --silent` *(fails: React Hook and display-name errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866f01bbb8c8323ba8e16287da30507