### PR TITLE
Fix stray selection outline after crop

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -843,6 +843,9 @@ if (container) {
   const crop = new CropTool(fc, SCALE, SEL_COLOR, state => {
     croppingRef.current = state
     isolateCrop(state)
+    hideSel()
+    hideHover()
+    hoverHL.visible = false
     onCroppingChange?.(state)
   })
   cropToolRef.current = crop;
@@ -1188,15 +1191,40 @@ const hideSizeBubble = () => {
   if (bubble) bubble.style.display = 'none'
 }
 
+const hideSel = () => {
+  if (!selDomRef.current) return
+  selDomRef.current.style.display = 'none'
+  ;(selDomRef.current as any)._object = null
+}
+
+const hideHover = () => {
+  if (!hoverDomRef.current) return
+  hoverDomRef.current.style.display = 'none'
+  ;(hoverDomRef.current as any)._object = null
+}
+
+let selFrame = 0
+const syncSelNext = () => {
+  if (selFrame) cancelAnimationFrame(selFrame)
+  selFrame = requestAnimationFrame(() => {
+    selFrame = requestAnimationFrame(() => {
+      fc.calcOffset()
+      syncSel()
+      selFrame = 0
+    })
+  })
+}
+
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
+  hideHover()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
   }
   syncSel()
-  requestAnimationFrame(syncSel)
+  syncSelNext()
   scrollHandler = () => {
     fc.calcOffset()
     syncSel()
@@ -1230,6 +1258,7 @@ const handleAfterRender = () => {
 
 fc.on('object:moving', () => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1241,6 +1270,7 @@ fc.on('object:moving', () => {
 
 .on('object:scaling', e => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1252,6 +1282,7 @@ fc.on('object:moving', () => {
 
 .on('object:rotating', () => {
   hoverHL.visible         = false;
+  hideHover();
   transformingRef.current = true;
   if (actionTimerRef.current) {
     clearTimeout(actionTimerRef.current);
@@ -1263,8 +1294,9 @@ fc.on('object:moving', () => {
 
 .on('object:scaled', e => {
   hoverHL.visible = false;
+  hideHover();
   hideSizeBubble();
-  requestAnimationFrame(() => requestAnimationFrame(syncSel));
+  syncSelNext();
 })
 
   .on('object:modified', () => {
@@ -1272,9 +1304,9 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(() => {
-        requestAnimationFrame(() => requestAnimationFrame(syncSel))
-      }, 250)
+      hideSel()
+      hideHover()
+      actionTimerRef.current = window.setTimeout(syncSelNext, 250)
     }
   })
   .on('mouse:up', () => {
@@ -1282,7 +1314,9 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(syncSel, 250)
+      hideSel()
+      hideHover()
+      actionTimerRef.current = window.setTimeout(syncSelNext, 250)
     }
   })
   .on('after:render',    handleAfterRender)
@@ -1692,10 +1726,17 @@ img.on('mouseup', () => {
               img.on('mouseout',  () => { ghost!.style.opacity = '0' })
             }
 
+let ghostFrame = 0
 doSync = () =>
   canvasRef.current && ghost && (() => {
-    fc.calcOffset()
-    syncGhost(img, ghost, canvasRef.current)
+    if (ghostFrame) cancelAnimationFrame(ghostFrame)
+    ghostFrame = requestAnimationFrame(() => {
+      ghostFrame = requestAnimationFrame(() => {
+        fc.calcOffset()
+        syncGhost(img, ghost, canvasRef.current!)
+        ghostFrame = 0
+      })
+    })
   })()
             doSync()
             img.on('moving',   doSync)


### PR DESCRIPTION
## Summary
- debounce selection overlay updates until a full frame passes
- debounce placeholder ghost overlay as well

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867f69c1f088323aad048c872425b80