### PR TITLE
Add rotation handle to card editor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -631,11 +631,12 @@ useEffect(() => {
   cropDomRef.current = cropEl;
   (cropEl as any)._object = null;
 
-  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const corners = ['tl','tr','br','bl','ml','mr','mt','mb','mtr'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
+    const type = ['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner';
+    h.className = `handle ${type} ${c}`;
     h.dataset.corner = c;
     selEl.appendChild(h);
     handleMap[c] = h;
@@ -643,7 +644,7 @@ useEffect(() => {
   (selEl as any)._handles = handleMap;
 
   const cropHandles: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  ['tl','tr','br','bl','ml','mr','mt','mb'].forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c;
@@ -683,8 +684,24 @@ useEffect(() => {
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
-    const dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+    let dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
+    let dy = corner?.includes('t') ? offset :
+             corner?.includes('b') ? -offset : 0
+
+    if (corner === 'mtr') {
+      const obj = (selEl as any)._object as fabric.Object | null
+      const mtr = obj?.oCoords?.mtr
+      if (obj && mtr && canvasRef.current) {
+        const rect = canvasRef.current.getBoundingClientRect()
+        const c = containerRef.current
+        const scrollX = c?.scrollLeft ?? 0
+        const scrollY = c?.scrollTop ?? 0
+        const realX = window.scrollX + scrollX + rect.left + vt[4] + mtr.x * scale
+        const realY = window.scrollY + scrollY + rect.top  + vt[5] + mtr.y * scale
+        dx = realX - e.clientX
+        dy = realY - e.clientY
+      }
+    }
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)
@@ -1025,14 +1042,20 @@ const drawOverlay = (
   const c = containerRef.current
   const scrollX = (c?.scrollLeft ?? 0)
   const scrollY = (c?.scrollTop  ?? 0)
-  const left   = window.scrollX + scrollX + rect.left + vt[4] + (box.left - PAD) * scale
-  const top    = window.scrollY + scrollY + rect.top  + vt[5] + (box.top - PAD) * scale
-  const width  = (box.width  + PAD * 2) * scale
-  const height = (box.height + PAD * 2) * scale
+
+  const center = obj.getCenterPoint()
+  const w = obj.getScaledWidth()
+  const h = obj.getScaledHeight()
+  const left   = window.scrollX + scrollX + rect.left + vt[4] + (center.x - w/2 - PAD) * scale
+  const top    = window.scrollY + scrollY + rect.top  + vt[5] + (center.y - h/2 - PAD) * scale
+  const width  = (w + PAD * 2) * scale
+  const height = (h + PAD * 2) * scale
   el.style.left   = `${left}px`
   el.style.top    = `${top}px`
   el.style.width  = `${width}px`
   el.style.height = `${height}px`
+  el.style.transform = `rotate(${obj.angle || 0}deg)`
+  el.style.transformOrigin = 'center'
   el._object = obj
   if (el._handles) {
     const h = el._handles
@@ -1051,6 +1074,11 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.mtr) {
+      const rotOff = 24; // px
+      h.mtr.style.left = `${midX}px`
+      h.mtr.style.top  = `${botY + rotOff}px`
+    }
   }
 }
 
@@ -1089,7 +1117,7 @@ const syncSel = () => {
       }
     }
     if (selEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','mtr'].forEach(k => selEl._handles![k].style.display = 'none')
     if (cropEl && cropEl._handles)
       ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
@@ -1104,7 +1132,7 @@ const syncSel = () => {
   drawOverlay(obj, selEl)
   selEl._object = obj
   if (selEl._handles)
-    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
+    ['ml','mr','mt','mb','mtr'].forEach(k => selEl._handles![k].style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,11 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.mtr {
+    background:#fff url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNCIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTIgMTBhMTAgMTAgMCAxIDAgMy4xNy03LjM2Ii8+PHBvbHlsaW5lIHBvaW50cz0iMiAyIDIgOCA4IDgiLz48L3N2Zz4=") center/14px 14px no-repeat;
+    cursor:grab;
+  }
+  .sel-overlay .handle.mtr:active { cursor:grabbing; }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,


### PR DESCRIPTION
## Summary
- add a rotation handle to the DOM overlay
- ensure selection outline rotates with elements
- show/hide the new handle when cropping
- include an icon for the rotation handle in global styles

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866fdda32a48323bf5a9ebd8a0ffb87