### PR TITLE
Fix rotation handle overlay

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -684,9 +684,15 @@ useEffect(() => {
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const base = corner === 'rot' ? 'mb' : corner
+    const base = corner === 'rot' ? 'mtr' : corner
     const dx = base?.includes('l') ? offset : base?.includes('r') ? -offset : 0
-    const dy = base?.includes('t') ? offset : base?.includes('b') ? -offset : 0
+    const dy = base === 'mtr'
+      ? 0
+      : base?.includes('t')
+        ? offset
+        : base?.includes('b')
+          ? -offset
+          : 0
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)

--- a/app/globals.css
+++ b/app/globals.css
@@ -107,7 +107,7 @@ html {
     transform-origin:0 0;
   }
   .sel-overlay.interactive {
-    @apply pointer-events-none;
+    @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -104,6 +104,7 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
 (fabric.Object.prototype as any).controls.mtr.sizeY =
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
+(fabric.Object.prototype as any).controls.mtr.visible = false;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- enable pointer events on selection overlay
- forward custom rotation handle to Fabric's `mtr` control
- hide Fabric's built in rotation handle

## Testing
- `npm run lint` *(fails: React hook & unescaped entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867ab549a248323baec4dc77d229fda