### PR TITLE
Improve layer sidebar reordering feedback

### DIFF
--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -37,6 +37,10 @@ function Row({ id, idx }: { id: string; idx: number }) {
     setNodeRef,
     transform,
     transition,
+    isOver,
+    isDragging,
+    index,
+    newIndex,
   } = useSortable({ id });
 
   const style: React.CSSProperties = {
@@ -44,15 +48,27 @@ function Row({ id, idx }: { id: string; idx: number }) {
     transition,
   };
 
+  const total = useEditor((s) => s.pages[s.activePage]?.layers.length || 0);
+  const showGuide = isOver && !isDragging;
+  const dropBefore =
+    showGuide && newIndex === index && newIndex > 0;
+  const dropAfter =
+    showGuide && newIndex === index + 1 && newIndex < total;
+
   if (!layer) return null;
 
   return (
     <li
       ref={setNodeRef}
       style={style}
-      className="group flex h-14 items-center gap-2 rounded-lg border-2 border-walty-teal/40 px-2 text-sm hover:bg-walty-orange/10"
-
+      className="relative group flex h-14 items-center gap-2 rounded-lg border-2 border-walty-teal/40 px-2 text-sm hover:bg-walty-orange/10"
     >
+      {dropBefore && (
+        <div className="pointer-events-none absolute inset-x-0 -top-7 h-1 bg-walty-orange" />
+      )}
+      {dropAfter && (
+        <div className="pointer-events-none absolute inset-x-0 -bottom-7 h-1 bg-walty-orange" />
+      )}
       {/* drag handle */}
       <button
         {...listeners}
@@ -64,7 +80,7 @@ function Row({ id, idx }: { id: string; idx: number }) {
 
       {/* name / preview */}
       <span
-        className="flex-1 truncate"
+        className="flex-1 truncate text-center"
         style={
           layer.type === 'text'
             ? {
@@ -89,7 +105,7 @@ function Row({ id, idx }: { id: string; idx: number }) {
             alt="layer"
             width={48}
             height={48}
-            className="inline-block h-12 w-12 rounded object-cover"
+            className="inline-block h-12 w-12 rounded object-cover mx-auto"
           />
         )}
       </span>


### PR DESCRIPTION
## Summary
- center thumbnails in the layer panel
- show a thicker guide line centered between layers during reordering
- hide the line when dragging to the top or bottom position

## Testing
- `npm run lint` *(fails: React hooks rules and other lint errors)*
- `npm run build` *(fails to compile due to existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686862a87208832390ea160807b8ff4b