### PR TITLE
Fix DOM rotation handle interactions

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -684,7 +684,7 @@ useEffect(() => {
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const base = corner === 'rot' ? 'mb' : corner
+    const base = corner === 'rot' ? 'mtr' : corner
     const dx = base?.includes('l') ? offset : base?.includes('r') ? -offset : 0
     const dy = base?.includes('t') ? offset : base?.includes('b') ? -offset : 0
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -107,7 +107,7 @@ html {
     transform-origin:0 0;
   }
   .sel-overlay.interactive {
-    @apply pointer-events-none;
+    @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;


### PR DESCRIPTION
## Summary
- forward DOM rotation handle to Fabric's `mtr` control instead of the bottom control
- allow pointer events on the selection overlay so handles receive input

## Testing
- `npm run lint > /tmp/lint.log 2>&1 && tail -n 20 /tmp/lint.log`

------
https://chatgpt.com/codex/tasks/task_e_68671fc832608323b0ed8ee72993ac20