### PR TITLE
Add rotation handle overlay

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,11 @@ html {
     height:7px;
     border-radius:3px;
   }
+  .sel-overlay .handle.rotate {
+    width:20px;
+    height:20px;
+    cursor:grab;
+  }
   .sel-overlay .handle.tl,
   .sel-overlay .handle.br { cursor:nwse-resize; }
   .sel-overlay .handle.tr,


### PR DESCRIPTION
## Summary
- allow a rotation handle to sit outside the canvas
- include a new rotate handle in FabricCanvas overlay
- style `.handle.rotate`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867f4a98ba88323a81e931c27f4ed12