### PR TITLE
Add admin-only layer locking indicator

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -928,6 +928,7 @@ const handleProofAll = async () => {
             <ImageToolbar
               canvas={activeFc}
               saving={saving}
+              mode={mode}
             />
           ) : (
             <div

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -37,12 +37,15 @@ import {
 
 
 /* ───────────────────────── main toolbar component ─── */
+type Mode = 'staff' | 'customer'
+
 interface Props {
-  canvas: fabric.Canvas | null;
-  saving: boolean;
+  canvas: fabric.Canvas | null
+  saving: boolean
+  mode?: Mode
 }
 
-export default function ImageToolbar({ canvas: fc, saving }: Props) {
+export default function ImageToolbar({ canvas: fc, saving, mode = 'customer' }: Props) {
   /* local state / editor wiring */
   const [, force]      = useState({});
   const reorder        = useEditor(s => s.reorder);
@@ -158,7 +161,10 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
         <IconButton Icon={AlignToPageVertical}   label="Center vertical" caption="Center Y" onClick={cycleVertical} disabled={locked} />
         <IconButton Icon={AlignToPageHorizontal} label="Center horizontal" caption="Center X" onClick={cycleHorizontal} disabled={locked} />
         <IconButton Icon={Eraser} label="Remove background" caption="BG Erase" onClick={() => alert("TODO: remove background") } disabled={locked} />
-        <IconButton Icon={locked ? Lock : Unlock} label={locked ? "Unlock layer" : "Lock layer"} active={locked} onClick={toggleLock} />
+        {mode === "staff" && (
+          <IconButton Icon={locked ? Lock : Unlock} label={locked ? "Unlock layer" : "Lock layer"} active={locked} onClick={toggleLock} />
+        )}
+
         <IconButton Icon={ArrowDownToLine} label="Send backward" caption="Send ↓" onClick={sendBackward} disabled={locked} />
         <IconButton Icon={ArrowUpToLine}   label="Bring forward" caption="Bring ↑" onClick={bringForward} disabled={locked} />
         <IconButton Icon={Trash2} label="Delete image" caption="Delete" onClick={deleteCurrent} disabled={locked} />

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -23,6 +23,7 @@ import {
   Upload as UploadIcon,
   Trash2,
   GripVertical,
+  Lock,
 } from "lucide-react";
 import { useEditor } from "./EditorStore";
 
@@ -91,6 +92,10 @@ function Row({ id, idx }: { id: string; idx: number }) {
           />
         )}
       </span>
+
+      {layer.locked && (
+        <Lock className="absolute right-2 text-walty-teal" />
+      )}
 
       {/* delete */}
       <button


### PR DESCRIPTION
## Summary
- restrict layer lock button to admin mode
- pass mode to `ImageToolbar`
- show lock icon in layer panel list when layers are locked

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a44f04be88323ac2f0e7355024c5e