### PR TITLE
Fix selection overlay offset

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1121,6 +1121,8 @@ const drawOverlay = (
 }
 
 const syncSel = () => {
+  // keep Fabric's notion of the canvas position in sync
+  fc.calcOffset()
   const obj = fc.getActiveObject() as fabric.Object | undefined
   if (!selDomRef.current || !canvasRef.current) return
   const selEl  = selDomRef.current as HTMLDivElement & { _handles?: Record<string, HTMLDivElement>; _object?: fabric.Object | null }


### PR DESCRIPTION
## Summary
- keep Fabric offsets synced when recalculating the DOM selection overlay

## Testing
- `npm run lint` *(fails: react-hooks and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868f1eebca883239148ed48234dbef8