### PR TITLE
Add rotation handle to image overlay

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -640,6 +640,12 @@ useEffect(() => {
     selEl.appendChild(h);
     handleMap[c] = h;
   });
+  const rot = document.createElement('div');
+  rot.className = 'handle mtr rotate';
+  rot.dataset.corner = 'mtr';
+  rot.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>`;
+  selEl.appendChild(rot);
+  handleMap['mtr'] = rot;
   (selEl as any)._handles = handleMap;
 
   const cropHandles: Record<string, HTMLDivElement> = {};
@@ -684,7 +690,8 @@ useEffect(() => {
     const scale = vt[0]
     const offset = PAD * scale
     const dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
-    const dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+    let dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+    if (corner === 'mtr') dy = -offset
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)
@@ -1051,6 +1058,11 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.mtr) {
+      const rotOff = 40 * scale
+      h.mtr.style.left = `${midX}px`
+      h.mtr.style.top  = `${botY + rotOff}px`
+    }
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,16 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rotate {
+    display:flex;
+    align-items:center;
+    justify-content:center;
+  }
+  .sel-overlay .handle.rotate svg {
+    width:12px;
+    height:12px;
+    stroke:#555;
+  }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,
@@ -139,6 +149,7 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+  .sel-overlay .handle.mtr { cursor:grab; }
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -94,9 +94,11 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
     withShadow(pillControlV);
 });
 
-// rotation handle
+// rotation handle – move below the object
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
+(fabric.Object.prototype as any).controls.mtr.y = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = 40;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- allow rotation handles on Fabric.js objects below the object
- create DOM element and style for rotation handle in FabricCanvas
- draw the handle with an icon in the overlay

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866fdda32a48323bf5a9ebd8a0ffb87