### PR TITLE
Move rotation handle to bottom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -115,7 +115,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const ROT_OFF = 40
+const ROT_OFF = 32
 const SEL_BORDER = 2
 
 recompute()
@@ -1114,7 +1114,7 @@ const drawOverlay = (
     h.mb.style.top   = `${botY}px`
     if (h.rot) {
       h.rot.style.left = `${midX}px`
-      h.rot.style.top  = `${Math.round(topY - ROT_OFF)}px`
+      h.rot.style.top  = `${Math.round(botY + ROT_OFF)}px`
     }
   }
   return { left, top, width, height }

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,7 +139,23 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
-  .sel-overlay .handle.rot { cursor:grab; }
+  .sel-overlay .handle.rot {
+    width:27px;
+    height:27px;
+    cursor:grab;
+    position:relative;
+  }
+  .sel-overlay .handle.rot::before {
+    content:'';
+    position:absolute;
+    top:50%;
+    left:50%;
+    width:16px;
+    height:16px;
+    transform:translate(-50%,-50%);
+    background:url('/rotate.svg') center/contain no-repeat;
+    pointer-events:none;
+  }
 
   /* ── NEW from stable-3-july-2025 ───────────────────────────── */
   .size-bubble {

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -18,6 +18,8 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).transparentCorners= true;
 (fabric.Object.prototype as any).hasBorders        = false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
+(fabric.Object.prototype as any).controls.mtr.y       = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = 32;
 
 /* ───────────────── helpers ──────────────────────────────── */
 

--- a/public/rotate.svg
+++ b/public/rotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <path d="M12 4V1m0 0L9 3.5M12 1v3A5 5 0 1 1 3 8" stroke="#666" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- reposition rotation handle below the object
- offset fabric's built-in rotation control accordingly
- decrease rotation handle distance and enlarge handle size
- add rotation icon inside the handle

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686834ddf50c832391be58a2d6f42c9a