### PR TITLE
Fix selection overlay jitter

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1241,12 +1241,13 @@ const hideRotBubble = () => {
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
+  // Position overlays before revealing them to avoid a brief jump to (0,0)
+  syncSel()
+  requestAnimationFrame(syncSel)
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
   }
-  syncSel()
-  requestAnimationFrame(syncSel)
   scrollHandler = () => {
     fc.calcOffset()
     syncSel()


### PR DESCRIPTION
## Summary
- adjust selection creation handler to set overlay position before displaying it

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868493a7c508323aae95fc13da4d0c0