### PR TITLE
Enable drag selections from canvas background

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -49,6 +49,20 @@ const EMPTY: TemplatePage[] = [
   { name: 'back'   , layers: [] },
 ]
 
+/* mirror a PointerEvent/MouseEvent so we can forward it */
+const mirrorPointer = (ev: PointerEvent | MouseEvent) => ({
+  clientX: ev.clientX,
+  clientY: ev.clientY,
+  button: ev.button,
+  buttons: 'buttons' in ev ? (ev as any).buttons : 0,
+  ctrlKey: ev.ctrlKey,
+  shiftKey: ev.shiftKey,
+  altKey: ev.altKey,
+  metaKey: ev.metaKey,
+  bubbles: true,
+  cancelable: true,
+})
+
 /* ---------- tiny coach-mark component ------------------------------ */
 function CoachMark({ anchor, onClose }: { anchor: DOMRect | null; onClose: () => void }) {
   if (!anchor) return null
@@ -183,6 +197,36 @@ export default function CardEditor({
     })
     setActiveIdx(idx)
   }
+
+  const handleBgPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const fc = activeFc
+    if (!fc) return
+    if (e.target !== e.currentTarget) return
+    fc.discardActiveObject()
+    fc.requestRenderAll()
+
+    const el = fc.upperCanvasEl
+    const rect = el.getBoundingClientRect()
+    const clamp = (v: number, min: number, max: number) =>
+      Math.max(min, Math.min(max, v))
+    const props = mirrorPointer(e.nativeEvent)
+    const down = new MouseEvent('mousedown', {
+      ...props,
+      clientX: clamp(e.clientX, rect.left + 1, rect.right - 1),
+      clientY: clamp(e.clientY, rect.top + 1, rect.bottom - 1),
+    })
+    el.dispatchEvent(down)
+    const move = (ev: PointerEvent) =>
+      el.dispatchEvent(new MouseEvent('mousemove', mirrorPointer(ev)))
+    const up = (ev: PointerEvent) => {
+      el.dispatchEvent(new MouseEvent('mouseup', mirrorPointer(ev)))
+      document.removeEventListener('pointermove', move)
+      document.removeEventListener('pointerup', up)
+    }
+    document.addEventListener('pointermove', move)
+    document.addEventListener('pointerup', up)
+    e.preventDefault()
+  }, [activeFc])
 
   const [thumbs, setThumbs] = useState<string[]>(['', '', '', ''])
 
@@ -855,12 +899,7 @@ const handleProofAll = async () => {
             className={`flex-1 flex justify-center items-start bg-[--walty-cream] pt-6 gap-6 ${
               isCropMode ? 'overflow-visible' : 'overflow-auto'
             }`}
-            onMouseDown={e => {
-              if (e.target === e.currentTarget && activeFc) {
-                activeFc.discardActiveObject();
-                activeFc.requestRenderAll();
-              }
-            }}
+            onPointerDown={handleBgPointerDown}
           >
             
             {/* front */}


### PR DESCRIPTION
## Summary
- forward pointer events from the editor background to the Fabric canvas
- clamp synthetic mousedown start to inside the canvas so group selection begins correctly

## Testing
- `npm run lint` *(fails: various existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68685e68143c8323ae124484f6d9575a