### PR TITLE
Fix selection overlay position

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1327,9 +1327,13 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      requestAnimationFrame(() => requestAnimationFrame(syncSel))
       actionTimerRef.current = window.setTimeout(() => {
-        requestAnimationFrame(() => requestAnimationFrame(syncSel))
+        /* keep quick actions delayed */
+        requestAnimationFrame(syncSel)
       }, 250)
+    } else {
+      requestAnimationFrame(() => requestAnimationFrame(syncSel))
     }
     hideRotBubble()
   })
@@ -1338,7 +1342,10 @@ fc.on('object:moving', () => {
       transformingRef.current = false
       setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+      requestAnimationFrame(() => requestAnimationFrame(syncSel))
       actionTimerRef.current = window.setTimeout(syncSel, 250)
+    } else {
+      requestAnimationFrame(() => requestAnimationFrame(syncSel))
     }
     hideSizeBubble()
     hideRotBubble()


### PR DESCRIPTION
## Summary
- ensure selection overlay syncs immediately on mouseup or modify

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68684bf0c820832394bf2f965d7be4c4