### PR TITLE
Fix rotation handle selection

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -106,7 +106,7 @@ html {
     border:2px solid #2EC4B6; /* SEL_COLOR */
   }
   .sel-overlay.interactive {
-    @apply pointer-events-none;
+    @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;
@@ -130,6 +130,16 @@ html {
     width:21px;
     height:7px;
     border-radius:3px;
+  }
+  .sel-overlay .handle.mtr {
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    cursor:grab;
+  }
+  .sel-overlay .handle.mtr svg {
+    width:12px;
+    height:12px;
   }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -97,6 +97,8 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 // rotation handle
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
+(fabric.Object.prototype as any).controls.mtr.y = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = 30;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- use `mtr` corner for rotation handle
- avoid offset when forwarding events from the rotation handle
- style `.handle.mtr` for the rotation icon
- ensure newline at EOF in `fabricDefaults.ts`

## Testing
- `npm run lint` *(fails: various React hook and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866ee9110c48323935570b23db8e9bc