### PR TITLE
Add rotation handle to card editor

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -13,7 +13,7 @@ import { fabric }            from 'fabric'
 import { useEditor }         from './EditorStore'
 import { fromSanity }        from '@/app/library/layerAdapters'
 import '@/lib/fabricDefaults'
-import { SEL_COLOR } from '@/lib/fabricDefaults';
+import { SEL_COLOR, ROT_HANDLE_OFFSET } from '@/lib/fabricDefaults';
 import { CropTool } from '@/lib/CropTool'
 import { enableSnapGuides } from '@/lib/useSnapGuides'
 import ContextMenu from './ContextMenu'
@@ -631,19 +631,20 @@ useEffect(() => {
   cropDomRef.current = cropEl;
   (cropEl as any)._object = null;
 
-  const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const corners = ['tl','tr','br','bl','ml','mr','mt','mb','mtr'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
   corners.forEach(c => {
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
-    h.dataset.corner = c;
+    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : c==='mtr' ? 'rot' : 'corner'} ${c}`;
+    h.dataset.corner = c === 'mtr' ? 'rot' : c;
     selEl.appendChild(h);
     handleMap[c] = h;
   });
   (selEl as any)._handles = handleMap;
 
+  const cropCorners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
   const cropHandles: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  cropCorners.forEach(c => {
     const h = document.createElement('div');
     h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c;
@@ -679,12 +680,14 @@ useEffect(() => {
   });
 
   const bridge = (e: PointerEvent) => {
-    const corner = (e.target as HTMLElement | null)?.dataset.corner
+    let corner = (e.target as HTMLElement | null)?.dataset.corner
+    const offsetCorner = corner === 'rot' ? 'mb' : corner
+    if (corner === 'rot') corner = 'mtr'
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
-    const dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+    const dx = offsetCorner?.includes('l') ? offset : offsetCorner?.includes('r') ? -offset : 0
+    const dy = offsetCorner?.includes('t') ? offset : offsetCorner?.includes('b') ? -offset : 0
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)
@@ -1018,21 +1021,24 @@ const drawOverlay = (
   obj: fabric.Object,
   el: HTMLDivElement & { _handles?: Record<string, HTMLDivElement>; _object?: fabric.Object | null }
 ) => {
-  const box  = obj.getBoundingRect(true, true)
-  const rect = canvasRef.current!.getBoundingClientRect()
-  const vt   = fc.viewportTransform || [1,0,0,1,0,0]
+  const rect  = canvasRef.current!.getBoundingClientRect()
+  const vt    = fc.viewportTransform || [1,0,0,1,0,0]
   const scale = vt[0]
+  const boxW  = obj.getScaledWidth()
+  const boxH  = obj.getScaledHeight()
   const c = containerRef.current
   const scrollX = (c?.scrollLeft ?? 0)
   const scrollY = (c?.scrollTop  ?? 0)
-  const left   = window.scrollX + scrollX + rect.left + vt[4] + (box.left - PAD) * scale
-  const top    = window.scrollY + scrollY + rect.top  + vt[5] + (box.top - PAD) * scale
-  const width  = (box.width  + PAD * 2) * scale
-  const height = (box.height + PAD * 2) * scale
+  const left   = window.scrollX + scrollX + rect.left + vt[4] + (obj.left - PAD) * scale
+  const top    = window.scrollY + scrollY + rect.top  + vt[5] + (obj.top  - PAD) * scale
+  const width  = (boxW + PAD * 2) * scale
+  const height = (boxH + PAD * 2) * scale
   el.style.left   = `${left}px`
   el.style.top    = `${top}px`
   el.style.width  = `${width}px`
   el.style.height = `${height}px`
+  el.style.transform = `rotate(${obj.angle || 0}deg)`
+  el.style.transformOrigin = '0 0'
   el._object = obj
   if (el._handles) {
     const h = el._handles
@@ -1043,6 +1049,7 @@ const drawOverlay = (
     const rightX = Math.round(width - half)
     const topY   = Math.round(half)
     const botY   = Math.round(height - half)
+    const rotY   = Math.round(height + ROT_HANDLE_OFFSET * scale)
     h.tl.style.left = `${leftX}px`;  h.tl.style.top = `${topY}px`
     h.tr.style.left = `${rightX}px`; h.tr.style.top = `${topY}px`
     h.br.style.left = `${rightX}px`; h.br.style.top = `${botY}px`
@@ -1051,6 +1058,10 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.mtr) {
+      h.mtr.style.left = `${midX}px`
+      h.mtr.style.top  = `${rotY}px`
+    }
   }
 }
 
@@ -1089,7 +1100,7 @@ const syncSel = () => {
       }
     }
     if (selEl._handles)
-      ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'none')
+      ['ml','mr','mt','mb','mtr'].forEach(k => selEl._handles![k].style.display = 'none')
     if (cropEl && cropEl._handles)
       ['ml','mr','mt','mb'].forEach(k => cropEl._handles![k].style.display = 'none')
     selEl.style.display = 'block'
@@ -1104,7 +1115,7 @@ const syncSel = () => {
   drawOverlay(obj, selEl)
   selEl._object = obj
   if (selEl._handles)
-    ['ml','mr','mt','mb'].forEach(k => selEl._handles![k].style.display = 'block')
+    ['ml','mr','mt','mb','mtr'].forEach(k => selEl._handles![k].style.display = 'block')
 }
 
 const syncHover = () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,6 +104,7 @@ html {
   .sel-overlay {
     @apply absolute pointer-events-none box-border z-40;
     border:2px solid #2EC4B6; /* SEL_COLOR */
+    transform-origin:0 0;
   }
   .sel-overlay.interactive {
     @apply pointer-events-none;
@@ -139,6 +140,19 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+
+  .sel-overlay .handle.rot {
+    cursor:grab;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:10px;
+    width:21px;
+    height:21px;
+  }
+  .sel-overlay .handle.rot::before {
+    content:'\21bb';
+  }
 
   /* crop window corner "L" handles */
   .sel-overlay.crop-window .handle.corner {

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -6,6 +6,7 @@ export const SCALE        = 420 / 1772;        // or the real SCALE you compute
 export const SEL_COLOR    = '#2EC4B6';         // brand teal – shared everywhere
 export const HANDLE_SHADOW = 'rgba(0,0,0,0.15)';
 export const HANDLE_BLUR   = 1 / SCALE;
+export const ROT_HANDLE_OFFSET = 54;  // increased distance for rotation handle
 
 /* ————— global Fabric defaults ————— */
 (fabric.Object.prototype as any).cornerSize        = Math.round(3 / SCALE);
@@ -97,6 +98,12 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
 // rotation handle
 (fabric.Object.prototype as any).controls.mtr.render =
   withShadow(utils.renderCircleControl);
+(fabric.Object.prototype as any).controls.mtr.y = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = ROT_HANDLE_OFFSET;
+(fabric.Object.prototype as any).controls.mtr.sizeX =
+  Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
+(fabric.Object.prototype as any).controls.mtr.sizeY =
+  Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- adjust Fabric defaults to position rotation control below an object
- expose a constant for the rotation handle offset
- display a rotation handle in the selection overlay with a rotate icon
- sync the DOM handle with Fabric's control
- rotate the DOM overlay with the canvas object so borders hug the element
- enlarge rotation handle and move it further from the element
- fix rotation handle alignment when objects are scaled
- fix rotation handle alignment

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68670176c8d88323a9ba6b643fa4f490