### PR TITLE
Enable selection drag from outside canvas

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -751,6 +751,19 @@ const handleProofAll = async () => {
     }
   }, [activeFc, handleZoomIn, handleZoomOut, setZoomSmooth])
 
+  const forward = (ev: PointerEvent | MouseEvent) => ({
+    clientX   : ev.clientX,
+    clientY   : ev.clientY,
+    button    : ev.button,
+    buttons   : 'buttons' in ev ? (ev as any).buttons : 0,
+    ctrlKey   : ev.ctrlKey,
+    shiftKey  : ev.shiftKey,
+    altKey    : ev.altKey,
+    metaKey   : ev.metaKey,
+    bubbles   : true,
+    cancelable: true,
+  })
+
   /* 8 ─ loader guard --------------------------------------------- */
   if (pages.length !== 4) {
     return (
@@ -855,10 +868,24 @@ const handleProofAll = async () => {
             className={`flex-1 flex justify-center items-start bg-[--walty-cream] pt-6 gap-6 ${
               isCropMode ? 'overflow-visible' : 'overflow-auto'
             }`}
-            onMouseDown={e => {
+            onPointerDown={e => {
               if (e.target === e.currentTarget && activeFc) {
                 activeFc.discardActiveObject();
                 activeFc.requestRenderAll();
+                const canvas = (activeFc as any).upperCanvasEl as HTMLCanvasElement | undefined
+                if (canvas) {
+                  const down = new MouseEvent('mousedown', forward(e.nativeEvent))
+                  canvas.dispatchEvent(down)
+                  const move = (ev: PointerEvent) =>
+                    canvas.dispatchEvent(new MouseEvent('mousemove', forward(ev)))
+                  const up = (ev: PointerEvent) => {
+                    canvas.dispatchEvent(new MouseEvent('mouseup', forward(ev)))
+                    document.removeEventListener('pointermove', move)
+                    document.removeEventListener('pointerup', up)
+                  }
+                  document.addEventListener('pointermove', move)
+                  document.addEventListener('pointerup', up)
+                }
               }
             }}
           >


### PR DESCRIPTION
## Summary
- forward pointer events to Fabric canvas when clicking the stage background
- allow drag-selection to start outside canvas

## Testing
- `npm run lint` *(fails: React Hook order errors, unescaped entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68685a3d95e083239a6061b3f12926e8