### PR TITLE
Fix overlay sync before showing

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1167,10 +1167,15 @@ const syncSel = () => {
   cropEl && cropEl.classList.remove('crop-window')
 
 cropEl && (cropEl.style.display = 'none', cropEl._object = null);
-if (!obj) return;
+if (!obj) {
+  selEl.style.display = 'none'
+  return
+}
 
+selEl.style.display = 'none'
 const box = drawOverlay(obj, selEl);   // redraw green outline
 selEl._object = obj;
+selEl.style.display = 'block'
 
 /* ── quick-action overlay ──────────────────────────── */
 if (transformingRef.current) {


### PR DESCRIPTION
## Summary
- hide selection overlay if no object is active
- when drawing overlay ensure it is hidden, coordinates are computed, then shown

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686837d6955883238435f3dbcb94391c