### PR TITLE
Add selection quick actions

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -17,6 +17,7 @@ import { SEL_COLOR } from '@/lib/fabricDefaults';
 import { CropTool } from '@/lib/CropTool'
 import { enableSnapGuides } from '@/lib/useSnapGuides'
 import ContextMenu from './ContextMenu'
+import QuickActions from './QuickActions'
 
 /* ---------- print spec ----------------------------------------- */
 export interface PrintSpec {
@@ -495,6 +496,7 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
   )
 
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null)
+  const [quickRect, setQuickRect] = useState<DOMRect | null>(null)
 
 
 
@@ -1105,6 +1107,7 @@ const syncSel = () => {
       }
     }
     selEl.style.display = 'block'
+    setQuickRect(null)
     return
   }
 
@@ -1112,6 +1115,7 @@ const syncSel = () => {
   if (!obj) return
   drawOverlay(obj, selEl)
   selEl._object = obj
+  setQuickRect(selEl.getBoundingClientRect())
 }
 
 const syncHover = () => {
@@ -1149,6 +1153,7 @@ fc.on('selection:created', () => {
   }
   selDomRef.current && (selDomRef.current.style.display = 'none')
   cropDomRef.current && (cropDomRef.current.style.display = 'none')
+  setQuickRect(null)
 })
 
 /* also hide hover during any transform of the active object */
@@ -1156,6 +1161,9 @@ const handleAfterRender = () => {
   fc.calcOffset()
   syncSel()
   syncHover()
+  if (selDomRef.current && fc.getActiveObject()) {
+    setQuickRect(selDomRef.current.getBoundingClientRect())
+  }
 }
 
 fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
@@ -1674,6 +1682,11 @@ doSync = () =>
           onClose={() => setMenuPos(null)}
         />
       )}
+      <QuickActions
+        anchor={quickRect}
+        onAction={handleMenuAction}
+        onMore={p => setMenuPos(p)}
+      />
     </>
   )
 }

--- a/app/components/QuickActions.tsx
+++ b/app/components/QuickActions.tsx
@@ -1,0 +1,36 @@
+import { createPortal } from 'react-dom'
+import IconButton from './toolbar/IconButton'
+import { Scissors, Copy, CopyPlus, Trash2, MoreHorizontal } from 'lucide-react'
+import type { MenuAction } from './ContextMenu'
+
+interface Props {
+  anchor: DOMRect | null
+  onAction: (a: MenuAction) => void
+  onMore: (pos: { x: number; y: number }) => void
+}
+
+export default function QuickActions({ anchor, onAction, onMore }: Props) {
+  if (!anchor) return null
+  const style: React.CSSProperties = {
+    position: 'fixed',
+    top: anchor.top - 8,
+    left: anchor.left + anchor.width / 2,
+    transform: 'translate(-50%, -100%)',
+    zIndex: 45,
+  }
+  const openMenu = () =>
+    onMore({ x: anchor.left + anchor.width / 2, y: anchor.bottom })
+  return createPortal(
+    <div
+      style={style}
+      className="pointer-events-auto flex items-center gap-1 rounded-full border border-[rgba(0,91,85,.2)] bg-white px-2 py-1 shadow-lg"
+    >
+      <IconButton Icon={Scissors} label="Cut" onClick={() => onAction('cut')} hideCaption size="sm" />
+      <IconButton Icon={Copy} label="Copy" onClick={() => onAction('copy')} hideCaption size="sm" />
+      <IconButton Icon={CopyPlus} label="Duplicate" onClick={() => onAction('duplicate')} hideCaption size="sm" />
+      <IconButton Icon={Trash2} label="Delete" onClick={() => onAction('delete')} hideCaption size="sm" />
+      <IconButton Icon={MoreHorizontal} label="More" onClick={openMenu} hideCaption size="sm" />
+    </div>,
+    document.body,
+  )
+}


### PR DESCRIPTION
## Summary
- add a QuickActions bar with cut, copy, duplicate, delete and more icons
- show the bar above the selected element in `FabricCanvas`

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, react/no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866f5c8a3e08323aa20dadb8307aaec