### PR TITLE
Add floating quick action bar

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -17,6 +17,7 @@ import { SEL_COLOR } from '@/lib/fabricDefaults';
 import { CropTool } from '@/lib/CropTool'
 import { enableSnapGuides } from '@/lib/useSnapGuides'
 import ContextMenu from './ContextMenu'
+import QuickActionBar from './QuickActionBar'
 
 /* ---------- print spec ----------------------------------------- */
 export interface PrintSpec {
@@ -489,12 +490,15 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
 
   const cropToolRef = useRef<CropTool | null>(null)
   const croppingRef = useRef(false)
+  const transformingRef = useRef(false)
 
   const savedInteractivityRef = useRef(
     new WeakMap<fabric.Object, { sel: boolean; evt: boolean }>()
   )
 
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null)
+  const [actionPos, setActionPos] = useState<{ x: number; y: number } | null>(null)
+  const actionTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 
 
@@ -1072,6 +1076,7 @@ const drawOverlay = (
     h.mt.style.left = `${midX}px`; h.mt.style.top = '0px'
     h.mb.style.left = `${midX}px`; h.mb.style.top = `${height}px`
   }
+  return { left, top, width, height }
 }
 
 const syncSel = () => {
@@ -1105,13 +1110,19 @@ const syncSel = () => {
       }
     }
     selEl.style.display = 'block'
+    setActionPos(null)
     return
   }
 
   cropEl && (cropEl.style.display = 'none', cropEl._object = null)
   if (!obj) return
-  drawOverlay(obj, selEl)
+  const box = drawOverlay(obj, selEl)
   selEl._object = obj
+  if (transformingRef.current) {
+    setActionPos(null)
+  } else {
+    setActionPos({ x: box.left + box.width / 2, y: box.top - 8 })
+  }
 }
 
 const syncHover = () => {
@@ -1139,17 +1150,18 @@ fc.on('selection:created', () => {
   window.addEventListener('resize', scrollHandler)
   containerRef.current?.addEventListener('scroll', scrollHandler, { passive: true, capture: true })
 })
-.on('selection:updated', syncSel)
-.on('selection:cleared', () => {
+  .on('selection:updated', syncSel)
+  .on('selection:cleared', () => {
   if (scrollHandler) {
     window.removeEventListener('scroll', scrollHandler)
     window.removeEventListener('resize', scrollHandler)
     containerRef.current?.removeEventListener('scroll', scrollHandler)
     scrollHandler = null
   }
-  selDomRef.current && (selDomRef.current.style.display = 'none')
-  cropDomRef.current && (cropDomRef.current.style.display = 'none')
-})
+    selDomRef.current && (selDomRef.current.style.display = 'none')
+    cropDomRef.current && (cropDomRef.current.style.display = 'none')
+    setActionPos(null)
+  })
 
 /* also hide hover during any transform of the active object */
 const handleAfterRender = () => {
@@ -1158,15 +1170,55 @@ const handleAfterRender = () => {
   syncHover()
 }
 
-fc.on('object:moving',   () => { hoverHL.visible = false; syncSel() })
-  .on('object:scaling',  () => { hoverHL.visible = false; syncSel() })
+fc.on('object:moving',   () => {
+    hoverHL.visible = false
+    transformingRef.current = true
+    if (actionTimerRef.current) {
+      clearTimeout(actionTimerRef.current)
+      actionTimerRef.current = null
+    }
+    syncSel()
+  })
+  .on('object:scaling',  () => {
+    hoverHL.visible = false
+    transformingRef.current = true
+    if (actionTimerRef.current) {
+      clearTimeout(actionTimerRef.current)
+      actionTimerRef.current = null
+    }
+    syncSel()
+  })
+  .on('object:rotating', () => {
+    hoverHL.visible = false
+    transformingRef.current = true
+    if (actionTimerRef.current) {
+      clearTimeout(actionTimerRef.current)
+      actionTimerRef.current = null
+    }
+    syncSel()
+  })
   .on('object:scaled',   () => {
     hoverHL.visible = false
     requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
-  .on('object:rotating', () => { hoverHL.visible = false; syncSel() })
-  .on('object:modified', () =>
-    requestAnimationFrame(() => requestAnimationFrame(syncSel)))
+  .on('object:modified', () => {
+    if (transformingRef.current) {
+      transformingRef.current = false
+      setActionPos(null)
+      if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      actionTimerRef.current = window.setTimeout(() => {
+        requestAnimationFrame(() => requestAnimationFrame(syncSel))
+      }, 250)
+    }
+  })
+  .on('mouse:up', () => {
+    if (transformingRef.current) {
+      transformingRef.current = false
+      setActionPos(null)
+      if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      actionTimerRef.current = window.setTimeout(syncSel, 250)
+    }
+  })
   .on('after:render',    handleAfterRender)
 
 /* ── 4 ▸ Hover outline (only when NOT the active object) ─── */
@@ -1666,6 +1718,11 @@ doSync = () =>
         height={PREVIEW_H * zoom}
         style={{ width: PREVIEW_W * zoom, height: PREVIEW_H * zoom }}
         className={`border shadow rounded ${className}`}
+      />
+      <QuickActionBar
+        pos={actionPos}
+        onAction={handleMenuAction}
+        onMenu={p => setMenuPos(p)}
       />
       {menuPos && (
         <ContextMenu

--- a/app/components/QuickActionBar.tsx
+++ b/app/components/QuickActionBar.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import IconButton from './toolbar/IconButton'
+import { Scissors, Copy, CopyPlus, Trash2, MoreHorizontal } from 'lucide-react'
+import type { MenuAction } from './ContextMenu'
+
+interface Props {
+  pos: { x: number; y: number } | null
+  onAction: (a: MenuAction) => void
+  onMenu: (pos: { x: number; y: number }) => void
+}
+
+export default function QuickActionBar({ pos, onAction, onMenu }: Props) {
+  if (!pos) return null
+  const openMenu = () => onMenu(pos)
+  return (
+    <div
+      className="fixed z-50 pointer-events-auto flex items-center gap-px bg-white border border-[rgba(0,91,85,.2)] shadow-lg rounded-full px-0.5 py-0"
+      style={{ top: pos.y, left: pos.x, transform: 'translate(-50%, -100%)' }}
+    >
+      <IconButton Icon={Scissors} label="Cut" hideCaption size="sm" onClick={() => onAction('cut')} />
+      <IconButton Icon={Copy} label="Copy" hideCaption size="sm" onClick={() => onAction('copy')} />
+      <IconButton Icon={CopyPlus} label="Duplicate" hideCaption size="sm" onClick={() => onAction('duplicate')} />
+      <IconButton Icon={Trash2} label="Delete" hideCaption size="sm" onClick={() => onAction('delete')} />
+      <IconButton Icon={MoreHorizontal} label="More" hideCaption size="sm" onClick={openMenu} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `QuickActionBar` for cut/copy/duplicate/delete/ellipsis actions
- show quick action bar when an element is selected in `FabricCanvas`
- hide the bar when the selection is cleared
- reduce padding on quick action bar
- hide quick action bar while dragging or resizing
- delay reappearance after transforms
- shrink quick action bar dimensions
- **fix flash when first clicking**
- **shorten delay after transforms**
- shrink gaps between icons

## Testing
- `npm test` *(fails: Missing script)*
- `pnpm test` *(no output)*
- `npx tsc -p tsconfig.json` *(fails to compile)*
- `npm run build` *(fails due to ESLint errors)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6866f5c8a3e08323aa20dadb8307aaec