### PR TITLE
Fix zoom shortcuts when selection active

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -718,8 +718,6 @@ const handleProofAll = async () => {
   }, [])
 
   useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
     const wheel = (e: WheelEvent) => {
       if (e.ctrlKey || e.metaKey || e.altKey) {
         const fc = activeFc
@@ -744,10 +742,10 @@ const handleProofAll = async () => {
         }
       }
     }
-    el.addEventListener('wheel', wheel, { passive: false })
+    window.addEventListener('wheel', wheel, { passive: false })
     window.addEventListener('keydown', key)
     return () => {
-      el.removeEventListener('wheel', wheel)
+      window.removeEventListener('wheel', wheel)
       window.removeEventListener('keydown', key)
     }
   }, [activeFc, handleZoomIn, handleZoomOut, setZoomSmooth])


### PR DESCRIPTION
## Summary
- ensure wheel zoom listener works even when overlays are outside the editor container

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869040cfb8c83239e562e4f4b43dc24