### PR TITLE
Fix zoom flicker by keeping canvas size static

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -639,8 +639,8 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
       case 'align':
         if (active) {
           const zoom = fc.viewportTransform?.[0] ?? 1
-          const fcH = (fc.getHeight() ?? 0) / zoom
-          const fcW = (fc.getWidth()  ?? 0) / zoom
+          const fcH = previewH()
+          const fcW = previewW()
           const { width, height } = active.getBoundingRect(true, true)
           active.set({ left: fcW / 2 - width / 2, top: fcH / 2 - height / 2 })
           active.setCoords()
@@ -845,8 +845,11 @@ if (container) {
   containerRef.current = container;
 }
   
-  fc.setWidth(PREVIEW_W * zoom)
-  fc.setHeight(PREVIEW_H * zoom)
+  fc.setWidth(PREVIEW_W)
+  fc.setHeight(PREVIEW_H)
+  const canvas = canvasRef.current!
+  canvas.style.width  = `${PREVIEW_W * zoom}px`
+  canvas.style.height = `${PREVIEW_H * zoom}px`
   addBackdrop(fc);
   // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
@@ -1677,8 +1680,6 @@ window.addEventListener('keydown', onKey)
       container.style.overflow = 'visible'
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
     canvas.style.width = `${PREVIEW_W * zoom}px`
     canvas.style.height = `${PREVIEW_H * zoom}px`
 

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState } from "react";
 import { fabric } from "fabric";
 import { useEditor } from "./EditorStore";
+import { previewW, previewH } from "./FabricCanvas";
 import ToolFlipImage     from "./toolbar/ToolFlipImage";
 import ToolOpacitySlider from "./toolbar/ToolOpacitySlider";
 import IconButton        from "./toolbar/IconButton";
@@ -71,8 +72,8 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
 
   /* canvas metrics */
   const zoom = fc.viewportTransform?.[0] ?? 1;
-  const fcH  = (fc.getHeight() ?? 0) / zoom;
-  const fcW  = (fc.getWidth()  ?? 0) / zoom;
+  const fcH  = previewH();
+  const fcW  = previewW();
 
   const img = fc.getActiveObject() as fabric.Image | null;
   if (!img || (img as any).type !== "image") return null;

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useState } from 'react'
 import { fabric }              from 'fabric'
-import { getActiveTextbox }    from './FabricCanvas'
+import { getActiveTextbox, previewW, previewH }    from './FabricCanvas'
 import { useEditor }           from './EditorStore'
 
 /* UI building blocks */
@@ -93,8 +93,8 @@ export default function TextToolbar (props: Props) {
   /* 4.  Centre-on-page maths (copied from Image toolbar)               */
   /* ------------------------------------------------------------------ */
   const zoom = fc.viewportTransform?.[0] ?? 1
-  const fcH  = (fc.getHeight() ?? 0) / zoom
-  const fcW  = (fc.getWidth()  ?? 0) / zoom
+  const fcH  = previewH()
+  const fcW  = previewW()
 
   const cycleVertical = () => {
     if (!tb) return


### PR DESCRIPTION
## Summary
- avoid changing Fabric canvas dimensions on every zoom step
- read preview size directly for alignment logic

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686a4367a24c8323b19bbb0bff7e6e77