### PR TITLE
Fix hover overlay glitch on drag release

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -844,6 +844,10 @@ if (container) {
     croppingRef.current = state
     isolateCrop(state)
     onCroppingChange?.(state)
+    if (!state) {
+      hideHover()
+      syncSel()
+    }
   })
   cropToolRef.current = crop;
   ;(fc as any)._cropTool = crop;
@@ -1188,9 +1192,16 @@ const hideSizeBubble = () => {
   if (bubble) bubble.style.display = 'none'
 }
 
+const hideHover = () => {
+  if (!hoverDomRef.current) return
+  hoverDomRef.current.style.display = 'none'
+  ;(hoverDomRef.current as any)._object = null
+}
+
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
+  hideHover()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
@@ -1230,6 +1241,7 @@ const handleAfterRender = () => {
 
 fc.on('object:moving', () => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1241,6 +1253,7 @@ fc.on('object:moving', () => {
 
 .on('object:scaling', e => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1252,6 +1265,7 @@ fc.on('object:moving', () => {
 
 .on('object:rotating', () => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1263,6 +1277,7 @@ fc.on('object:moving', () => {
 
 .on('object:scaled', e => {
   hoverHL.visible = false;
+  hideHover();
   hideSizeBubble();
   requestAnimationFrame(() => requestAnimationFrame(syncSel));
 })
@@ -1272,6 +1287,7 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      hideHover()
       actionTimerRef.current = window.setTimeout(() => {
         requestAnimationFrame(() => requestAnimationFrame(syncSel))
       }, 250)
@@ -1282,6 +1298,7 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      hideHover()
       actionTimerRef.current = window.setTimeout(syncSel, 250)
     }
   })


### PR DESCRIPTION
## Summary
- ensure hover outline is hidden when an object becomes active or is transformed
- add helper `hideHover` and call from relevant Fabric event handlers
- clear crop overlay as soon as cropping ends

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867f69c1f088323aad048c872425b80