### PR TITLE
Fix quick action flash on drag

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -745,11 +745,23 @@ useEffect(() => {
   const onSelDown = (e: PointerEvent) => {
     const obj = (selEl as any)._object as fabric.Object | null
     if (obj) fc.setActiveObject(obj)
+    if (actionTimerRef.current) {
+      clearTimeout(actionTimerRef.current)
+      actionTimerRef.current = null
+    }
+    transformingRef.current = true
+    setActionPos(null)
     bridge(e)
   }
   const onCropDown = (e: PointerEvent) => {
     const obj = (cropEl as any)._object as fabric.Object | null
     if (obj) fc.setActiveObject(obj)
+    if (actionTimerRef.current) {
+      clearTimeout(actionTimerRef.current)
+      actionTimerRef.current = null
+    }
+    transformingRef.current = true
+    setActionPos(null)
     bridge(e)
   }
   selEl.addEventListener('pointerdown', onSelDown)


### PR DESCRIPTION
## Summary
- clear pending timers and hide quick action bar immediately when the selection or crop overlay is pressed

## Testing
- `npm run lint` *(fails: react hooks and other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_686858d407a88323bf526d6a521ad007