### PR TITLE
Improve Layer Panel UI

### DIFF
--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -11,6 +11,8 @@ import {
   useSensor,
   useSensors,
   DragEndEvent,
+  DragStartEvent,
+  DragOverEvent,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -18,26 +20,28 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import {
-  Type,
-  Upload as UploadIcon,
-  Trash2,
-  GripVertical,
-} from "lucide-react";
+import { Type, Upload as UploadIcon, Trash2, GripVertical } from "lucide-react";
 import { useEditor } from "./EditorStore";
 
 /*────────────────────────────    Sortable row    ──*/
-function Row({ id, idx }: { id: string; idx: number }) {
+function Row({
+  id,
+  idx,
+  activeId,
+  overId,
+  layerOrder,
+}: {
+  id: string;
+  idx: number;
+  activeId?: string | null;
+  overId?: string | null;
+  layerOrder: number[];
+}) {
   const layer = useEditor((s) => s.pages[s.activePage]?.layers[idx]);
   const remove = useEditor((s) => s.deleteLayer);
 
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-  } = useSortable({ id });
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id });
 
   const style: React.CSSProperties = {
     transform: CSS.Translate.toString(transform),
@@ -46,13 +50,23 @@ function Row({ id, idx }: { id: string; idx: number }) {
 
   if (!layer) return null;
 
+  const activePos = activeId != null ? layerOrder.indexOf(+activeId) : -1;
+  const overPos = overId != null ? layerOrder.indexOf(+overId) : -1;
+  const showTop = overId === id && activePos > overPos;
+  const showBottom = overId === id && activePos < overPos;
+
   return (
     <li
       ref={setNodeRef}
       style={style}
-      className="group flex h-14 items-center gap-2 rounded-lg border-2 border-walty-teal/40 px-2 text-sm hover:bg-walty-orange/10"
-
+      className="relative group flex h-14 items-center gap-2 rounded-lg border-2 border-walty-teal/40 px-2 text-sm hover:bg-walty-orange/10"
     >
+      {showTop && (
+        <div className="pointer-events-none absolute inset-x-0 top-0 border-t-2 border-walty-teal" />
+      )}
+      {showBottom && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 border-t-2 border-walty-teal" />
+      )}
       {/* drag handle */}
       <button
         {...listeners}
@@ -63,33 +77,31 @@ function Row({ id, idx }: { id: string; idx: number }) {
       </button>
 
       {/* name / preview */}
-      <span
-        className="flex-1 truncate"
-        style={
-          layer.type === 'text'
-            ? {
-                fontFamily: layer.fontFamily,
-                fontWeight: layer.fontWeight as React.CSSProperties['fontWeight'],
-                fontStyle: layer.fontStyle as React.CSSProperties['fontStyle'],
-                textDecoration: layer.underline ? 'underline' : undefined,
-                color: layer.fill,
-                textAlign: layer.textAlign as React.CSSProperties['textAlign'],
-              }
-            : undefined
-        }
-      >
-        {layer.type === 'text' ? (
-          (layer.text ?? 'text').slice(0, 20)
+      <span className="flex-1 flex justify-center">
+        {layer.type === "text" ? (
+          <span
+            className="truncate text-center"
+            style={{
+              fontFamily: layer.fontFamily,
+              fontWeight: layer.fontWeight as React.CSSProperties["fontWeight"],
+              fontStyle: layer.fontStyle as React.CSSProperties["fontStyle"],
+              textDecoration: layer.underline ? "underline" : undefined,
+              color: layer.fill,
+              textAlign: layer.textAlign as React.CSSProperties["textAlign"],
+            }}
+          >
+            {(layer.text ?? "text").slice(0, 20)}
+          </span>
         ) : (
           <img
             src={
               layer.srcUrl ||
-              (typeof layer.src === 'string' ? layer.src : undefined)
+              (typeof layer.src === "string" ? layer.src : undefined)
             }
             alt="layer"
             width={48}
             height={48}
-            className="inline-block h-12 w-12 rounded object-cover"
+            className="mx-auto h-12 w-12 rounded object-cover"
           />
         )}
       </span>
@@ -113,28 +125,43 @@ export default function LayerPanel() {
   const addText = useEditor((s) => s.addText);
   const [open, setOpen] = useState(true);
 
-  if (!pages[activePage]) return null;
-  const layerOrder = pages[activePage].layers.map((_, i) => pages[activePage].layers.length - 1 - i);
-  const ids = layerOrder.map(i => i.toString());
-
   /* drag‑and‑drop */
   const sensors = useSensors(useSensor(PointerSensor));
-  const onDragEnd = (e: DragEndEvent) => {
-    if (e.over && e.active.id !== e.over.id)
-      reorder(+e.active.id, +e.over.id);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+
+  const onDragStart = (e: DragStartEvent) => {
+    setActiveId(e.active.id as string);
   };
 
+  const onDragOver = (e: DragOverEvent) => {
+    setOverId(e.over?.id as string | null);
+  };
+
+  const onDragEnd = (e: DragEndEvent) => {
+    setActiveId(null);
+    setOverId(null);
+    if (e.over && e.active.id !== e.over.id) reorder(+e.active.id, +e.over.id);
+  };
+
+  if (!pages[activePage]) return null;
+  const layerOrder = pages[activePage].layers.map(
+    (_, i) => pages[activePage].layers.length - 1 - i,
+  );
+  const ids = layerOrder.map((i) => i.toString());
+
   return (
-        <aside
-        className={`fixed left-0 z-20
+    <aside
+      className={`fixed left-0 z-20
                       w-54 sm:w-60 md:w-64 lg:w-70 xl:w-74
                       rounded-r-2xl bg-white shadow-xl ring-2 ring-walty-teal/40
                       transition-transform duration-300
                       ${open ? "translate-x-0" : "-translate-x-full"}`}
-        style={{ top: "var(--walty-header-h)", height: "calc(100vh - var(--walty-header-h))" }}
-        >
-
-
+      style={{
+        top: "var(--walty-header-h)",
+        height: "calc(100vh - var(--walty-header-h))",
+      }}
+    >
       {/* upload */}
       <label className="m-4 flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-walty-teal/50 p-4 text-walty-teal hover:bg-walty-orange/5">
         <UploadIcon className="h-8 w-8" />
@@ -163,11 +190,23 @@ export default function LayerPanel() {
       </div>
 
       {/* layer list */}
-      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+      <DndContext
+        sensors={sensors}
+        onDragStart={onDragStart}
+        onDragOver={onDragOver}
+        onDragEnd={onDragEnd}
+      >
         <SortableContext items={ids} strategy={verticalListSortingStrategy}>
           <ul className="scrollbar-hidden flex h-[calc(100%-330px)] flex-col gap-1 overflow-y-auto px-4 pb-6">
             {layerOrder.map((idx) => (
-              <Row key={idx} id={idx.toString()} idx={idx} />
+              <Row
+                key={idx}
+                id={idx.toString()}
+                idx={idx}
+                activeId={activeId}
+                overId={overId}
+                layerOrder={layerOrder}
+              />
             ))}
           </ul>
         </SortableContext>


### PR DESCRIPTION
## Summary
- center thumbnails in the layer list
- show solid line when reordering layers

## Testing
- `npm run lint` *(fails: various warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_686862a87208832390ea160807b8ff4b