### PR TITLE
Restrict layer locking to staff mode

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -928,6 +928,7 @@ const handleProofAll = async () => {
             <ImageToolbar
               canvas={activeFc}
               saving={saving}
+              mode={mode}
             />
           ) : (
             <div

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -533,6 +533,10 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : !next,
+      evented      : !next,
+      hasControls  : !next,
+      editable     : !next,
     })
     fc.requestRenderAll()
     if ((active as any).layerIdx !== undefined) {
@@ -1771,15 +1775,17 @@ if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
           img.angle = ly.angle ?? 0
 
           ;(img as any).locked = ly.locked
-          if (ly.locked) {
-            img.set({
-              lockMovementX: true,
-              lockMovementY: true,
-              lockScalingX : true,
-              lockScalingY : true,
-              lockRotation : true,
-            })
-          }
+          const locked = !!ly.locked
+          img.set({
+            lockMovementX: locked,
+            lockMovementY: locked,
+            lockScalingX : locked,
+            lockScalingY : locked,
+            lockRotation : locked,
+            selectable   : !locked,
+            evented      : !locked,
+            hasControls  : !locked,
+          })
 
           /* ---------- AI placeholder extras -------------------------------- */
           let doSync: (() => void) | undefined
@@ -1895,15 +1901,18 @@ doSync = () =>
     })
         tb.angle = ly.angle ?? 0
         ;(tb as any).locked = ly.locked
-        if (ly.locked) {
-          tb.set({
-            lockMovementX: true,
-            lockMovementY: true,
-            lockScalingX : true,
-            lockScalingY : true,
-            lockRotation : true,
-          })
-        }
+        const locked = !!ly.locked
+        tb.set({
+          lockMovementX: locked,
+          lockMovementY: locked,
+          lockScalingX : locked,
+          lockScalingY : locked,
+          lockRotation : locked,
+          selectable   : !locked,
+          evented      : !locked,
+          hasControls  : !locked,
+          editable     : !locked,
+        })
         ;(tb as any).layerIdx = idx
         ;(tb as any).uid = ly.uid
         fc.insertAt(tb, idx, false)
@@ -1937,6 +1946,7 @@ doSync = () =>
         onMenu={p => setMenuPos(p)}
         locked={Boolean(fcRef.current?.getActiveObject() && (fcRef.current!.getActiveObject() as any).locked)}
         onUnlock={toggleActiveLock}
