### PR TITLE
Fix overlay flashing during transform

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1068,6 +1068,7 @@ const drawOverlay = (
     _object?: fabric.Object | null
   }
 ) => {
+  obj.setCoords()
   const box  = obj.getBoundingRect(true, true)
   const rect = canvasRef.current!.getBoundingClientRect()
   const vt   = fc.viewportTransform || [1, 0, 0, 1, 0, 0]


### PR DESCRIPTION
## Summary
- refresh Fabric coordinates before computing overlay

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686858d407a88323bf526d6a521ad007