### PR TITLE
Add scaling info bubble

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,4 +131,8 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+
+  .size-bubble {
+    @apply absolute text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
+  }
 }


### PR DESCRIPTION
## Summary
- show object size while scaling in the card editor
- style overlay bubble
- follow cursor with size bubble
- pad & round the size bubble

## Testing
- `npm run lint --silent` *(fails: React Hook and display-name errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866f01bbb8c8323ba8e16287da30507