### PR TITLE
enable drag selection from editor background

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -631,6 +631,45 @@ const handleProofAll = async () => {
   URL.revokeObjectURL(url)
 }
 
+  /* helper ─ forward pointer events from the surrounding area */
+  const handleBgPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget || !activeFc) return
+    activeFc.discardActiveObject()
+    activeFc.requestRenderAll()
+
+    const forward = (ev: PointerEvent | MouseEvent) => ({
+      clientX   : ev.clientX,
+      clientY   : ev.clientY,
+      button    : ev.button,
+      buttons   : 'buttons' in ev ? (ev as any).buttons : 0,
+      ctrlKey   : ev.ctrlKey,
+      shiftKey  : ev.shiftKey,
+      altKey    : ev.altKey,
+      metaKey   : ev.metaKey,
+      bubbles   : true,
+      cancelable: true,
+    })
+
+    activeFc.upperCanvasEl.dispatchEvent(
+      new MouseEvent('mousedown', forward(e.nativeEvent))
+    )
+
+    const move = (ev: PointerEvent) =>
+      activeFc.upperCanvasEl.dispatchEvent(
+        new MouseEvent('mousemove', forward(ev))
+      )
+    const up = (ev: PointerEvent) => {
+      activeFc.upperCanvasEl.dispatchEvent(
+        new MouseEvent('mouseup', forward(ev))
+      )
+      document.removeEventListener('pointermove', move)
+      document.removeEventListener('pointerup', up)
+    }
+    document.addEventListener('pointermove', move)
+    document.addEventListener('pointerup', up)
+    e.preventDefault()
+  }
+
   /* 7 ─ coach-mark ----------------------------------------------- */
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [anchor, setAnchor] = useState<DOMRect | null>(null)
@@ -855,12 +894,7 @@ const handleProofAll = async () => {
             className={`flex-1 flex justify-center items-start bg-[--walty-cream] pt-6 gap-6 ${
               isCropMode ? 'overflow-visible' : 'overflow-auto'
             }`}
-            onMouseDown={e => {
-              if (e.target === e.currentTarget && activeFc) {
-                activeFc.discardActiveObject();
-                activeFc.requestRenderAll();
-              }
-            }}
+            onPointerDown={handleBgPointerDown}
           >
             
             {/* front */}


### PR DESCRIPTION
## Summary
- forward pointer events from the editor background to the active Fabric canvas
- clear the selection when starting a drag from outside the canvas

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68685e68143c8323ae124484f6d9575a