### PR TITLE
Fix outline reposition glitch

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1241,11 +1241,11 @@ const hideRotBubble = () => {
 fc.on('selection:created', () => {
   hoverHL.visible = false
   fc.requestRenderAll()
+  syncSel()
   selDomRef.current && (selDomRef.current.style.display = 'block')
   if (croppingRef.current && cropDomRef.current) {
     cropDomRef.current.style.display = 'block'
   }
-  syncSel()
   requestAnimationFrame(syncSel)
   scrollHandler = () => {
     fc.calcOffset()
@@ -1287,6 +1287,7 @@ fc.on('object:moving', () => {
     actionTimerRef.current = null;
   }
   syncSel();
+  requestAnimationFrame(syncSel);
   hideSizeBubble();                  // moving never shows the bubble
   hideRotBubble();
 })
@@ -1299,6 +1300,7 @@ fc.on('object:moving', () => {
     actionTimerRef.current = null;
   }
   syncSel();
+  requestAnimationFrame(syncSel);
   showSizeBubble(e.target as fabric.Object, e);   // live size read-out
   hideRotBubble();
 })
@@ -1311,6 +1313,7 @@ fc.on('object:moving', () => {
     actionTimerRef.current = null;
   }
   syncSel();
+  requestAnimationFrame(syncSel);
   hideSizeBubble();                  // hide during rotation
   showRotBubble(e.target as fabric.Object, e);
 })


### PR DESCRIPTION
## Summary
- ensure selection outline is positioned before showing it
- keep outline synced during transforms

## Testing
- `npm run lint` *(fails: React hook rule violations and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868493a7c508323aae95fc13da4d0c0