### PR TITLE
Fix overlay flash during crop/transform

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1327,6 +1327,10 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      selDomRef.current && (selDomRef.current.style.display = 'none')
+      if (croppingRef.current && cropDomRef.current) {
+        cropDomRef.current.style.display = 'none'
+      }
       actionTimerRef.current = window.setTimeout(() => {
         requestAnimationFrame(() => requestAnimationFrame(syncSel))
       }, 250)
@@ -1338,6 +1342,10 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      selDomRef.current && (selDomRef.current.style.display = 'none')
+      if (croppingRef.current && cropDomRef.current) {
+        cropDomRef.current.style.display = 'none'
+      }
       actionTimerRef.current = window.setTimeout(syncSel, 250)
     }
     hideSizeBubble()


### PR DESCRIPTION
## Summary
- hide selection and crop overlays before scheduling `syncSel` on transform complete

## Testing
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*

------
https://chatgpt.com/codex/tasks/task_e_68683839baac8323a12fd261d9926831