### PR TITLE
Enable deselect from page background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -161,6 +161,11 @@ html {
     @apply fixed text-white text-xs px-2 py-1 rounded-md bg-neutral-800/90 whitespace-nowrap pointer-events-none;
   }
 
+  /* marquee for multi-select starting outside canvas */
+  .drag-box {
+    @apply fixed pointer-events-none z-30 border-2 border-dashed border-[--walty-teal] bg-[--walty-teal]/10;
+  }
+
   /* ── NEW from stable-4-july-2025 ───────────────────────────── */
   /* crop window corner “L” handles */
   .sel-overlay.crop-window .handle.corner {


### PR DESCRIPTION
## Summary
- improve card editor by listening for pointer events on the page
- forward outside drags to the active Fabric canvas to allow multi-select
- show marquee outside canvas bounds

## Testing
- `npm run lint` *(fails: React Hook issues etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868fac08b488323a2cc47ac4ca31578