### PR TITLE
Add rotation bubble indicator

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -146,6 +146,10 @@ html {
     @apply absolute text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
   }
 
+  .rotate-bubble {
+    @apply absolute text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
+  }
+
   /* ── NEW from stable-4-july-2025 ───────────────────────────── */
   /* crop window corner “L” handles */
   .sel-overlay.crop-window .handle.corner {


### PR DESCRIPTION
## Summary
- display a new `rotate-bubble` next to the resize bubble
- show rotation degrees while rotating elements
- hide rotation bubble when other transforms occur

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868275a2a5c8323be165cbc43748e0d