### PR TITLE
Fix rotation handle functionality

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -684,7 +684,7 @@ useEffect(() => {
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const base = corner === 'rot' ? 'mb' : corner
+    const base = corner === 'rot' ? 'mtr' : corner
     const dx = base?.includes('l') ? offset : base?.includes('r') ? -offset : 0
     const dy = base?.includes('t') ? offset : base?.includes('b') ? -offset : 0
 

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -104,6 +104,7 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
 (fabric.Object.prototype as any).controls.mtr.sizeY =
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
+(fabric.Object.prototype as any).controls.mtr.visible = false;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- forward custom rotation handle events using the `mtr` control
- hide Fabric's default rotation handle so the DOM handle is the only one visible

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other lint errors)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68671cb9d61483239a5120d1046e367d