### PR TITLE
Fix selection overlay flash during transforms

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1068,6 +1068,7 @@ const drawOverlay = (
     _object?: fabric.Object | null
   }
 ) => {
+  fc.calcOffset()
   const box  = obj.getBoundingRect(true, true)
   const rect = canvasRef.current!.getBoundingClientRect()
   const vt   = fc.viewportTransform || [1, 0, 0, 1, 0, 0]


### PR DESCRIPTION
## Summary
- update drawOverlay to recalc canvas offset before measuring

## Testing
- `npm run lint`
- `npm run build` *(fails: React hook and JSX lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686858d407a88323bf526d6a521ad007