### PR TITLE
Fix crop cancel zoom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1625,7 +1625,12 @@ window.addEventListener('keydown', onKey)
     canvas.style.height = `${PREVIEW_H * zoom}px`
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
-    if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
+    if (cropToolRef.current) {
+      (cropToolRef.current as any).SCALE = SCALE * zoom
+      if (cropToolRef.current.isActive) {
+        cropToolRef.current.updateBase()
+      }
+    }
     fc.requestRenderAll()
   }, [zoom])
 

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -55,6 +55,22 @@ export class CropTool {
     }
   }
 
+  /** Update stored canvas/base dimensions when zoom changes */
+  public updateBase () {
+    this.baseW = this.fc.getWidth()
+    this.baseH = this.fc.getHeight()
+    const wrapper = (this.fc as any).wrapperEl as HTMLElement | undefined
+    if (wrapper) {
+      this.wrapStyles = {
+        w:  wrapper.style.width,
+        h:  wrapper.style.height,
+        mw: wrapper.style.maxWidth,
+        mh: wrapper.style.maxHeight,
+        transform: wrapper.style.transform,
+      }
+    }
+  }
+
   /* ─────────────── public API ──────────────────────────────────── */
   public begin (img: fabric.Image) {
     if (this.isActive) return


### PR DESCRIPTION
## Summary
- keep CropTool canvas metadata updated when zoom changes
- ensure canvas dimensions restore properly on crop cancel

## Testing
- `npm run lint` *(fails: React hooks rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_686905e82c6883238faad6be583428e9