### PR TITLE
Fix drag/drop layer jump

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -808,6 +808,7 @@ const handleProofAll = async () => {
       if (!target) return
       if (target.closest('canvas')) return
       if (target.closest('button, input, textarea, select, label, a')) return
+      if (target.closest('[data-layer-panel]')) return
 
       startX = e.clientX
       startY = e.clientY

--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -32,8 +32,11 @@ recompute()
 /* ---------- helpers ------------------------------------------------ */
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v))
 
+const makeId = () => Math.random().toString(36).slice(2, 9)
+
 /* ---------- extra editor-only fields ------------------------------- */
 export type EditorLayer = Layer & {
+  uid: string
   /** blob: URL shown while an upload is in-flight                   */
   srcUrl?: string
   /** `true` between upload POST → success                           */
@@ -141,7 +144,11 @@ export const useEditor = create<EditorState>((set, get) => ({
 
   /* ───── generic setters ───── */
   setPages: pages => {
-    set({ pages })
+    const withIds = pages.map(p => ({
+      ...p,
+      layers: p.layers.map(l => ({ ...l, uid: l.uid || makeId() }))
+    }))
+    set({ pages: withIds })
     /* initialise history once we know the starting template          */
     if (get().history.length === 0) get().pushHistory()
   },
@@ -157,7 +164,10 @@ export const useEditor = create<EditorState>((set, get) => ({
       set(state => {
         const pages = [...state.pages]
         if (!pages[pageIdx]) return { pages }
-        pages[pageIdx] = { ...pages[pageIdx], layers }
+        pages[pageIdx] = {
+          ...pages[pageIdx],
+          layers: layers.map(l => ({ ...l, uid: l.uid || makeId() }))
+        }
         return { pages }
       }),
 
@@ -167,6 +177,7 @@ export const useEditor = create<EditorState>((set, get) => ({
     const nextPages = clone(pages)
 
     nextPages[activePage].layers.push({
+      uid  : makeId(),
       type : 'text',
       text : 'New text',
       x    : 100,
@@ -195,6 +206,7 @@ export const useEditor = create<EditorState>((set, get) => ({
     const blobUrl  = URL.createObjectURL(file)
     const nextPages= clone(pages)
     nextPages[activePage].layers.push({
+      uid     : makeId(),
       type     : 'image',
       x        : 100,
       y        : 100,

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -134,6 +134,8 @@ export const EXPORT_MULT = () => {
 // 4 CSS-px padding used by the hover outline
 const dash = (gap: number) => [gap / SCALE, (gap - 2) / SCALE];
 
+const makeId = () => Math.random().toString(36).slice(2, 9);
+
 /* ---------- shared clipboard helpers ------------------------------ */
 type Clip = { json: any[]; nudge: number };
 export const clip: Clip = { json: [], nudge: 0 };
@@ -176,6 +178,8 @@ export type ImageSrc = string | SanityImageRef | null
 
 /** A single canvas layer (image | text) */
 export interface Layer {
+  /** stable ID used for drag‑and‑drop */
+  uid?: string
   /* ---- layer kind ------------------------------------------------ */
   type: 'image' | 'text'
 
@@ -310,6 +314,7 @@ const objToLayer = (o: fabric.Object): Layer => {
   if ((o as any).type === 'textbox') {
     const t = o as fabric.Textbox
     return {
+      uid      : (t as any).uid || makeId(),
       type      : 'text',
       text      : t.text || '',
       x         : t.left || 0,
@@ -338,6 +343,7 @@ const objToLayer = (o: fabric.Object): Layer => {
   const assetId = (i as any).assetId as string | undefined
 
   const layer: Layer = {
+    uid   : (i as any).uid || makeId(),
     type   : 'image',
     src    : assetId
                ? { _type:'image', asset:{ _type:'reference', _ref: assetId } }
@@ -1790,6 +1796,7 @@ doSync = () =>
 
           /* keep z-order */
           ;(img as any).layerIdx = idx
+          ;(img as any).uid = ly.uid
           fc.insertAt(img, idx, false)
           img.setCoords()
           fc.requestRenderAll()
@@ -1823,6 +1830,7 @@ doSync = () =>
           lockScalingFlip: true,
         })
         ;(tb as any).layerIdx = idx
+        ;(tb as any).uid = ly.uid
         fc.insertAt(tb, idx, false)
       }
     }


### PR DESCRIPTION
## Summary
- generate a stable `uid` for each layer
- use these ids when rendering LayerPanel
- preserve uids in FabricCanvas and EditorStore
- allow dragging an entire layer card
- center text layer previews in the panel
- avoid selection overlay when dragging layer cards
- remove drop-line indicator in LayerPanel

## Testing
- `npm run lint` *(fails: React hook order and other errors)*
- `npm run build` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686911d87bcc832394bf276e3b80f994