### PR TITLE
Fix overlay sync glitch

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1325,12 +1325,15 @@ fc.on('object:moving', () => {
   .on('object:modified', () => {
     if (transformingRef.current) {
       transformingRef.current = false
-      setActionPos(null)
-      if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(() => {
-        requestAnimationFrame(() => requestAnimationFrame(syncSel))
-      }, 250)
     }
+    setActionPos(null)
+    if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+    // Keep the outline aligned by syncing right away and again
+    // after Fabric settles the final bounding box.
+    syncSel()
+    actionTimerRef.current = window.setTimeout(() => {
+      requestAnimationFrame(() => requestAnimationFrame(syncSel))
+    }, 250)
     hideRotBubble()
   })
   .on('mouse:up', () => {


### PR DESCRIPTION
## Summary
- keep selection overlay in sync when transforming stops

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68683d146d088323a6e5547fc122c149