### PR TITLE
Update rotation handle appearance and placement

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -668,6 +668,7 @@ useEffect(() => {
         ? 'handle rot'
         : `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c === 'rot' ? 'mtr' : c;
+    if (c === 'rot') h.textContent = '⟳';
     selEl.appendChild(h);
     handleMap[c] = h;
   });
@@ -1108,7 +1109,7 @@ const drawOverlay = (
     h.mb.style.top   = `${botY}px`
     if (h.rot) {
       h.rot.style.left = `${midX}px`
-      h.rot.style.top  = `${Math.round(topY - ROT_OFF)}px`
+      h.rot.style.top  = `${Math.round(botY + ROT_OFF)}px`
     }
   }
   return { left, top, width, height }

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,7 +139,15 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
-  .sel-overlay .handle.rot { cursor:grab; }
+  .sel-overlay .handle.rot {
+    cursor:grab;
+    width:24px;
+    height:24px;
+    line-height:24px;
+    font-size:14px;
+    text-align:center;
+    user-select:none;
+  }
 
   /* ── NEW from stable-3-july-2025 ───────────────────────────── */
   .size-bubble {


### PR DESCRIPTION
## Summary
- make rotation handle larger with an icon
- move rotation handle below the element

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68681340ef2c8323b7653c4874a5a49b