### PR TITLE
Fix overlay flicker on card element drag

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1230,6 +1230,10 @@ const handleAfterRender = () => {
 
 fc.on('object:moving', () => {
   hoverHL.visible         = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1241,6 +1245,10 @@ fc.on('object:moving', () => {
 
 .on('object:scaling', e => {
   hoverHL.visible         = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1252,6 +1260,10 @@ fc.on('object:moving', () => {
 
 .on('object:rotating', () => {
   hoverHL.visible         = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1263,6 +1275,10 @@ fc.on('object:moving', () => {
 
 .on('object:scaled', e => {
   hoverHL.visible = false;
+  if (hoverDomRef.current) {
+    hoverDomRef.current.style.display = 'none';
+    (hoverDomRef.current as any)._object = null;
+  }
   hideSizeBubble();
   requestAnimationFrame(() => requestAnimationFrame(syncSel));
 })
@@ -1281,6 +1297,10 @@ fc.on('object:moving', () => {
     if (transformingRef.current) {
       transformingRef.current = false
       setActionPos(null)
+      if (hoverDomRef.current) {
+        hoverDomRef.current.style.display = 'none'
+        ;(hoverDomRef.current as any)._object = null
+      }
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
       actionTimerRef.current = window.setTimeout(syncSel, 250)
     }


### PR DESCRIPTION
## Summary
- avoid showing the hover DOM overlay while an element is being transformed
- hide leftover hover overlay on mouse up

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867f451aad08323b8937cb05d46ddf1