### PR TITLE
Move rotation handle to bottom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -115,7 +115,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const ROT_OFF = 40
+const ROT_OFF = 32
 const SEL_BORDER = 2
 
 recompute()
@@ -668,6 +668,10 @@ useEffect(() => {
         ? 'handle rot'
         : `handle ${['ml','mr','mt','mb'].includes(c) ? 'side' : 'corner'} ${c}`;
     h.dataset.corner = c === 'rot' ? 'mtr' : c;
+    if (c === 'rot') {
+      h.innerHTML =
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>';
+    }
     selEl.appendChild(h);
     handleMap[c] = h;
   });
@@ -1114,7 +1118,7 @@ const drawOverlay = (
     h.mb.style.top   = `${botY}px`
     if (h.rot) {
       h.rot.style.left = `${midX}px`
-      h.rot.style.top  = `${Math.round(topY - ROT_OFF)}px`
+      h.rot.style.top  = `${Math.round(botY + ROT_OFF)}px`
     }
   }
   return { left, top, width, height }

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,7 +139,21 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
-  .sel-overlay .handle.rot { cursor:grab; }
+  .sel-overlay .handle.rot {
+    width:27px;
+    height:27px;
+    cursor:grab;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    color:#666;
+  }
+
+  .sel-overlay .handle.rot svg {
+    width:16px;
+    height:16px;
+    pointer-events:none;
+  }
 
   /* ── NEW from stable-3-july-2025 ───────────────────────────── */
   .size-bubble {

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -18,6 +18,8 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).transparentCorners= true;
 (fabric.Object.prototype as any).hasBorders        = false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
+(fabric.Object.prototype as any).controls.mtr.y       = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = 32;
 
 /* ───────────────── helpers ──────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- reposition rotation handle below the object
- offset fabric's built-in rotation control accordingly
- decrease rotation handle distance and enlarge handle size
- add a rotation icon in the HTML handle

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686834ddf50c832391be58a2d6f42c9a