### PR TITLE
Fix crop overlay flicker

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1138,8 +1138,8 @@ const syncSel = () => {
       selEl._object = frame
       selEl.classList.add('crop-window')
       if (cropEl) {
-        cropEl.style.display = 'block'
         drawOverlay(img, cropEl)
+        cropEl.style.display = 'block'
         cropEl._object = img
         cropEl.classList.remove('crop-window')
       }
@@ -1148,8 +1148,8 @@ const syncSel = () => {
       selEl._object = img
       selEl.classList.remove('crop-window')
       if (cropEl) {
-        cropEl.style.display = 'block'
         drawOverlay(frame, cropEl)
+        cropEl.style.display = 'block'
         cropEl._object = frame
         cropEl.classList.add('crop-window')
       }


### PR DESCRIPTION
## Summary
- avoid showing crop overlay before it is positioned

## Testing
- `pre-commit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68683617ebc08323b0b285b9ce61bc24