### PR TITLE
Fix rotation handle interactivity

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -680,13 +680,18 @@ useEffect(() => {
   });
 
   const bridge = (e: PointerEvent) => {
-    const corner = (e.target as HTMLElement | null)?.dataset.corner
+    let corner = (e.target as HTMLElement | null)?.dataset.corner
     const vt = fc.viewportTransform || [1, 0, 0, 1, 0, 0]
     const scale = vt[0]
     const offset = PAD * scale
-    const base = corner === 'rot' ? 'mb' : corner
-    const dx = base?.includes('l') ? offset : base?.includes('r') ? -offset : 0
-    const dy = base?.includes('t') ? offset : base?.includes('b') ? -offset : 0
+    let dx = 0, dy = 0
+    if (corner === 'rot') {
+      corner = 'mtr'
+      dy = -offset
+    } else {
+      dx = corner?.includes('l') ? offset : corner?.includes('r') ? -offset : 0
+      dy = corner?.includes('t') ? offset : corner?.includes('b') ? -offset : 0
+    }
 
     const down = new MouseEvent('mousedown', forward(e, dx, dy))
     fc.upperCanvasEl.dispatchEvent(down)

--- a/app/globals.css
+++ b/app/globals.css
@@ -107,7 +107,7 @@ html {
     transform-origin:0 0;
   }
   .sel-overlay.interactive {
-    @apply pointer-events-none;
+    @apply pointer-events-auto;
   }
   .sel-overlay .handle {
     position:absolute;

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -104,6 +104,7 @@ const utils = (fabric as any).controlsUtils;   // hidden Fabric helpers
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
 (fabric.Object.prototype as any).controls.mtr.sizeY =
   Math.round((fabric.Object.prototype as any).cornerSize * 1.3);
+(fabric.Object.prototype as any).controls.mtr.visible = false;
 
 // corner circles
 ['tl','tr','bl','br'].forEach(pos => {


### PR DESCRIPTION
## Summary
- enable pointer events on the selection overlay
- forward DOM rotation handle events to Fabric's `mtr` control
- hide Fabric's built‑in rotation control

## Testing
- `npm run lint` *(fails: React hook and img usage warnings)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6867ab549a248323baec4dc77d229fda