### PR TITLE
Fix crop handles resetting

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -166,10 +166,12 @@ export class CropTool {
         wrapper.style.maxHeight = `${needH}px`
       }
     }
+    const prevControls = { ...img.controlsVisibility }
     this.cleanup.push(() => {
       img.lockUniScaling  = prevLockUniScaling
       img.centeredScaling = prevCenteredScaling
       img.hasBorders      = prevHasBorders
+      img.setControlsVisibility(prevControls)
     })
     /* hide the rotate ("mtr") and side controls while cropping */
     img.setControlsVisibility({


### PR DESCRIPTION
## Summary
- restore Fabric.js control visibility after crop operations

## Testing
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*
- `npm run build` *(fails: Failed to compile due to lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686905216bfc8323a976130bfd4661de