### PR TITLE
Add rotation indicator bubble

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -679,6 +679,12 @@ useEffect(() => {
   selEl.appendChild(sizeBubble);
   (selEl as any)._sizeBubble = sizeBubble;
 
+  const rotBubble = document.createElement('div');
+  rotBubble.className = 'rot-bubble';
+  rotBubble.style.display = 'none';
+  selEl.appendChild(rotBubble);
+  (selEl as any)._rotBubble = rotBubble;
+
   const cropHandles: Record<string, HTMLDivElement> = {};
   cropCorners.forEach(c => {
     const h = document.createElement('div');
@@ -1211,6 +1217,29 @@ const hideSizeBubble = () => {
   if (bubble) bubble.style.display = 'none'
 }
 
+const showRotBubble = (obj: fabric.Object | undefined, ev: fabric.IEvent | undefined) => {
+  if (!obj || !selDomRef.current || !ev) return
+  const bubble = (selDomRef.current as any)._rotBubble as HTMLDivElement | undefined
+  if (!bubble) return
+  let angle = obj.angle || 0
+  angle = ((angle % 360) + 360) % 360
+  if (angle > 180) angle -= 360
+  bubble.textContent = `${Math.round(angle)}\u00B0`
+  const rect = selDomRef.current.getBoundingClientRect()
+  const e = ev.e as MouseEvent | PointerEvent | undefined
+  const x = e?.clientX ?? 0
+  const y = e?.clientY ?? 0
+  bubble.style.left = `${x - rect.left + 30}px`
+  bubble.style.top = `${y - rect.top + 30}px`
+  bubble.style.display = 'block'
+}
+
+const hideRotBubble = () => {
+  if (!selDomRef.current) return
+  const bubble = (selDomRef.current as any)._rotBubble as HTMLDivElement | undefined
+  if (bubble) bubble.style.display = 'none'
+}
+
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
@@ -1241,6 +1270,7 @@ fc.on('selection:created', () => {
   cropDomRef.current && (cropDomRef.current.style.display = 'none');
   setActionPos(null);     // from quick-action branch
   hideSizeBubble();       // from stable branch
+  hideRotBubble();
 })
 
 
@@ -1260,6 +1290,7 @@ fc.on('object:moving', () => {
   }
   syncSel();
   hideSizeBubble();                  // moving never shows the bubble
+  hideRotBubble();
 })
 
 .on('object:scaling', e => {
@@ -1271,9 +1302,10 @@ fc.on('object:moving', () => {
   }
   syncSel();
   showSizeBubble(e.target as fabric.Object, e);   // live size read-out
+  hideRotBubble();
 })
 
-.on('object:rotating', () => {
+.on('object:rotating', e => {
   hoverHL.visible         = false;
   transformingRef.current = true;
   if (actionTimerRef.current) {
@@ -1282,11 +1314,13 @@ fc.on('object:moving', () => {
   }
   syncSel();
   hideSizeBubble();                  // hide during rotation
+  showRotBubble(e.target as fabric.Object, e);
 })
 
 .on('object:scaled', e => {
   hoverHL.visible = false;
   hideSizeBubble();
+  hideRotBubble();
   requestAnimationFrame(() => requestAnimationFrame(syncSel));
 })
 
@@ -1299,6 +1333,7 @@ fc.on('object:moving', () => {
         requestAnimationFrame(() => requestAnimationFrame(syncSel))
       }, 250)
     }
+    hideRotBubble()
   })
   .on('mouse:up', () => {
     if (transformingRef.current) {
@@ -1346,6 +1381,7 @@ fc.on('mouse:over', e => {
 addGuides(fc, mode)                           // add guides based on mode
   /* ── 4.5 ▸ Fabric ➜ Zustand sync ──────────────────────────── */
   fc.on('object:modified', e=>{
+    hideRotBubble()
     isEditing.current = true
     const t = e.target as any
     if (t?.layerIdx === undefined) return

--- a/app/globals.css
+++ b/app/globals.css
@@ -146,6 +146,10 @@ html {
     @apply absolute text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
   }
 
+  .rot-bubble {
+    @apply absolute text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
+  }
+
   /* ── NEW from stable-4-july-2025 ───────────────────────────── */
   /* crop window corner “L” handles */
   .sel-overlay.crop-window .handle.corner {


### PR DESCRIPTION
## Summary
- show a rotation bubble during object transforms
- hide the rotation bubble when transformations end
- style the rotation bubble just like the size bubble

## Testing
- `npm run lint` *(fails: React Hooks rules and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868275a2a5c8323be165cbc43748e0d