### PR TITLE
Fix selection overlay jump

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1322,7 +1322,8 @@ fc.on('object:moving', () => {
   requestAnimationFrame(() => requestAnimationFrame(syncSel));
 })
 
-  .on('object:modified', () => {
+.on('object:modified', () => {
+    syncSel() // ensure overlay hugs the element immediately
     if (transformingRef.current) {
       transformingRef.current = false
       setActionPos(null)
@@ -1334,6 +1335,7 @@ fc.on('object:moving', () => {
     hideRotBubble()
   })
   .on('mouse:up', () => {
+    syncSel() // refresh overlay after drag/crop release
     if (transformingRef.current) {
       transformingRef.current = false
       setActionPos(null)


### PR DESCRIPTION
## Summary
- keep the selection overlay aligned when objects are changed

## Testing
- `npm run lint` *(fails: React hook and lint errors)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68684bf0c820832394bf2f965d7be4c4