### PR TITLE
Fix template rotation persistence

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -225,6 +225,8 @@ export interface Layer {
   opacity?:   number
   scaleX?:    number
   scaleY?:    number
+  /** rotation in degrees */
+  angle?:     number
   selectable?:boolean
   editable?:  boolean
   locked?:    boolean
@@ -335,6 +337,7 @@ const objToLayer = (o: fabric.Object): Layer => {
       opacity   : t.opacity,
       scaleX    : t.scaleX,
       scaleY    : t.scaleY,
+      angle     : t.angle,
       lines     : t.textLines as string[],
       locked    : (t as any).locked,
     }
@@ -364,6 +367,7 @@ const objToLayer = (o: fabric.Object): Layer => {
     scaleY : i.scaleY,
     flipX  : (i as any).flipX,
     flipY  : (i as any).flipY,
+    angle  : i.angle,
     locked : (i as any).locked,
   }
 
@@ -1764,6 +1768,7 @@ if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
             flipX     : ly.flipX ?? false,
             flipY     : ly.flipY ?? false,
           })
+          img.angle = ly.angle ?? 0
 
           ;(img as any).locked = ly.locked
           if (ly.locked) {
@@ -1881,13 +1886,14 @@ doSync = () =>
           underline: !!ly.underline,
           fill: hex(ly.fill ?? '#000'),
           textAlign: ly.textAlign ?? 'left',
-          lineHeight: ly.lineHeight ?? 1.16,
+      lineHeight: ly.lineHeight ?? 1.16,
       opacity: ly.opacity ?? 1,
       selectable: ly.selectable ?? true,
       editable: ly.editable ?? true,
       scaleX: ly.scaleX ?? 1, scaleY: ly.scaleY ?? 1,
       lockScalingFlip: true,
     })
+        tb.angle = ly.angle ?? 0
         ;(tb as any).locked = ly.locked
         if (ly.locked) {
           tb.set({

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -62,6 +62,7 @@ if (raw._type === 'aiLayer') {
     heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
     scaleX: raw.scaleX,
     scaleY: raw.scaleY,
+    ...(raw.angle != null && { angle: raw.angle }),
     ...(raw.flipX != null && { flipX: raw.flipX }),
     ...(raw.flipY != null && { flipY: raw.flipY }),
     selectable: !locked,
@@ -91,6 +92,7 @@ if (raw._type === 'aiLayer') {
       heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
       scaleX: raw.scaleX,
       scaleY: raw.scaleY,
+      ...(raw.angle  != null && { angle: raw.angle }),
       ...(raw.flipX != null && { flipX: raw.flipX }),
       ...(raw.flipY != null && { flipY: raw.flipY }),
       ...(raw.cropX != null && { cropX: raw.cropX }),
@@ -137,6 +139,7 @@ if (raw._type === 'aiLayer') {
       opacity   : raw.opacity,
       scaleX    : raw.scaleX,
       scaleY    : raw.scaleY,
+      ...(raw.angle != null && { angle: raw.angle }),
     }
   }
 
@@ -183,6 +186,7 @@ if (layer?._type === 'aiLayer') {
     // ── persist explicit scale adjustments, if any ─────────────────
     ...(scaleX != null && { scaleX }),
     ...(scaleY != null && { scaleY }),
+    ...(layer.angle != null && { angle: layer.angle }),
     ...(layer.flipX != null && { flipX: layer.flipX }),
     ...(layer.flipY != null && { flipY: layer.flipY }),
   };
@@ -221,6 +225,7 @@ if (layer.type === 'image') {
     ...(layer.opacity != null && { opacity: layer.opacity }),
     ...(layer.scaleX  != null && { scaleX: layer.scaleX }),
     ...(layer.scaleY  != null && { scaleY: layer.scaleY }),
+    ...(layer.angle   != null && { angle: layer.angle }),
     ...(layer.flipX   != null && { flipX: layer.flipX }),
     ...(layer.flipY   != null && { flipY: layer.flipY }),
   };
@@ -272,6 +277,7 @@ else if (typeof layer.src === 'string') {
       ...(layer.opacity != null && { opacity: layer.opacity }),
       ...(layer.scaleX  != null && { scaleX : layer.scaleX }),
       ...(layer.scaleY  != null && { scaleY : layer.scaleY }),
+      ...(layer.angle   != null && { angle : layer.angle }),
     }
   }
 

--- a/sanity/schemaTypes/aiLayer.ts
+++ b/sanity/schemaTypes/aiLayer.ts
@@ -29,6 +29,7 @@ export default defineType({
     defineField({ name: 'scaleX',  type: 'number', hidden: true }),
     defineField({ name: 'scaleY',  type: 'number', hidden: true }),
     defineField({ name: 'opacity', type: 'number', hidden: true }),
+    defineField({ name: 'angle',   type: 'number', hidden: true }),
     defineField({ name: 'src',     type: 'url',    hidden: true }),  // PNG URL after swap
 
     defineField({

--- a/sanity/schemaTypes/editableImage.ts
+++ b/sanity/schemaTypes/editableImage.ts
@@ -13,7 +13,7 @@ export default defineType({
 
   /* ── geometry + style (hidden) ── */
   fields: [
-    ...(['x','y','w','h','width','height','scaleX','scaleY','opacity'] as const)
+    ...(['x','y','w','h','width','height','scaleX','scaleY','opacity','angle'] as const)
       .map((n) => defineField({name: n, type: 'number', hidden: true})),
 
     /* uploaded Sanity asset */

--- a/sanity/schemaTypes/editableText.ts
+++ b/sanity/schemaTypes/editableText.ts
@@ -10,6 +10,7 @@ export default defineType({
     defineField({name:'x', type:'number', hidden:true}),
     defineField({name:'y', type:'number', hidden:true}),
     defineField({name:'width', type:'number', hidden:true}),
+    defineField({name:'angle', type:'number', hidden:true}),
     /* content + style */
     defineField({name:'text',       type:'string', title:'Default text'}),
     defineField({name:'fontSize',   type:'number'}),


### PR DESCRIPTION
## Summary
- store layer rotation angle
- include angle when converting between editor and Sanity
- update schemas for `angle` field

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a3f5433908323a0eb8dfdb64b92f0