### PR TITLE
Add quick action bar for selections

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -17,6 +17,7 @@ import { SEL_COLOR } from '@/lib/fabricDefaults';
 import { CropTool } from '@/lib/CropTool'
 import { enableSnapGuides } from '@/lib/useSnapGuides'
 import ContextMenu from './ContextMenu'
+import QuickActionBar from './QuickActionBar'
 
 /* ---------- print spec ----------------------------------------- */
 export interface PrintSpec {
@@ -495,6 +496,7 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
   )
 
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null)
+  const [toolPos, setToolPos] = useState<{ x: number; y: number } | null>(null)
 
 
 
@@ -1105,13 +1107,19 @@ const syncSel = () => {
       }
     }
     selEl.style.display = 'block'
+    setToolPos(null)
     return
   }
 
   cropEl && (cropEl.style.display = 'none', cropEl._object = null)
-  if (!obj) return
+  if (!obj) {
+    setToolPos(null)
+    return
+  }
   drawOverlay(obj, selEl)
   selEl._object = obj
+  const rect = selEl.getBoundingClientRect()
+  setToolPos({ x: rect.left + rect.width / 2, y: rect.top })
 }
 
 const syncHover = () => {
@@ -1149,6 +1157,7 @@ fc.on('selection:created', () => {
   }
   selDomRef.current && (selDomRef.current.style.display = 'none')
   cropDomRef.current && (cropDomRef.current.style.display = 'none')
+  setToolPos(null)
 })
 
 /* also hide hover during any transform of the active object */
@@ -1667,6 +1676,13 @@ doSync = () =>
         style={{ width: PREVIEW_W * zoom, height: PREVIEW_H * zoom }}
         className={`border shadow rounded ${className}`}
       />
+      {toolPos && (
+        <QuickActionBar
+          pos={toolPos}
+          onAction={handleMenuAction}
+          onMore={p => setMenuPos(p)}
+        />
+      )}
       {menuPos && (
         <ContextMenu
           pos={menuPos}

--- a/app/components/QuickActionBar.tsx
+++ b/app/components/QuickActionBar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { createPortal } from "react-dom";
+import {
+  Scissors,
+  Copy,
+  CopyPlus,
+  Trash2,
+  Ellipsis,
+} from "lucide-react";
+import IconButton from "./toolbar/IconButton";
+import type { MenuAction } from "./ContextMenu";
+
+interface Props {
+  pos: { x: number; y: number } | null;
+  onAction: (a: MenuAction) => void;
+  onMore: (pos: { x: number; y: number }) => void;
+}
+
+export default function QuickActionBar({ pos, onAction, onMore }: Props) {
+  if (!pos) return null;
+  return createPortal(
+    <div
+      className="fixed z-40 flex items-center gap-1.5 bg-white border border-[rgba(0,91,85,.2)] rounded-full shadow-lg px-2 py-1 pointer-events-auto"
+      style={{ top: pos.y, left: pos.x, transform: "translate(-50%, -100%)" }}
+    >
+      <IconButton size="sm" hideCaption Icon={Scissors} label="Cut" onClick={() => onAction("cut")} />
+      <IconButton size="sm" hideCaption Icon={Copy} label="Copy" onClick={() => onAction("copy")} />
+      <IconButton size="sm" hideCaption Icon={CopyPlus} label="Duplicate" onClick={() => onAction("duplicate")} />
+      <IconButton size="sm" hideCaption Icon={Trash2} label="Delete" onClick={() => onAction("delete")} />
+      <IconButton size="sm" hideCaption Icon={Ellipsis} label="More" onClick={() => onMore(pos)} />
+    </div>,
+    document.body
+  );
+}


### PR DESCRIPTION
## Summary
- add `QuickActionBar` component with icons only
- show the bar when an object is selected on the canvas

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866f5c8a3e08323aa20dadb8307aaec