### PR TITLE
Fix rogue hover outline after dragging

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1230,6 +1230,10 @@ const handleAfterRender = () => {
 
 fc.on('object:moving', () => {
   hoverHL.visible         = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1241,6 +1245,10 @@ fc.on('object:moving', () => {
 
 .on('object:scaling', e => {
   hoverHL.visible         = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1252,6 +1260,10 @@ fc.on('object:moving', () => {
 
 .on('object:rotating', () => {
   hoverHL.visible         = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1263,6 +1275,10 @@ fc.on('object:moving', () => {
 
 .on('object:scaled', e => {
   hoverHL.visible = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   hideSizeBubble();
   requestAnimationFrame(() => requestAnimationFrame(syncSel));
 })


### PR DESCRIPTION
## Summary
- reset hover overlay when objects are transformed to stop rogue outlines from appearing

## Testing
- `npm run lint` *(fails: React Hook and next/no-img-element warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6867f451aad08323b8937cb05d46ddf1