### PR TITLE
Fix stray selection outline after crop

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -843,6 +843,9 @@ if (container) {
   const crop = new CropTool(fc, SCALE, SEL_COLOR, state => {
     croppingRef.current = state
     isolateCrop(state)
+    hideSel()
+    hideHover()
+    hoverHL.visible = false
     onCroppingChange?.(state)
   })
   cropToolRef.current = crop;
@@ -1188,15 +1191,34 @@ const hideSizeBubble = () => {
   if (bubble) bubble.style.display = 'none'
 }
 
+const hideSel = () => {
+  if (!selDomRef.current) return
+  selDomRef.current.style.display = 'none'
+  ;(selDomRef.current as any)._object = null
+}
+
+const hideHover = () => {
+  if (!hoverDomRef.current) return
+  hoverDomRef.current.style.display = 'none'
+  ;(hoverDomRef.current as any)._object = null
+}
+
+const rafSyncSel = () => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(syncSel)
+  })
+}
+
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
+  hideHover()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
   }
   syncSel()
-  requestAnimationFrame(syncSel)
+  rafSyncSel()
   scrollHandler = () => {
     fc.calcOffset()
     syncSel()
@@ -1230,6 +1252,7 @@ const handleAfterRender = () => {
 
 fc.on('object:moving', () => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1241,6 +1264,7 @@ fc.on('object:moving', () => {
 
 .on('object:scaling', e => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1252,6 +1276,7 @@ fc.on('object:moving', () => {
 
 .on('object:rotating', () => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1263,8 +1288,9 @@ fc.on('object:moving', () => {
 
 .on('object:scaled', e => {
   hoverHL.visible = false;
+  hideHover();
   hideSizeBubble();
-  requestAnimationFrame(() => requestAnimationFrame(syncSel));
+  rafSyncSel();
 })
 
   .on('object:modified', () => {
@@ -1272,9 +1298,9 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(() => {
-        requestAnimationFrame(() => requestAnimationFrame(syncSel))
-      }, 250)
+      hideSel()
+      hideHover()
+      actionTimerRef.current = window.setTimeout(rafSyncSel, 250)
     }
   })
   .on('mouse:up', () => {
@@ -1282,7 +1308,9 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(syncSel, 250)
+      hideSel()
+      hideHover()
+      actionTimerRef.current = window.setTimeout(rafSyncSel, 250)
     }
   })
   .on('after:render',    handleAfterRender)
@@ -1694,8 +1722,12 @@ img.on('mouseup', () => {
 
 doSync = () =>
   canvasRef.current && ghost && (() => {
-    fc.calcOffset()
-    syncGhost(img, ghost, canvasRef.current)
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        fc.calcOffset()
+        syncGhost(img, ghost, canvasRef.current!)
+      })
+    })
   })()
             doSync()
             img.on('moving',   doSync)


### PR DESCRIPTION
## Summary
- hide the selection DOM overlay via new `hideSel` helper
- hide selection when crop mode toggles or a transform completes
- debounce selection and AI ghost overlays using double `requestAnimationFrame`

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, hooks rules)*

------
https://chatgpt.com/codex/tasks/task_e_6867f69c1f088323aad048c872425b80