### PR TITLE
Fix selection outline jumping during transforms

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1275,8 +1275,10 @@ fc.on('selection:created', () => {
 /* also hide hover during any transform of the active object */
 const handleAfterRender = () => {
   fc.calcOffset()
-  syncSel()
-  syncHover()
+  requestAnimationFrame(() => {
+    syncSel()
+    syncHover()
+  })
 }
 
 fc.on('object:moving', () => {
@@ -1286,7 +1288,7 @@ fc.on('object:moving', () => {
     clearTimeout(actionTimerRef.current);
     actionTimerRef.current = null;
   }
-  syncSel();
+  requestAnimationFrame(syncSel);
   hideSizeBubble();                  // moving never shows the bubble
   hideRotBubble();
 })
@@ -1298,7 +1300,7 @@ fc.on('object:moving', () => {
     clearTimeout(actionTimerRef.current);
     actionTimerRef.current = null;
   }
-  syncSel();
+  requestAnimationFrame(syncSel);
   showSizeBubble(e.target as fabric.Object, e);   // live size read-out
   hideRotBubble();
 })
@@ -1310,7 +1312,7 @@ fc.on('object:moving', () => {
     clearTimeout(actionTimerRef.current);
     actionTimerRef.current = null;
   }
-  syncSel();
+  requestAnimationFrame(syncSel);
   hideSizeBubble();                  // hide during rotation
   showRotBubble(e.target as fabric.Object, e);
 })


### PR DESCRIPTION
## Summary
- fix unstable selection overlay while moving or transforming objects in the card editor

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868f1eebca883239148ed48234dbef8