### PR TITLE
Fix lock button behavior

### DIFF
--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -111,9 +111,13 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : !next,
+      evented      : !next,
+      hasControls  : !next,
     });
     fc.requestRenderAll();
     updateLayer(activePage, (img as any).layerIdx, { locked: next });
+    force({});
   };
 
   /* layer order helpers */

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -124,9 +124,13 @@ export default function TextToolbar (props: Props) {
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : !next,
+      evented      : !next,
+      hasControls  : !next,
     })
     fc.requestRenderAll()
     updateLayer(activePage, (tb as any).layerIdx, { locked: next })
+    force({})
   }
 
   const sendBackward = () => {


### PR DESCRIPTION
## Summary
- lock/unlock should prevent any object editing and reflect state immediately
- add selectable, evented and hasControls locking when toggling
- force toolbar re-render after locking

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68691149af788323a3c2be7d23aa9e83