### PR TITLE
Move rotation handle to bottom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -115,7 +115,7 @@ let PAGE_H = 0
 let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 0
-const ROT_OFF = 40
+const ROT_OFF = 32
 const SEL_BORDER = 2
 
 recompute()
@@ -1114,7 +1114,7 @@ const drawOverlay = (
     h.mb.style.top   = `${botY}px`
     if (h.rot) {
       h.rot.style.left = `${midX}px`
-      h.rot.style.top  = `${Math.round(topY - ROT_OFF)}px`
+      h.rot.style.top  = `${Math.round(botY + ROT_OFF)}px`
     }
   }
   return { left, top, width, height }

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,7 +139,18 @@ html {
   .sel-overlay .handle.mr { cursor:ew-resize; }
   .sel-overlay .handle.mt,
   .sel-overlay .handle.mb { cursor:ns-resize; }
-  .sel-overlay .handle.rot { cursor:grab; }
+  .sel-overlay .handle.rot {
+    width:27px;
+    height:27px;
+    cursor:grab;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    background-image:url('/icons/rotate.svg');
+    background-repeat:no-repeat;
+    background-position:center;
+    background-size:16px;
+  }
 
   /* ── NEW from stable-3-july-2025 ───────────────────────────── */
   .size-bubble {

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -18,6 +18,8 @@ export const HANDLE_BLUR   = 1 / SCALE;
 (fabric.Object.prototype as any).transparentCorners= true;
 (fabric.Object.prototype as any).hasBorders        = false;
 (fabric.Object.prototype as any).cornerStyle       = 'circle';
+(fabric.Object.prototype as any).controls.mtr.y       = 0.5;
+(fabric.Object.prototype as any).controls.mtr.offsetY = 32;
 
 /* ───────────────── helpers ──────────────────────────────── */
 

--- a/public/icons/rotate.svg
+++ b/public/icons/rotate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#555" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="23 4 23 10 17 10" />
+  <path d="M20.49 15a9 9 0 1 1 2.12-9.36" />
+</svg>


### PR DESCRIPTION
## Summary
- reposition rotation handle below the object
- offset fabric's built-in rotation control accordingly
- decrease rotation handle distance and enlarge handle size
- add rotation icon inside the handle
- fix rotation icon graphic

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686834ddf50c832391be58a2d6f42c9a