### PR TITLE
Fix selection outline flicker

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1241,11 +1241,12 @@ const hideRotBubble = () => {
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
+  syncSel()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
   }
-  syncSel()
+  hoverDomRef.current && (hoverDomRef.current.style.display = 'none')
   requestAnimationFrame(syncSel)
   scrollHandler = () => {
     fc.calcOffset()


### PR DESCRIPTION
## Summary
- ensure selection overlay is positioned before becoming visible
- hide hover overlay when an object is selected

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868493a7c508323aae95fc13da4d0c0