### PR TITLE
Fix template rotation

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -225,6 +225,7 @@ export interface Layer {
   opacity?:   number
   scaleX?:    number
   scaleY?:    number
+  angle?:     number
   selectable?:boolean
   editable?:  boolean
   locked?:    boolean

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -62,6 +62,7 @@ if (raw._type === 'aiLayer') {
     heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
     scaleX: raw.scaleX,
     scaleY: raw.scaleY,
+    ...(raw.angle  != null && { angle: raw.angle }),
     ...(raw.flipX != null && { flipX: raw.flipX }),
     ...(raw.flipY != null && { flipY: raw.flipY }),
     selectable: !locked,
@@ -91,6 +92,7 @@ if (raw._type === 'aiLayer') {
       heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
       scaleX: raw.scaleX,
       scaleY: raw.scaleY,
+      ...(raw.angle  != null && { angle: raw.angle }),
       ...(raw.flipX != null && { flipX: raw.flipX }),
       ...(raw.flipY != null && { flipY: raw.flipY }),
       ...(raw.cropX != null && { cropX: raw.cropX }),
@@ -137,6 +139,7 @@ if (raw._type === 'aiLayer') {
       opacity   : raw.opacity,
       scaleX    : raw.scaleX,
       scaleY    : raw.scaleY,
+      ...(raw.angle != null && { angle: raw.angle }),
     }
   }
 
@@ -183,6 +186,7 @@ if (layer?._type === 'aiLayer') {
     // ── persist explicit scale adjustments, if any ─────────────────
     ...(scaleX != null && { scaleX }),
     ...(scaleY != null && { scaleY }),
+    ...(layer.angle  != null && { angle: layer.angle }),
     ...(layer.flipX != null && { flipX: layer.flipX }),
     ...(layer.flipY != null && { flipY: layer.flipY }),
   };
@@ -221,6 +225,7 @@ if (layer.type === 'image') {
     ...(layer.opacity != null && { opacity: layer.opacity }),
     ...(layer.scaleX  != null && { scaleX: layer.scaleX }),
     ...(layer.scaleY  != null && { scaleY: layer.scaleY }),
+    ...(layer.angle   != null && { angle: layer.angle }),
     ...(layer.flipX   != null && { flipX: layer.flipX }),
     ...(layer.flipY   != null && { flipY: layer.flipY }),
   };
@@ -272,6 +277,7 @@ else if (typeof layer.src === 'string') {
       ...(layer.opacity != null && { opacity: layer.opacity }),
       ...(layer.scaleX  != null && { scaleX : layer.scaleX }),
       ...(layer.scaleY  != null && { scaleY : layer.scaleY }),
+      ...(layer.angle   != null && { angle : layer.angle }),
     }
   }
 

--- a/sanity/schemaTypes/editableImage.ts
+++ b/sanity/schemaTypes/editableImage.ts
@@ -13,8 +13,12 @@ export default defineType({
 
   /* ── geometry + style (hidden) ── */
   fields: [
-    ...(['x','y','w','h','width','height','scaleX','scaleY','opacity'] as const)
-      .map((n) => defineField({name: n, type: 'number', hidden: true})),
+    ...([
+      'x','y','w','h','width','height','scaleX','scaleY','angle'
+    ] as const).map((n) => defineField({ name: n, type: 'number', hidden: true })),
+    defineField({ name: 'flipX', type: 'boolean', hidden: true }),
+    defineField({ name: 'flipY', type: 'boolean', hidden: true }),
+    defineField({ name: 'opacity', type: 'number', hidden: true }),
 
     /* uploaded Sanity asset */
     defineField({

--- a/sanity/schemaTypes/editableText.ts
+++ b/sanity/schemaTypes/editableText.ts
@@ -10,6 +10,7 @@ export default defineType({
     defineField({name:'x', type:'number', hidden:true}),
     defineField({name:'y', type:'number', hidden:true}),
     defineField({name:'width', type:'number', hidden:true}),
+    defineField({name:'angle', type:'number', hidden:true}),
     /* content + style */
     defineField({name:'text',       type:'string', title:'Default text'}),
     defineField({name:'fontSize',   type:'number'}),


### PR DESCRIPTION
## Summary
- preserve angle data on text and images
- record flips & opacity when saving image layers
- support rotation field in Sanity schemas

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686a3f5433908323a0eb8dfdb64b92f0