### PR TITLE
Fix selection overlay staying in sync during edits

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1329,19 +1329,28 @@ fc.on('object:moving', () => {
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
       actionTimerRef.current = window.setTimeout(() => {
         requestAnimationFrame(() => requestAnimationFrame(syncSel))
-      }, 250)
+      }, 200)
+      hideRotBubble()
+      return
     }
     hideRotBubble()
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
   .on('mouse:up', () => {
     if (transformingRef.current) {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(syncSel, 250)
+      actionTimerRef.current = window.setTimeout(() => {
+        requestAnimationFrame(() => requestAnimationFrame(syncSel))
+      }, 200)
+      hideSizeBubble()
+      hideRotBubble()
+      return
     }
     hideSizeBubble()
     hideRotBubble()
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
   })
   .on('after:render',    handleAfterRender)
 


### PR DESCRIPTION
## Summary
- delay QuickActionBar update 200ms after finishing a transform

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68683d146d088323a6e5547fc122c149