### PR TITLE
Add rotation handle below image

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -632,8 +632,9 @@ useEffect(() => {
   (cropEl as any)._object = null;
 
   const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const selHandles = [...corners, 'rot'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  selHandles.forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c;
@@ -683,8 +684,10 @@ useEffect(() => {
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
-    const dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+    const dx = corner && ['l','r'].some(c=>corner!.includes(c))
+      ? (corner.includes('l') ? offset : -offset) : 0
+    const dy = corner && ['t','b'].some(c=>corner!.includes(c))
+      ? (corner.includes('t') ? offset : -offset) : 0
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)
@@ -1051,6 +1054,11 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.rot) {
+      const ROT = 24
+      h.rot.style.left = `${midX}px`
+      h.rot.style.top  = `${botY + ROT}px`
+    }
   }
 }
 
@@ -1089,7 +1097,7 @@ const syncSel = () => {
       }
     }
     if (selEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k]?.style.display = 'none')
     if (cropEl && cropEl._handles)
       ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
@@ -1104,7 +1112,7 @@ const syncSel = () => {
   drawOverlay(obj, selEl)
   selEl._object = obj
   if (selEl._handles)
-    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
+    ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k]?.style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -140,6 +140,13 @@ html {
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
 
+  /* rotation handle */
+  .sel-overlay .handle.rot {
+    background:url('/icons/rotate.svg') center/14px 14px no-repeat,#fff;
+    cursor:grab;
+  }
+  .sel-overlay .handle.rot:active { cursor:grabbing; }
+
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {
     width:17px;

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -97,6 +97,10 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 // rotation handle
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
+(fabric.Object.prototype as any).controls.mtr.visible = false;
+(fabric.Object.prototype as any).controls.mtr.x = 0;
+(fabric.Object.prototype as any).controls.mtr.y = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = 24;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {

--- a/public/icons/rotate.svg
+++ b/public/icons/rotate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12a9 9 0 1 1-9-9c2.5 0 4.9 1 6.7 2.7L21 8" />
+  <path d="M21 3v5h-5" />
+</svg>


### PR DESCRIPTION
## Summary
- support new rotation handle in `FabricCanvas`
- style rotation handle with icon
- hide built-in Fabric rotation control and reposition it
- include rotation icon asset

## Testing
- `npm run lint` *(fails: multiple warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866fdda32a48323bf5a9ebd8a0ffb87