### PR TITLE
Fix selection overlay staying in sync during edits

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1327,21 +1327,19 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(() => {
-        requestAnimationFrame(() => requestAnimationFrame(syncSel))
-      }, 250)
     }
     hideRotBubble()
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
   .on('mouse:up', () => {
     if (transformingRef.current) {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(syncSel, 250)
     }
     hideSizeBubble()
     hideRotBubble()
+    requestAnimationFrame(syncSel)
   })
   .on('after:render',    handleAfterRender)
 

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1245,8 +1245,7 @@ fc.on('selection:created', () => {
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
   }
-  syncSel()
-  requestAnimationFrame(syncSel)
+  requestAnimationFrame(() => requestAnimationFrame(syncSel))
   scrollHandler = () => {
     fc.calcOffset()
     syncSel()
@@ -1256,7 +1255,9 @@ fc.on('selection:created', () => {
   window.addEventListener('resize', scrollHandler)
   containerRef.current?.addEventListener('scroll', scrollHandler, { passive: true, capture: true })
 })
-  .on('selection:updated', syncSel)
+  .on('selection:updated', () =>
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
+  )
 .on('selection:cleared', () => {
   if (scrollHandler) {
     window.removeEventListener('scroll', scrollHandler);


### PR DESCRIPTION
## Summary
- ensure selection overlay updates immediately after finishing a transform
- update mouseup handler accordingly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68683d146d088323a6e5547fc122c149