### PR TITLE
Fix rotation handle interaction

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -683,10 +683,20 @@ useEffect(() => {
     const corner = (e.target as HTMLElement | null)?.dataset.corner
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
-    const offset = PAD * scale
-    const base = corner === 'rot' ? 'mb' : corner
-    const dx = base?.includes('l') ? offset : base?.includes('r') ? -offset : 0
-    const dy = base?.includes('t') ? offset : base?.includes('b') ? -offset : 0
+    const base = corner === 'rot' ? 'mtr' : corner
+    const padOffset = PAD * scale
+    const rotOffset = (PAD + ROT_HANDLE_OFFSET) * scale
+    let dx = 0, dy = 0
+    if (base) {
+      if (base.includes('l')) dx = padOffset
+      else if (base.includes('r')) dx = -padOffset
+      if (base.includes('t')) dy = padOffset
+      else if (base.includes('b')) dy = -padOffset
+      if (base === 'mtr') {
+        dx = 0
+        dy = -rotOffset
+      }
+    }
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)

--- a/app/globals.css
+++ b/app/globals.css
@@ -107,7 +107,7 @@ html {
     transform-origin:0 0;
   }
   .sel-overlay.interactive {
-    @apply pointer-events-none;
+    @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -104,6 +104,7 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
 (fabric.Object.prototype as any).controls.mtr.sizeY =
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
+(fabric.Object.prototype as any).controls.mtr.visible = false;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- forward custom rotation handle events to Fabric's `mtr` control
- allow pointer events on DOM overlay
- hide Fabric's native rotation handle

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, react-hooks/rules-of-hooks, etc.)*
- `npm run build` *(fails: lint errors during build)*

------
https://chatgpt.com/codex/tasks/task_e_68671fc832608323b0ed8ee72993ac20