### PR TITLE
Allow selection start from outside canvas

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -855,11 +855,38 @@ const handleProofAll = async () => {
             className={`flex-1 flex justify-center items-start bg-[--walty-cream] pt-6 gap-6 ${
               isCropMode ? 'overflow-visible' : 'overflow-auto'
             }`}
-            onMouseDown={e => {
-              if (e.target === e.currentTarget && activeFc) {
-                activeFc.discardActiveObject();
-                activeFc.requestRenderAll();
-              }
+            onPointerDown={e => {
+              if (e.target !== e.currentTarget || !activeFc) return;
+              activeFc.discardActiveObject();
+              activeFc.requestRenderAll();
+              const forward = (ev: PointerEvent | MouseEvent) => ({
+                clientX   : ev.clientX,
+                clientY   : ev.clientY,
+                button    : ev.button,
+                buttons   : 'buttons' in ev ? ev.buttons : 0,
+                ctrlKey   : ev.ctrlKey,
+                shiftKey  : ev.shiftKey,
+                altKey    : ev.altKey,
+                metaKey   : ev.metaKey,
+                bubbles   : true,
+                cancelable: true,
+              });
+              const down = new MouseEvent('mousedown', forward(e.nativeEvent));
+              (activeFc as any).upperCanvasEl.dispatchEvent(down);
+              const move = (ev: PointerEvent) =>
+                (activeFc as any).upperCanvasEl.dispatchEvent(
+                  new MouseEvent('mousemove', forward(ev)),
+                );
+              const up = (ev: PointerEvent) => {
+                (activeFc as any).upperCanvasEl.dispatchEvent(
+                  new MouseEvent('mouseup', forward(ev)),
+                );
+                document.removeEventListener('pointermove', move);
+                document.removeEventListener('pointerup', up);
+              };
+              document.addEventListener('pointermove', move);
+              document.addEventListener('pointerup', up);
+              e.preventDefault();
             }}
           >
             


### PR DESCRIPTION
## Summary
- enable pointer interactions in CardEditor background to clear selection and forward events to canvas

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68685a3d95e083239a6061b3f12926e8