### PR TITLE
Enable drag selections from canvas background

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -49,6 +49,20 @@ const EMPTY: TemplatePage[] = [
   { name: 'back'   , layers: [] },
 ]
 
+/* clone a PointerEvent/MouseEvent so we can forward it */
+const mirrorPointer = (ev: PointerEvent | MouseEvent) => ({
+  clientX   : ev.clientX,
+  clientY   : ev.clientY,
+  button    : ev.button,
+  buttons   : 'buttons' in ev ? ev.buttons : 0,
+  ctrlKey   : ev.ctrlKey,
+  shiftKey  : ev.shiftKey,
+  altKey    : ev.altKey,
+  metaKey   : ev.metaKey,
+  bubbles   : true,
+  cancelable: true,
+})
+
 /* ---------- tiny coach-mark component ------------------------------ */
 function CoachMark({ anchor, onClose }: { anchor: DOMRect | null; onClose: () => void }) {
   if (!anchor) return null
@@ -183,6 +197,29 @@ export default function CardEditor({
     })
     setActiveIdx(idx)
   }
+
+  const handleBgPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const fc = activeFc
+    if (!fc) return
+    if (e.target !== e.currentTarget) return
+    fc.discardActiveObject()
+    fc.calcOffset()
+    fc.requestRenderAll()
+
+    const el = fc.upperCanvasEl
+    const down = new MouseEvent('mousedown', mirrorPointer(e.nativeEvent))
+    el.dispatchEvent(down)
+    const move = (ev: PointerEvent) =>
+      el.dispatchEvent(new MouseEvent('mousemove', mirrorPointer(ev)))
+    const up = (ev: PointerEvent) => {
+      el.dispatchEvent(new MouseEvent('mouseup', mirrorPointer(ev)))
+      document.removeEventListener('pointermove', move)
+      document.removeEventListener('pointerup', up)
+    }
+    document.addEventListener('pointermove', move)
+    document.addEventListener('pointerup', up)
+    e.preventDefault()
+  }, [activeFc])
 
   const [thumbs, setThumbs] = useState<string[]>(['', '', '', ''])
 
@@ -855,12 +892,7 @@ const handleProofAll = async () => {
             className={`flex-1 flex justify-center items-start bg-[--walty-cream] pt-6 gap-6 ${
               isCropMode ? 'overflow-visible' : 'overflow-auto'
             }`}
-            onMouseDown={e => {
-              if (e.target === e.currentTarget && activeFc) {
-                activeFc.discardActiveObject();
-                activeFc.requestRenderAll();
-              }
-            }}
+            onPointerDown={handleBgPointerDown}
           >
             
             {/* front */}


### PR DESCRIPTION
## Summary
- clone pointer event properties when forwarding to Fabric
- update canvas offset before synthetic drag events

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68685e68143c8323ae124484f6d9575a