### PR TITLE
Add bottom rotation handle

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -631,11 +631,15 @@ useEffect(() => {
   cropDomRef.current = cropEl;
   (cropEl as any)._object = null;
 
-  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const corners = ['tl','tr','br','bl','ml','mr','mt','mb','rot'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
+    const cls =
+      c === 'rot'
+        ? 'handle rotate'
+        : `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'}`;
+    h.className = `${cls} ${c}`;
     h.dataset.corner = c;
     selEl.appendChild(h);
     handleMap[c] = h;
@@ -645,7 +649,11 @@ useEffect(() => {
   const cropHandles: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
+    const cls =
+      c === 'rot'
+        ? 'handle rotate'
+        : `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'}`;
+    h.className = `${cls} ${c}`;
     h.dataset.corner = c;
     cropEl.appendChild(h);
     cropHandles[c] = h;
@@ -1051,6 +1059,11 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.rot) {
+      const off = 40 * scale
+      h.rot.style.left = `${midX}px`
+      h.rot.style.top = `${botY + off}px`
+    }
   }
 }
 
@@ -1089,9 +1102,9 @@ const syncSel = () => {
       }
     }
     if (selEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k].style.display = 'none')
     if (cropEl && cropEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','rot'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
     return
   }
@@ -1104,7 +1117,7 @@ const syncSel = () => {
   drawOverlay(obj, selEl)
   selEl._object = obj
   if (selEl._handles)
-    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
+    ['ml','mr','mt','mb','rot'].forEach(k => selEl._handles![k].style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,10 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rotate {
+    background:#fff url('/rotate.svg') center/12px 12px no-repeat;
+    cursor:grab;
+  }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -174,6 +174,7 @@ export class CropTool {
     /* hide the rotate ("mtr") and side controls while cropping */
     img.setControlsVisibility({
       mtr: false,          // hide rotation
+      mbr: false,
       ml : false, mr : false,      // hide middle-left / middle-right
       mt : false, mb : false       // hide middle-top / middle-bottom
     });

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -98,6 +98,19 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
 
+// bottom rotation handle
+(fabric.Object.prototype as any).controls.mbr = new fabric.Control({
+  x: 0,
+  y: 0.5,
+  offsetY: 40,
+  withConnection: true,
+  actionHandler: utils.rotationWithSnapping,
+  cursorStyleHandler: utils.rotationStyleHandler,
+  actionName: 'rotate',
+});
+(fabric.Object.prototype as any).controls.mbr.render =
+  withShadow(utils.renderCircleControl);
+
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {
   (fabric.Object.prototype as any).controls[pos].render =

--- a/public/rotate.svg
+++ b/public/rotate.svg
@@ -1,0 +1,4 @@
+<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M21 3v5h-5" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add an SVG rotation icon
- style new rotation handle
- create bottom rotation control in Fabric defaults
- hide bottom rotation handle when cropping
- render and position rotation handle in FabricCanvas

## Testing
- `npm run lint`
- `npm run build` *(fails: React Hook rule violations and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68670176c8d88323a9ba6b643fa4f490