### PR TITLE
Fix canvas size after canceling crop

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1625,7 +1625,10 @@ window.addEventListener('keydown', onKey)
     canvas.style.height = `${PREVIEW_H * zoom}px`
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
-    if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
+    if (cropToolRef.current) {
+      (cropToolRef.current as any).SCALE = SCALE * zoom
+      ;(cropToolRef.current as any).syncSize?.()
+    }
     fc.requestRenderAll()
   }, [zoom])
 

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -34,6 +34,27 @@ export class CropTool {
   /** clean‑up callbacks to run on `teardown()` */
   private cleanup: Array<() => void> = [];
 
+  /**
+   * Update stored canvas dimensions while cropping is active.
+   * Called when the parent component changes zoom so we can
+   * restore the correct size on cancel.
+   */
+  public syncSize () {
+    if (!this.isActive) return;
+    this.baseW = this.fc.getWidth();
+    this.baseH = this.fc.getHeight();
+    const wrapper = (this.fc as any).wrapperEl as HTMLElement | undefined;
+    if (wrapper && this.wrapStyles) {
+      this.wrapStyles = {
+        w : wrapper.style.width,
+        h : wrapper.style.height,
+        mw: wrapper.style.maxWidth,
+        mh: wrapper.style.maxHeight,
+        transform: wrapper.style.transform,
+      };
+    }
+  }
+
   constructor (fc: fabric.Canvas, scale: number, selColour: string,
                onChange?: (state: boolean) => void) {
     this.fc      = fc


### PR DESCRIPTION
## Summary
- ensure crop tool records canvas size changes when zooming
- sync crop tool when zoom changes

## Testing
- `npm run lint`
- `npm run build` *(fails: react-hooks/rules-of-hooks and others)*

------
https://chatgpt.com/codex/tasks/task_e_686905e82c6883238faad6be583428e9