### PR TITLE
Fix outline flash

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1241,11 +1241,12 @@ const hideRotBubble = () => {
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
+  // draw the overlay before making it visible to avoid a brief jump
+  syncSel()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
   }
-  syncSel()
   requestAnimationFrame(syncSel)
   scrollHandler = () => {
     fc.calcOffset()


### PR DESCRIPTION
## Summary
- keep Fabric selection overlay hidden until its position is synced

## Testing
- `npm run lint` *(fails: React hooks rule errors)*

------
https://chatgpt.com/codex/tasks/task_e_68683d146d088323a6e5547fc122c149