### PR TITLE
Fix layer locking in editor

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -370,7 +370,7 @@ useEffect(() => {
     const fc = canvasMap[activeIdx]
     if (!fc) return
     const obj = fc.getActiveObject() as any
-    if (!obj || obj.type !== 'image') return
+    if (!obj || obj.type !== 'image' || obj.locked) return
     const tool = (fc as any)._cropTool as CropTool | undefined
     if (tool && !tool.isActive) {
       tool.begin(obj)

--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -260,6 +260,11 @@ export const useEditor = create<EditorState>((set, get) => ({
   /* drag-to-reorder in LayerPanel --------------------------------- */
   reorder: (from, to) => {
     const { activePage, pages, pushHistory } = get()
+    const currentLayers = pages[activePage]?.layers ?? []
+    const fromLayer = currentLayers[from]
+    const toLayer   = currentLayers[to]
+    if (fromLayer?.locked || toLayer?.locked) return
+
     const nextPages = clone(pages)
     const [moved]   = nextPages[activePage].layers.splice(from, 1)
     nextPages[activePage].layers.splice(to, 0, moved)

--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -271,6 +271,8 @@ export const useEditor = create<EditorState>((set, get) => ({
   /* delete layer (sidebar OR ⌫ key) ------------------------------- */
   deleteLayer: idx => {
     const { activePage, pages, pushHistory } = get()
+    const layer = pages[activePage]?.layers[idx]
+    if (layer?.locked) return
     const nextPages = clone(pages)
     nextPages[activePage].layers.splice(idx, 1)
 

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -331,6 +331,7 @@ const objToLayer = (o: fabric.Object): Layer => {
       scaleX    : t.scaleX,
       scaleY    : t.scaleY,
       lines     : t.textLines as string[],
+      locked    : (t as any).locked,
     }
   }
   const i = o as fabric.Image
@@ -357,6 +358,7 @@ const objToLayer = (o: fabric.Object): Layer => {
     scaleY : i.scaleY,
     flipX  : (i as any).flipX,
     flipY  : (i as any).flipY,
+    locked : (i as any).locked,
   }
 
   if (i.cropX != null) layer.cropX = i.cropX
@@ -507,13 +509,36 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
   const setPageLayers = useEditor(s => s.setPageLayers)
   const updateLayer   = useEditor(s => s.updateLayer)
 
+  const toggleActiveLock = () => {
+    const fc = fcRef.current
+    if (!fc) return
+    const active = fc.getActiveObject() as fabric.Object | undefined
+    if (!active) return
+    const locked = !!(active as any).locked
+    const next = !locked
+    ;(active as any).locked = next
+    active.set({
+      lockMovementX: next,
+      lockMovementY: next,
+      lockScalingX : next,
+      lockScalingY : next,
+      lockRotation : next,
+    })
+    fc.requestRenderAll()
+    if ((active as any).layerIdx !== undefined) {
+      updateLayer(pageIdx, (active as any).layerIdx, { locked: next })
+    }
+    setActionPos(pos => (pos ? { ...pos } : null))
+  }
+
   const handleMenuAction = (a: import('./ContextMenu').MenuAction) => {
     const fc = fcRef.current
     if (!fc) return
     const active = fc.getActiveObject() as fabric.Object | undefined
+    const locked = (active as any)?.locked
     switch (a) {
       case 'cut':
-        if (active) {
+        if (active && !locked) {
           clip.json = [active.toJSON(PROPS)]
           clip.nudge = 0
           allObjs(active).forEach(o => fc.remove(o))
@@ -550,7 +575,7 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
         }
         break
       case 'duplicate':
-        if (active) {
+        if (active && !locked) {
           clip.json = [active.toJSON(PROPS)]
           clip.nudge += 10
           fabric.util.enlivenObjects(clip.json, (objs: fabric.Object[]) => {
@@ -614,13 +639,15 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
         }
         break
       case 'delete':
-        if (active) {
+        if (active && !locked) {
           allObjs(active).forEach(o => fc.remove(o))
           syncLayersFromCanvas(fc, pageIdx)
         }
         break
       case 'crop':
-        document.dispatchEvent(new Event('start-crop'))
+        if (active && !locked) {
+          document.dispatchEvent(new Event('start-crop'))
+        }
         break
     }
     setMenuPos(null)
@@ -863,7 +890,7 @@ if (container) {
   // double‑click on an <image> starts cropping
   const dblHandler = (e: fabric.IEvent) => {
     const tgt = e.target as fabric.Object | undefined;
-    if (tgt && (tgt as any).type === 'image') {
+    if (tgt && (tgt as any).type === 'image' && !(tgt as any).locked) {
       cropToolRef.current?.begin(tgt as fabric.Image);
     }
   };
@@ -1238,7 +1265,27 @@ const hideRotBubble = () => {
   if (bubble) bubble.style.display = 'none'
 }
 
+const filterLockedSelection = () => {
+  const act = fc.getActiveObject() as fabric.Object | undefined
+  if (act && (act as any).type === 'activeSelection') {
+    const as = act as fabric.ActiveSelection
+    const objs = as.getObjects()
+    const unlocked = objs.filter(o => !(o as any).locked)
+    if (unlocked.length !== objs.length) {
+      fc.discardActiveObject()
+      if (unlocked.length === 1) {
+        fc.setActiveObject(unlocked[0])
+      } else if (unlocked.length > 1) {
+        const sel = new fabric.ActiveSelection(unlocked, { canvas: fc } as any)
+        fc.setActiveObject(sel)
+      }
+      fc.requestRenderAll()
+    }
+  }
+}
+
 fc.on('selection:created', () => {
+  filterLockedSelection()
   hoverHL.visible = false
   fc.requestRenderAll()
   selDomRef.current && (selDomRef.current.style.display = 'block')
@@ -1256,8 +1303,8 @@ fc.on('selection:created', () => {
   window.addEventListener('resize', scrollHandler)
   containerRef.current?.addEventListener('scroll', scrollHandler, { passive: true, capture: true })
 })
-  .on('selection:updated', syncSel)
-.on('selection:cleared', () => {
+  .on('selection:updated', () => { filterLockedSelection(); syncSel() })
+  .on('selection:cleared', () => {
   if (scrollHandler) {
     window.removeEventListener('scroll', scrollHandler);
     window.removeEventListener('resize', scrollHandler);
@@ -1460,6 +1507,7 @@ const onKey = (e: KeyboardEvent) => {
   if (useEditor.getState().activePage !== pageIdx) return
   const active = fc.getActiveObject() as fabric.Object | undefined
   const cmd    = e.metaKey || e.ctrlKey
+  const locked = (active as any)?.locked
 
   /* —— COPY ————————————————————————————————————— */
   if (cmd && e.code === 'KeyC' && active) {
@@ -1470,7 +1518,7 @@ const onKey = (e: KeyboardEvent) => {
   }
 
   /* —— CUT —————————————————————————————————————— */
-  if (cmd && e.code === 'KeyX' && active) {
+  if (cmd && e.code === 'KeyX' && active && !locked) {
     clip.json  = [(active).toJSON(PROPS)]
     clip.nudge = 0
 
@@ -1517,7 +1565,7 @@ const onKey = (e: KeyboardEvent) => {
   }
 
   /* —— DELETE ——————————————————————————————————— */
-  if (!cmd && (e.code === 'Delete' || e.code === 'Backspace') && active) {
+  if (!cmd && (e.code === 'Delete' || e.code === 'Backspace') && active && !locked) {
     allObjs(active).forEach(o => fc.remove(o))
     syncLayersFromCanvas(fc, pageIdx)
     e.preventDefault()
@@ -1636,7 +1684,7 @@ window.addEventListener('keydown', onKey)
 
     if (isCropping && !croppingRef.current) {
       const act = fc.getActiveObject() as fabric.Object | undefined
-      if (act && (act as any).type === 'image') {
+      if (act && (act as any).type === 'image' && !(act as any).locked) {
         document.dispatchEvent(new Event('start-crop'))
       }
     }
@@ -1710,6 +1758,17 @@ if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
             flipX     : ly.flipX ?? false,
             flipY     : ly.flipY ?? false,
           })
+
+          ;(img as any).locked = ly.locked
+          if (ly.locked) {
+            img.set({
+              lockMovementX: true,
+              lockMovementY: true,
+              lockScalingX : true,
+              lockScalingY : true,
+              lockRotation : true,
+            })
+          }
 
           /* ---------- AI placeholder extras -------------------------------- */
           let doSync: (() => void) | undefined
@@ -1816,12 +1875,22 @@ doSync = () =>
           fill: hex(ly.fill ?? '#000'),
           textAlign: ly.textAlign ?? 'left',
           lineHeight: ly.lineHeight ?? 1.16,
-          opacity: ly.opacity ?? 1,
-          selectable: ly.selectable ?? true,
-          editable: ly.editable ?? true,
-          scaleX: ly.scaleX ?? 1, scaleY: ly.scaleY ?? 1,
-          lockScalingFlip: true,
-        })
+      opacity: ly.opacity ?? 1,
+      selectable: ly.selectable ?? true,
+      editable: ly.editable ?? true,
+      scaleX: ly.scaleX ?? 1, scaleY: ly.scaleY ?? 1,
+      lockScalingFlip: true,
+    })
+        ;(tb as any).locked = ly.locked
+        if (ly.locked) {
+          tb.set({
+            lockMovementX: true,
+            lockMovementY: true,
+            lockScalingX : true,
+            lockScalingY : true,
+            lockRotation : true,
+          })
+        }
         ;(tb as any).layerIdx = idx
         fc.insertAt(tb, idx, false)
       }
@@ -1852,6 +1921,8 @@ doSync = () =>
         pos={actionPos}
         onAction={handleMenuAction}
         onMenu={p => setMenuPos(p)}
+        locked={Boolean(fcRef.current?.getActiveObject() && (fcRef.current!.getActiveObject() as any).locked)}
+        onUnlock={toggleActiveLock}
       />
       {menuPos && (
         <ContextMenu

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -79,6 +79,7 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
 
   /* helper: mutate + refresh */
   const mutate = (p: Partial<fabric.Image>) => {
+    if (locked) return
     img.set(p).setCoords();
     fc.setActiveObject(img);
     fc.requestRenderAll();
@@ -118,16 +119,19 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
 
   /* layer order helpers */
   const sendBackward = () => {
+    if (locked) return
     const idx = (img as any).layerIdx ?? 0;
     if (idx < layerCount - 1) reorder(idx, idx + 1);
   };
   const bringForward = () => {
+    if (locked) return
     const idx = (img as any).layerIdx ?? 0;
     if (idx > 0 && idx <= layerCount - 1) reorder(idx, idx - 1);
   };
 
   /* remove active image */
   const deleteCurrent = () => {
+    if (locked) return
     fc.remove(img);
     fc.requestRenderAll();
   };
@@ -148,16 +152,16 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
                    bg-white shadow-lg rounded-xl
                    border border-[rgba(0,91,85,.2)] px-4 py-3 max-w-[720px] w-[calc(100%-6rem)]"
       >
-        <IconButton Icon={Crop} label="Crop" onClick={() => document.dispatchEvent(new Event("start-crop"))} />
-        <ToolFlipImage img={img} mutate={mutate} />
-        <ToolOpacitySlider img={img} mutate={mutate} />
-        <IconButton Icon={AlignToPageVertical}   label="Center vertical" caption="Center Y" onClick={cycleVertical} />
-        <IconButton Icon={AlignToPageHorizontal} label="Center horizontal" caption="Center X" onClick={cycleHorizontal} />
-        <IconButton Icon={Eraser} label="Remove background" caption="BG Erase" onClick={() => alert("TODO: remove background") } />
+        <IconButton Icon={Crop} label="Crop" onClick={() => document.dispatchEvent(new Event("start-crop"))} disabled={locked} />
+        <ToolFlipImage img={img} mutate={mutate} disabled={locked} />
+        <ToolOpacitySlider img={img} mutate={mutate} disabled={locked} />
+        <IconButton Icon={AlignToPageVertical}   label="Center vertical" caption="Center Y" onClick={cycleVertical} disabled={locked} />
+        <IconButton Icon={AlignToPageHorizontal} label="Center horizontal" caption="Center X" onClick={cycleHorizontal} disabled={locked} />
+        <IconButton Icon={Eraser} label="Remove background" caption="BG Erase" onClick={() => alert("TODO: remove background") } disabled={locked} />
         <IconButton Icon={locked ? Lock : Unlock} label={locked ? "Unlock layer" : "Lock layer"} active={locked} onClick={toggleLock} />
-        <IconButton Icon={ArrowDownToLine} label="Send backward" caption="Send ↓" onClick={sendBackward} />
-        <IconButton Icon={ArrowUpToLine}   label="Bring forward" caption="Bring ↑" onClick={bringForward} />
-        <IconButton Icon={Trash2} label="Delete image" caption="Delete" onClick={deleteCurrent} />
+        <IconButton Icon={ArrowDownToLine} label="Send backward" caption="Send ↓" onClick={sendBackward} disabled={locked} />
+        <IconButton Icon={ArrowUpToLine}   label="Bring forward" caption="Bring ↑" onClick={bringForward} disabled={locked} />
+        <IconButton Icon={Trash2} label="Delete image" caption="Delete" onClick={deleteCurrent} disabled={locked} />
       </div>
 
     </div>

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -50,7 +50,7 @@ function Row({
     isDragging,
     index,
     newIndex,
-  } = useSortable({ id });
+  } = useSortable({ id, disabled: layer?.locked });
 
   const style: React.CSSProperties = {
     transform: CSS.Translate.toString(transform),
@@ -83,9 +83,10 @@ function Row({
       )}
       {/* drag handle */}
       <button
-        {...listeners}
+        {...(!layer.locked ? listeners : {})}
         {...attributes}
-        className="cursor-grab text-walty-teal hover:text-walty-orange"
+        disabled={layer.locked}
+        className="text-walty-teal hover:text-walty-orange disabled:opacity-40 disabled:cursor-not-allowed"
       >
         <GripVertical className="h-4 w-4" />
       </button>
@@ -150,10 +151,17 @@ export default function LayerPanel() {
   /* drag‑and‑drop */
   const sensors = useSensors(useSensor(PointerSensor));
   const onDragEnd = (e: DragEndEvent) => {
-    if (e.over && e.active.id !== e.over.id)
-      reorder(+e.active.id, +e.over.id);
-    setDropIndex(null);
-  };
+    if (e.over && e.active.id !== e.over.id) {
+      const fromIdx = +e.active.id
+      const toIdx   = +e.over.id
+      const fromLayer = pages[activePage].layers[fromIdx]
+      const toLayer   = pages[activePage].layers[toIdx]
+      if (!fromLayer.locked && !toLayer.locked) {
+        reorder(fromIdx, toIdx)
+      }
+    }
+    setDropIndex(null)
+  }
 
   return (
         <aside

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -124,8 +124,9 @@ function Row({
 
       {/* delete */}
       <button
-        onClick={() => remove(idx)}
-        className="opacity-0 transition-opacity group-hover:opacity-100 text-walty-teal hover:text-walty-orange"
+        onClick={() => !layer.locked && remove(idx)}
+        disabled={layer.locked}
+        className="opacity-0 transition-opacity group-hover:opacity-100 text-walty-teal hover:text-walty-orange disabled:opacity-40"
       >
         <Trash2 className="h-4 w-4" />
       </button>

--- a/app/components/QuickActionBar.tsx
+++ b/app/components/QuickActionBar.tsx
@@ -1,14 +1,23 @@
 import React from 'react'
-import { Scissors, Copy, CopyPlus, Trash2, MoreHorizontal } from 'lucide-react'
+import {
+  Scissors,
+  Copy,
+  CopyPlus,
+  Trash2,
+  MoreHorizontal,
+  Lock,
+} from 'lucide-react'
 import type { MenuAction } from './ContextMenu'
 
 interface Props {
   pos: { x: number; y: number } | null
   onAction: (a: MenuAction) => void
   onMenu: (pos: { x: number; y: number }) => void
+  locked?: boolean
+  onUnlock?: () => void
 }
 
-export default function QuickActionBar({ pos, onAction, onMenu }: Props) {
+export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock }: Props) {
   if (!pos) return null
 
   const openMenu = (e: React.MouseEvent) => {
@@ -21,12 +30,32 @@ export default function QuickActionBar({ pos, onAction, onMenu }: Props) {
       type="button"
       aria-label={label}
       title={label}
+      disabled={locked && !!action && (action === 'cut' || action === 'duplicate' || action === 'delete')}
       onClick={action ? () => onAction(action) : openMenu}
-      className="h-8 w-8 flex items-center justify-center -ml-px first:ml-0 rounded-lg text-[--walty-teal] enabled:hover:bg-[--walty-orange]/10 enabled:hover:text-[--walty-orange] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+      className="h-8 w-8 flex items-center justify-center -ml-px first:ml-0 rounded-lg text-[--walty-teal] enabled:hover:bg-[--walty-orange]/10 enabled:hover:text-[--walty-orange] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50 disabled:opacity-40"
     >
       <Icon className="w-5 h-5" />
     </button>
   )
+
+  if (locked) {
+    return (
+      <div
+        className="fixed z-50 pointer-events-auto flex items-center bg-white border border-[rgba(0,91,85,.2)] shadow-lg rounded-full p-0"
+        style={{ top: pos.y, left: pos.x, transform: 'translate(-50%, -100%)' }}
+      >
+        <button
+          type="button"
+          aria-label="Unlock layer"
+          title="Unlock layer"
+          onClick={onUnlock}
+          className="h-8 w-8 flex items-center justify-center ml-0 rounded-lg text-[--walty-teal] hover:bg-[--walty-orange]/10 hover:text-[--walty-orange] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+        >
+          <Lock className="w-5 h-5" />
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -130,10 +130,12 @@ export default function TextToolbar (props: Props) {
   }
 
   const sendBackward = () => {
+    if (locked) return
     const idx = (tb as any).layerIdx ?? 0
     if (idx < layerCount - 1) reorder(idx, idx + 1)
   }
   const bringForward = () => {
+    if (locked) return
     const idx = (tb as any).layerIdx ?? 0
     if (idx > 0 && idx <= layerCount - 1) reorder(idx, idx - 1)
   }
@@ -142,7 +144,7 @@ export default function TextToolbar (props: Props) {
   /* 6.  mutate helper – keeps focus & fires Fabric events              */
   /* ------------------------------------------------------------------ */
   const mutate = (p: Partial<fabric.Textbox>) => {
-    if (!tb) return
+    if (!tb || locked) return
     tb.set(p); tb.setCoords()
     fc.setActiveObject(tb); fc.requestRenderAll()
     tb.fire('modified'); fc.fire('object:modified', { target: tb })
@@ -172,18 +174,18 @@ export default function TextToolbar (props: Props) {
         >
           {/* ───────── Font family & size (no captions) ───────── */}
           <FontFamilySelect
-            disabled={!tb}
+            disabled={!tb || locked}
             value={tb?.fontFamily ?? 'Arial'}
             onChange={(v: string) => mutate({ fontFamily: v })}
           />
           <FontSizeStepper
-            disabled={!tb}
+            disabled={!tb || locked}
             value={tb?.fontSize ?? 12}
             onChange={(v: number) => mutate({ fontSize: v })}
           />
 
           {/* colour picker */}
-          <ToolTextColorPicker tb={tb} canvas={fc} mutate={mutate} />
+          <ToolTextColorPicker tb={tb} canvas={fc} mutate={mutate} disabled={locked} />
 
           {/* centre on page */}
           <IconButton 
@@ -191,14 +193,14 @@ export default function TextToolbar (props: Props) {
             label="Center vertical"
             caption="Center Y"
             onClick={cycleVertical}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
           <IconButton 
             Icon={AlignToPageHorizontal}
             label="Center horizontal"
             caption="Center X"
             onClick={cycleHorizontal}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
 
           {/* lock / unlock */}
@@ -207,7 +209,7 @@ export default function TextToolbar (props: Props) {
             label={locked ? 'Unlock layer' : 'Lock layer'}
             active={locked}
             onClick={toggleLock}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
 
           {/* send backward / bring forward */}
@@ -216,14 +218,14 @@ export default function TextToolbar (props: Props) {
             label="Send backward"
             caption="Send ↓"
             onClick={sendBackward}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
           <IconButton 
             Icon={ArrowUpToLine}
             label="Bring forward"
             caption="Bring ↑"
             onClick={bringForward}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
 
           {/* B / I / U */}
@@ -233,7 +235,7 @@ export default function TextToolbar (props: Props) {
             onClick={() =>
               mutate({ fontWeight: tb!.fontWeight === 'bold' ? 'normal' : 'bold' })}
             active={tb?.fontWeight === 'bold'}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
           <IconButton 
             Icon={Italic}
@@ -241,14 +243,14 @@ export default function TextToolbar (props: Props) {
             onClick={() =>
               mutate({ fontStyle: tb!.fontStyle === 'italic' ? 'normal' : 'italic' })}
             active={tb?.fontStyle === 'italic'}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
           <IconButton 
             Icon={Underline}
             label="Underline"
             onClick={() => mutate({ underline: !tb!.underline })}
             active={!!tb?.underline}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
 
           {/* text-case cycle */}
@@ -275,7 +277,7 @@ export default function TextToolbar (props: Props) {
                 setCaseState('upper')
               }
             }}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
 
           {/* align cycle */}
@@ -291,12 +293,12 @@ export default function TextToolbar (props: Props) {
             }
             label="Align"
             onClick={cycleAlign}
-            disabled={!tb}
+            disabled={!tb || locked}
           />
 
           {/* line-height input */}
           <input
-            disabled={!tb}
+            disabled={!tb || locked}
             type="number"
             step={0.1}
             min={0.5}
@@ -312,7 +314,7 @@ export default function TextToolbar (props: Props) {
           />
 
           {/* opacity slider */}
-          <ToolTextOpacitySlider tb={tb} mutate={mutate} />
+          <ToolTextOpacitySlider tb={tb} mutate={mutate} disabled={locked} />
 
         </div>
       )}

--- a/app/components/toolbar/ToolFlipImage.tsx
+++ b/app/components/toolbar/ToolFlipImage.tsx
@@ -12,9 +12,10 @@ import { MirrorH, MirrorV } from "./icons";      // export them from one place
 interface Props {
   img: fabric.Image;
   mutate: (p: Partial<fabric.Image>) => void;
+  disabled?: boolean;
 }
 
-export default function ToolFlipImage({ img, mutate }: Props) {
+export default function ToolFlipImage({ img, mutate, disabled }: Props) {
   const [open, setOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
 
@@ -25,12 +26,13 @@ export default function ToolFlipImage({ img, mutate }: Props) {
         ref={btnRef}
         Icon={MirrorH}
         label="Flip image"
-        onClick={() => setOpen(o => !o)}
+        onClick={() => !disabled && setOpen(o => !o)}
         active={open}
+        disabled={disabled}
       />
 
 {/* pop-over content */}
-<Popover anchor={btnRef.current} open={open} onClose={() => setOpen(false)}>
+<Popover anchor={btnRef.current} open={open && !disabled} onClose={() => setOpen(false)}>
   <button
     className="flex w-full items-center gap-2 rounded-lg px-3 py-2
                text-sm hover:bg-walty-orange/10 focus:outline-none

--- a/app/components/toolbar/ToolOpacitySlider.tsx
+++ b/app/components/toolbar/ToolOpacitySlider.tsx
@@ -10,9 +10,10 @@ import IconButton from "./IconButton";   // forward-ref version
 interface Props {
   img: fabric.Image;
   mutate: (p: Partial<fabric.Image>) => void;
+  disabled?: boolean;
 }
 
-export default function ToolOpacitySlider({ img, mutate }: Props) {
+export default function ToolOpacitySlider({ img, mutate, disabled }: Props) {
   const [open, setOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);   // ⬅️ grab anchor via ref
 
@@ -26,10 +27,11 @@ export default function ToolOpacitySlider({ img, mutate }: Props) {
         Icon={Droplet}
         label="Opacity"
         active={open}
-        onClick={() => setOpen(o => !o)}
+        onClick={() => !disabled && setOpen(o => !o)}
+        disabled={disabled}
       />
 
-      <Popover anchor={btnRef.current} open={open} onClose={() => setOpen(false)}>
+      <Popover anchor={btnRef.current} open={open && !disabled} onClose={() => setOpen(false)}>
         <label htmlFor="opacity-slider" className="sr-only">
           Image opacity
         </label>

--- a/app/components/toolbar/ToolTextColorPicker.tsx
+++ b/app/components/toolbar/ToolTextColorPicker.tsx
@@ -93,9 +93,10 @@ interface Props {
   tb: fabric.Textbox | null;
   canvas: fabric.Canvas | null;
   mutate: (p: Partial<fabric.Textbox>) => void;
+  disabled?: boolean;
 }
 
-export default function ToolTextColorPicker({ tb, canvas, mutate }: Props) {
+export default function ToolTextColorPicker({ tb, canvas, mutate, disabled }: Props) {
   const [open, setOpen] = useState(false);
   const [color, setColor] = useState("#000000");
   const [hsv, setHsv] = useState<[number, number, number]>([0, 0, 0]);
@@ -147,13 +148,13 @@ export default function ToolTextColorPicker({ tb, canvas, mutate }: Props) {
         ref={btnRef}
         type="button"
         aria-label="Text colour"
-        disabled={!tb}
-        onClick={() => tb && setOpen(o => !o)}
+        disabled={!tb || disabled}
+        onClick={() => tb && !disabled && setOpen(o => !o)}
         className="h-12 w-12 rounded-lg border border-teal-800/10 shadow disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
         style={{ backgroundColor: tb ? (tb.fill as string) : "#000" }}
       />
 
-      <Popover anchor={btnRef.current} open={open && !!tb} onClose={() => setOpen(false)}>
+      <Popover anchor={btnRef.current} open={open && !!tb && !disabled} onClose={() => setOpen(false)}>
         <div className="space-y-3 w-52" onKeyDown={e => e.stopPropagation()}>
           <ColorArea hsv={hsv} onChange={nv => {
             setHsv(nv);

--- a/app/components/toolbar/ToolTextOpacitySlider.tsx
+++ b/app/components/toolbar/ToolTextOpacitySlider.tsx
@@ -8,9 +8,10 @@ import IconButton from "./IconButton";
 interface Props {
   tb: fabric.Textbox | null;
   mutate: (p: Partial<fabric.Textbox>) => void;
+  disabled?: boolean;
 }
 
-export default function ToolTextOpacitySlider({ tb, mutate }: Props) {
+export default function ToolTextOpacitySlider({ tb, mutate, disabled }: Props) {
   const [open, setOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
 
@@ -26,11 +27,11 @@ export default function ToolTextOpacitySlider({ tb, mutate }: Props) {
         Icon={Droplet}
         label="Opacity"
         active={open}
-        disabled={!tb}
-        onClick={() => tb && setOpen(o => !o)}
+        disabled={!tb || disabled}
+        onClick={() => tb && !disabled && setOpen(o => !o)}
       />
 
-      <Popover anchor={btnRef.current} open={open && !!tb} onClose={() => setOpen(false)}>
+      <Popover anchor={btnRef.current} open={open && !!tb && !disabled} onClose={() => setOpen(false)}>
         <label htmlFor="text-opacity-slider" className="sr-only">
           Text opacity
         </label>


### PR DESCRIPTION
## Summary
- preserve lock state when serializing canvas objects
- apply lock properties when creating Fabric objects
- prevent toolbar actions on locked layers
- disable deletion or duplication when locked
- show only a lock icon in the quick action bar while locked
- block cropping when locked and ignore locked objects in multiselect

## Testing
- `npm run lint` *(fails: React hook rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68691149af788323a3c2be7d23aa9e83