### PR TITLE
Fix selection outline jumping during transforms

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1286,7 +1286,7 @@ fc.on('object:moving', () => {
     clearTimeout(actionTimerRef.current);
     actionTimerRef.current = null;
   }
-  syncSel();
+  requestAnimationFrame(syncSel);
   hideSizeBubble();                  // moving never shows the bubble
   hideRotBubble();
 })
@@ -1298,7 +1298,7 @@ fc.on('object:moving', () => {
     clearTimeout(actionTimerRef.current);
     actionTimerRef.current = null;
   }
-  syncSel();
+  requestAnimationFrame(syncSel);
   showSizeBubble(e.target as fabric.Object, e);   // live size read-out
   hideRotBubble();
 })
@@ -1310,7 +1310,7 @@ fc.on('object:moving', () => {
     clearTimeout(actionTimerRef.current);
     actionTimerRef.current = null;
   }
-  syncSel();
+  requestAnimationFrame(syncSel);
   hideSizeBubble();                  // hide during rotation
   showRotBubble(e.target as fabric.Object, e);
 })


### PR DESCRIPTION
## Summary
- fix unstable selection overlay while moving or transforming objects in the card editor

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6868f1eebca883239148ed48234dbef8