### PR TITLE
Fix selection overlay staying in sync during edits

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1327,21 +1327,19 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(() => {
-        requestAnimationFrame(() => requestAnimationFrame(syncSel))
-      }, 250)
     }
     hideRotBubble()
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
   .on('mouse:up', () => {
     if (transformingRef.current) {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(syncSel, 250)
     }
     hideSizeBubble()
     hideRotBubble()
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
   .on('after:render',    handleAfterRender)
 


### PR DESCRIPTION
## Summary
- ensure selection overlay updates immediately after finishing a transform
- update mouseup handler accordingly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68683d146d088323a6e5547fc122c149