### PR TITLE
Fix crop-tool canvas size after zoom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1625,7 +1625,12 @@ window.addEventListener('keydown', onKey)
     canvas.style.height = `${PREVIEW_H * zoom}px`
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
-    if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
+    if (cropToolRef.current) {
+      (cropToolRef.current as any).SCALE = SCALE * zoom
+      if (cropToolRef.current.isActive) {
+        cropToolRef.current.updateBase?.()
+      }
+    }
     fc.requestRenderAll()
   }, [zoom])
 

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -34,6 +34,25 @@ export class CropTool {
   /** clean‑up callbacks to run on `teardown()` */
   private cleanup: Array<() => void> = [];
 
+  /** Update the stored base canvas size and wrapper styles */
+  public updateBase () {
+    this.baseW = this.fc.getWidth();
+    this.baseH = this.fc.getHeight();
+    const wrap = (this.fc as any).wrapperEl as HTMLElement | undefined;
+    if (wrap) {
+      this.wrapper = wrap;
+      this.scrollLeft = wrap.scrollLeft;
+      this.scrollTop  = wrap.scrollTop;
+      this.wrapStyles = {
+        w: wrap.style.width,
+        h: wrap.style.height,
+        mw: wrap.style.maxWidth,
+        mh: wrap.style.maxHeight,
+        transform: wrap.style.transform,
+      };
+    }
+  }
+
   constructor (fc: fabric.Canvas, scale: number, selColour: string,
                onChange?: (state: boolean) => void) {
     this.fc      = fc


### PR DESCRIPTION
## Summary
- track canvas wrapper dimensions in CropTool via `updateBase`
- refresh CropTool base data on zoom to keep cancel behaviour stable

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_686905e82c6883238faad6be583428e9