+        mode={mode}
       />
       {menuPos && (
         <ContextMenu

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -40,9 +40,10 @@ import {
 interface Props {
   canvas: fabric.Canvas | null;
   saving: boolean;
+  mode?: 'staff' | 'customer';
 }
 
-export default function ImageToolbar({ canvas: fc, saving }: Props) {
+export default function ImageToolbar({ canvas: fc, saving, mode = 'customer' }: Props) {
   /* local state / editor wiring */
   const [, force]      = useState({});
   const reorder        = useEditor(s => s.reorder);
@@ -112,6 +113,9 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : !next,
+      evented      : !next,
+      hasControls  : !next,
     });
     fc.requestRenderAll();
     updateLayer(activePage, (img as any).layerIdx, { locked: next });
@@ -158,7 +162,9 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
         <IconButton Icon={AlignToPageVertical}   label="Center vertical" caption="Center Y" onClick={cycleVertical} disabled={locked} />
         <IconButton Icon={AlignToPageHorizontal} label="Center horizontal" caption="Center X" onClick={cycleHorizontal} disabled={locked} />
         <IconButton Icon={Eraser} label="Remove background" caption="BG Erase" onClick={() => alert("TODO: remove background") } disabled={locked} />
-        <IconButton Icon={locked ? Lock : Unlock} label={locked ? "Unlock layer" : "Lock layer"} active={locked} onClick={toggleLock} />
+        {mode === 'staff' && (
+          <IconButton Icon={locked ? Lock : Unlock} label={locked ? 'Unlock layer' : 'Lock layer'} active={locked} onClick={toggleLock} />
+        )}
         <IconButton Icon={ArrowDownToLine} label="Send backward" caption="Send ↓" onClick={sendBackward} disabled={locked} />
         <IconButton Icon={ArrowUpToLine}   label="Bring forward" caption="Bring ↑" onClick={bringForward} disabled={locked} />
         <IconButton Icon={Trash2} label="Delete image" caption="Delete" onClick={deleteCurrent} disabled={locked} />

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -23,6 +23,7 @@ import {
   Upload as UploadIcon,
   Trash2,
   GripVertical,
+  Lock,
 } from "lucide-react";
 import { useEditor } from "./EditorStore";
 
@@ -50,7 +51,7 @@ function Row({ id, idx }: { id: string; idx: number }) {
       className={`relative group flex h-14 items-center gap-2 rounded-lg
                   border-2 border-walty-teal/40 px-2 text-sm
                   hover:bg-walty-orange/10
-                  ${layer?.locked ? "cursor-default" : "cursor-grab"}`}
+                  ${layer?.locked ? 'cursor-default opacity-50' : 'cursor-grab'}`}
     >
       {/* drag handle */}
       <button
@@ -91,6 +92,10 @@ function Row({ id, idx }: { id: string; idx: number }) {
           />
         )}
       </span>
+
+      {layer.locked && (
+        <Lock className="h-4 w-4 text-walty-teal" />
+      )}
 
       {/* delete */}
       <button

--- a/app/components/QuickActionBar.tsx
+++ b/app/components/QuickActionBar.tsx
@@ -15,9 +15,10 @@ interface Props {
   onMenu: (pos: { x: number; y: number }) => void
   locked?: boolean
   onUnlock?: () => void
+  mode?: 'staff' | 'customer'
 }
 
-export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock }: Props) {
+export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock, mode = 'customer' }: Props) {
   if (!pos) return null
 
   const openMenu = (e: React.MouseEvent) => {
@@ -44,15 +45,21 @@ export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock
         className="fixed z-50 pointer-events-auto flex items-center bg-white border border-[rgba(0,91,85,.2)] shadow-lg rounded-full p-0"
         style={{ top: pos.y, left: pos.x, transform: 'translate(-50%, -100%)' }}
       >
-        <button
-          type="button"
-          aria-label="Unlock layer"
-          title="Unlock layer"
-          onClick={onUnlock}
-          className="h-8 w-8 flex items-center justify-center ml-0 rounded-lg text-[--walty-teal] hover:bg-[--walty-orange]/10 hover:text-[--walty-orange] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
-        >
-          <Lock className="w-5 h-5" />
-        </button>
+        {mode === 'staff' ? (
+          <button
+            type="button"
+            aria-label="Unlock layer"
+            title="Unlock layer"
+            onClick={onUnlock}
+            className="h-8 w-8 flex items-center justify-center ml-0 rounded-lg text-[--walty-teal] hover:bg-[--walty-orange]/10 hover:text-[--walty-orange] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+          >
+            <Lock className="w-5 h-5" />
+          </button>
+        ) : (
+          <div className="h-8 w-8 flex items-center justify-center ml-0 rounded-lg text-[--walty-teal] opacity-40">
+            <Lock className="w-5 h-5" />
+          </div>
+        )}
       </div>
     )
   }

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -124,6 +124,10 @@ export default function TextToolbar (props: Props) {
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : !next,
+      evented      : !next,
+      hasControls  : !next,
+      editable     : !next,
     })
     fc.requestRenderAll()
     updateLayer(activePage, (tb as any).layerIdx, { locked: next })


### PR DESCRIPTION
## Summary
- add `mode` awareness to QuickActionBar and ImageToolbar
- disable object interactivity when locking layers
- hide lock icon in ImageToolbar for customers
- pass mode to QuickActionBar/ImageToolbar
- show lock state in LayerPanel

## Testing
- `npm run lint` *(fails: React hooks ordering, etc.)*
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a44f04be88323ac2f0e7355024c5e