### PR TITLE
Add rotation handle outside canvas

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -658,10 +658,12 @@ useEffect(() => {
   (cropEl as any)._object = null;
 
   const corners = ['tl','tr','br','bl','ml','mr','mt','mb'] as const;
+  const selHandles = [...corners, 'mtr'] as const;
   const handleMap: Record<string, HTMLDivElement> = {};
-  corners.forEach(c => {
+  selHandles.forEach(c => {
+    const cls = ['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner';
     const h = document.createElement('div');
-    h.className = `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
+    h.className = `handle ${cls} ${c}`;
     h.dataset.corner = c;
     selEl.appendChild(h);
     handleMap[c] = h;
@@ -1087,6 +1089,11 @@ const drawOverlay = (
     h.mr.style.left = `${rightX}px`; h.mr.style.top = `${midY}px`
     h.mt.style.left = `${midX}px`;   h.mt.style.top = `${topY}px`
     h.mb.style.left = `${midX}px`;   h.mb.style.top = `${botY}px`
+    if (h.mtr) {
+      const off = obj.controls?.mtr?.offsetY ?? -40
+      h.mtr.style.left = `${midX}px`
+      h.mtr.style.top  = `${Math.round(topY + off * scale)}px`
+    }
   }
   return { left, top, width, height }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,6 +139,8 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
+  .sel-overlay .handle.mtr { cursor:grab; }
+  .sel-overlay .handle.mtr:active { cursor:grabbing; }
 
   /* ── NEW from stable-3-july-2025 ───────────────────────────── */
   .size-bubble {


### PR DESCRIPTION
## Summary
- add rotation handle to DOM overlay
- style rotation handle cursor

## Testing
- `npm run lint` *(fails: React hooks usage errors)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules and various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867f4a98ba88323a81e931c27f4ed12