### PR TITLE
Add rotation bubble

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -116,6 +116,7 @@ let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
 const ROT_OFF = 40
+const BUBBLE_OFF = 30
 const SEL_BORDER = 2
 
 recompute()
@@ -679,6 +680,12 @@ useEffect(() => {
   selEl.appendChild(sizeBubble);
   (selEl as any)._sizeBubble = sizeBubble;
 
+  const rotBubble = document.createElement('div');
+  rotBubble.className = 'rot-bubble';
+  rotBubble.style.display = 'none';
+  selEl.appendChild(rotBubble);
+  (selEl as any)._rotBubble = rotBubble;
+
   const cropHandles: Record<string, HTMLDivElement> = {};
   cropCorners.forEach(c => {
     const h = document.createElement('div');
@@ -1200,14 +1207,39 @@ const syncHover = () => {
     const e = ev.e as MouseEvent | PointerEvent | undefined
     const x = e?.clientX ?? 0
     const y = e?.clientY ?? 0
-    bubble.style.left = `${x - rect.left + 30}px`
-    bubble.style.top = `${y - rect.top + 30}px`
+    bubble.style.left = `${x - rect.left + BUBBLE_OFF}px`
+    bubble.style.top = `${y - rect.top + BUBBLE_OFF}px`
     bubble.style.display = 'block'
   }
 
 const hideSizeBubble = () => {
   if (!selDomRef.current) return
   const bubble = (selDomRef.current as any)._sizeBubble as HTMLDivElement | undefined
+  if (bubble) bubble.style.display = 'none'
+}
+
+const showRotBubble = (obj: fabric.Object | undefined, ev: fabric.IEvent | undefined) => {
+  if (!obj || !selDomRef.current || !ev) return
+  const bubble = (selDomRef.current as any)._rotBubble as HTMLDivElement | undefined
+  if (!bubble) return
+  let ang = obj.angle ?? 0
+  ang = ((ang % 360) + 360) % 360
+  if (ang > 180) ang -= 360
+  let deg = Math.round(ang)
+  if (deg === -180) deg = 180
+  bubble.textContent = `${deg}\u00B0`
+  const rect = selDomRef.current.getBoundingClientRect()
+  const e = ev.e as MouseEvent | PointerEvent | undefined
+  const x = e?.clientX ?? 0
+  const y = e?.clientY ?? 0
+  bubble.style.left = `${x - rect.left + BUBBLE_OFF}px`
+  bubble.style.top = `${y - rect.top + BUBBLE_OFF}px`
+  bubble.style.display = 'block'
+}
+
+const hideRotBubble = () => {
+  if (!selDomRef.current) return
+  const bubble = (selDomRef.current as any)._rotBubble as HTMLDivElement | undefined
   if (bubble) bubble.style.display = 'none'
 }
 
@@ -1241,6 +1273,7 @@ fc.on('selection:created', () => {
   cropDomRef.current && (cropDomRef.current.style.display = 'none');
   setActionPos(null);     // from quick-action branch
   hideSizeBubble();       // from stable branch
+  hideRotBubble();
 })
 
 
@@ -1260,6 +1293,7 @@ fc.on('object:moving', () => {
   }
   syncSel();
   hideSizeBubble();                  // moving never shows the bubble
+  hideRotBubble();
 })
 
 .on('object:scaling', e => {
@@ -1271,9 +1305,10 @@ fc.on('object:moving', () => {
   }
   syncSel();
   showSizeBubble(e.target as fabric.Object, e);   // live size read-out
+  hideRotBubble();
 })
 
-.on('object:rotating', () => {
+.on('object:rotating', e => {
   hoverHL.visible         = false;
   transformingRef.current = true;
   if (actionTimerRef.current) {
@@ -1281,12 +1316,14 @@ fc.on('object:moving', () => {
     actionTimerRef.current = null;
   }
   syncSel();
-  hideSizeBubble();                  // hide during rotation
+  hideSizeBubble();                  // hide size bubble during rotation
+  showRotBubble(e.target as fabric.Object, e);
 })
 
 .on('object:scaled', e => {
   hoverHL.visible = false;
   hideSizeBubble();
+  hideRotBubble();
   requestAnimationFrame(() => requestAnimationFrame(syncSel));
 })
 
@@ -1299,6 +1336,7 @@ fc.on('object:moving', () => {
         requestAnimationFrame(() => requestAnimationFrame(syncSel))
       }, 250)
     }
+    hideRotBubble()
   })
   .on('mouse:up', () => {
     if (transformingRef.current) {
@@ -1307,6 +1345,7 @@ fc.on('object:moving', () => {
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
       actionTimerRef.current = window.setTimeout(syncSel, 250)
     }
+    hideRotBubble()
   })
   .on('after:render',    handleAfterRender)
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -146,6 +146,10 @@ html {
     @apply absolute text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
   }
 
+  .rot-bubble {
+    @apply absolute text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
+  }
+
   /* ── NEW from stable-4-july-2025 ───────────────────────────── */
   /* crop window corner “L” handles */
   .sel-overlay.crop-window .handle.corner {


### PR DESCRIPTION
## Summary
- display a rotation bubble while rotating objects in Fabric canvas
- hide rotation bubble after transforms
- style the rotation bubble
- use constant BUBBLE_OFF so both size and rotation bubbles show bottom-right of cursor

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run build` *(fails during linting step)*

------
https://chatgpt.com/codex/tasks/task_e_6868275a2a5c8323be165cbc43748e0d