### PR TITLE
Fix overlay jump after drag

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1094,6 +1094,7 @@ const drawOverlay = (
 const syncSel = () => {
   const obj = fc.getActiveObject() as fabric.Object | undefined
   if (!selDomRef.current || !canvasRef.current) return
+  fc.calcOffset()
   const selEl  = selDomRef.current as HTMLDivElement & { _handles?: Record<string, HTMLDivElement>; _object?: fabric.Object | null }
   const cropEl = cropDomRef.current as HTMLDivElement & { _handles?: Record<string, HTMLDivElement>; _object?: fabric.Object | null } | null
 


### PR DESCRIPTION
## Summary
- call `fc.calcOffset()` before syncing selection so the overlay doesn't flash after dropping

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867f451aad08323b8937cb05d46ddf1