### PR TITLE
Fix rotation handle forwarding

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -684,9 +684,14 @@ useEffect(() => {
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
+    const rotOff = ROT_HANDLE_OFFSET * scale
     const base = corner === 'rot' ? 'mb' : corner
     const dx = base?.includes('l') ? offset : base?.includes('r') ? -offset : 0
-    const dy = base?.includes('t') ? offset : base?.includes('b') ? -offset : 0
+    const dy = base?.includes('t')
+      ? offset
+      : base?.includes('b')
+        ? -(offset + (corner === 'rot' ? rotOff : 0))
+        : 0
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)


### PR DESCRIPTION
## Summary
- handle offset for rotation control in `FabricCanvas` so the visible control responds to drag events

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68671cb9d61483239a5120d1046e367d