### PR TITLE
Fix crop handles after committing crop

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -22,6 +22,8 @@ export class CropTool {
   private ratio: number | null = null
   /** original bitmap state before cropping */
   private orig: { left:number; top:number; cropX:number; cropY:number; width:number; height:number; } | null = null;
+  /** store control visibility so it can be restored */
+  private prevControls: Record<string, boolean> | null = null;
   /** canvas size before cropping */
   private baseW = 0;
   private baseH = 0;
@@ -172,6 +174,14 @@ export class CropTool {
       img.hasBorders      = prevHasBorders
     })
     /* hide the rotate ("mtr") and side controls while cropping */
+    const vis = (img as any)._controlsVisibility || {}
+    this.prevControls = {
+      mtr: vis.mtr ?? true,
+      ml : vis.ml  ?? true,
+      mr : vis.mr  ?? true,
+      mt : vis.mt  ?? true,
+      mb : vis.mb  ?? true,
+    }
     img.setControlsVisibility({
       mtr: false,          // hide rotation
       ml : false, mr : false,      // hide middle-left / middle-right
@@ -775,6 +785,10 @@ export class CropTool {
     if (ctx) this.fc.clearContext(ctx)
 
     if (this.img) {
+      if (this.prevControls) {
+        this.img.setControlsVisibility(this.prevControls)
+        this.prevControls = null
+      }
       this.img.lockMovementX = false
       this.img.lockMovementY = false
       // allow free resizing again


### PR DESCRIPTION
## Summary
- store previous control visibility when entering crop mode
- restore control visibility after crop ends

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686905216bfc8323a976130bfd4661de