### PR TITLE
Fix overlay position

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1322,24 +1322,22 @@ fc.on('object:moving', () => {
   requestAnimationFrame(() => requestAnimationFrame(syncSel));
 })
 
-  .on('object:modified', () => {
-    if (transformingRef.current) {
-      transformingRef.current = false
-      setActionPos(null)
-      if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(() => {
-        requestAnimationFrame(() => requestAnimationFrame(syncSel))
-      }, 250)
-    }
-    hideRotBubble()
-  })
+.on('object:modified', () => {
+  if (transformingRef.current) {
+    transformingRef.current = false
+    if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
+    actionTimerRef.current = null
+  }
+  requestAnimationFrame(() => requestAnimationFrame(syncSel))
+  hideRotBubble()
+})
   .on('mouse:up', () => {
     if (transformingRef.current) {
       transformingRef.current = false
-      setActionPos(null)
       if (actionTimerRef.current) clearTimeout(actionTimerRef.current)
-      actionTimerRef.current = window.setTimeout(syncSel, 250)
+      actionTimerRef.current = null
     }
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
     hideSizeBubble()
     hideRotBubble()
   })


### PR DESCRIPTION
## Summary
- ensure selection overlay stays aligned after editing
- stop clearing quick action position on release

## Testing
- `npm run lint` *(fails: React hook and unescaped entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_68684bf0c820832394bf2f965d7be4c4