### PR TITLE
Limit layer locking to admin mode

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -928,6 +928,7 @@ const handleProofAll = async () => {
             <ImageToolbar
               canvas={activeFc}
               saving={saving}
+              mode={mode}
             />
           ) : (
             <div

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -850,7 +850,7 @@ if (container) {
   addBackdrop(fc);
   // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
-  enableSnapGuides(fc, PAGE_W, PAGE_H);
+  enableSnapGuides(fc, PAGE_W, PAGE_H, mode);
 
   /* keep event coordinates aligned with any scroll/resize */
   const updateOffset = () => fc.calcOffset();
@@ -1937,6 +1937,7 @@ doSync = () =>
         onMenu={p => setMenuPos(p)}
         locked={Boolean(fcRef.current?.getActiveObject() && (fcRef.current!.getActiveObject() as any).locked)}
         onUnlock={toggleActiveLock}
+        mode={mode}
       />
       {menuPos && (
         <ContextMenu

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState } from "react";
 import { fabric } from "fabric";
 import { useEditor } from "./EditorStore";
+import type { Mode } from '@/lib/useSnapGuides'
 import ToolFlipImage     from "./toolbar/ToolFlipImage";
 import ToolOpacitySlider from "./toolbar/ToolOpacitySlider";
 import IconButton        from "./toolbar/IconButton";
@@ -38,11 +39,12 @@ import {
 
 /* ───────────────────────── main toolbar component ─── */
 interface Props {
-  canvas: fabric.Canvas | null;
-  saving: boolean;
+  canvas: fabric.Canvas | null
+  saving: boolean
+  mode?: Mode
 }
 
-export default function ImageToolbar({ canvas: fc, saving }: Props) {
+export default function ImageToolbar({ canvas: fc, saving, mode = 'customer' }: Props) {
   /* local state / editor wiring */
   const [, force]      = useState({});
   const reorder        = useEditor(s => s.reorder);
@@ -158,7 +160,14 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
         <IconButton Icon={AlignToPageVertical}   label="Center vertical" caption="Center Y" onClick={cycleVertical} disabled={locked} />
         <IconButton Icon={AlignToPageHorizontal} label="Center horizontal" caption="Center X" onClick={cycleHorizontal} disabled={locked} />
         <IconButton Icon={Eraser} label="Remove background" caption="BG Erase" onClick={() => alert("TODO: remove background") } disabled={locked} />
-        <IconButton Icon={locked ? Lock : Unlock} label={locked ? "Unlock layer" : "Lock layer"} active={locked} onClick={toggleLock} />
+        {mode === 'staff' && (
+          <IconButton
+            Icon={locked ? Lock : Unlock}
+            label={locked ? 'Unlock layer' : 'Lock layer'}
+            active={locked}
+            onClick={toggleLock}
+          />
+        )}
         <IconButton Icon={ArrowDownToLine} label="Send backward" caption="Send ↓" onClick={sendBackward} disabled={locked} />
         <IconButton Icon={ArrowUpToLine}   label="Bring forward" caption="Bring ↑" onClick={bringForward} disabled={locked} />
         <IconButton Icon={Trash2} label="Delete image" caption="Delete" onClick={deleteCurrent} disabled={locked} />

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -23,6 +23,7 @@ import {
   Upload as UploadIcon,
   Trash2,
   GripVertical,
+  Lock,
 } from "lucide-react";
 import { useEditor } from "./EditorStore";
 
@@ -92,15 +93,17 @@ function Row({ id, idx }: { id: string; idx: number }) {
         )}
       </span>
 
-      {/* delete */}
-      <button
-        onClick={() => !layer.locked && remove(idx)}
-        disabled={layer.locked}
-        className="opacity-0 transition-opacity group-hover:opacity-100
-                   text-walty-teal hover:text-walty-orange disabled:opacity-40"
-      >
-        <Trash2 className="h-4 w-4" />
-      </button>
+      {/* status / delete */}
+      {layer.locked ? (
+        <Lock className="h-4 w-4 text-walty-teal opacity-40" />
+      ) : (
+        <button
+          onClick={() => remove(idx)}
+          className="opacity-0 transition-opacity group-hover:opacity-100 text-walty-teal hover:text-walty-orange"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      )}
     </li>
   );
 }

--- a/app/components/QuickActionBar.tsx
+++ b/app/components/QuickActionBar.tsx
@@ -9,15 +9,18 @@ import {
 } from 'lucide-react'
 import type { MenuAction } from './ContextMenu'
 
+import type { Mode } from '@/lib/useSnapGuides'
+
 interface Props {
   pos: { x: number; y: number } | null
   onAction: (a: MenuAction) => void
   onMenu: (pos: { x: number; y: number }) => void
   locked?: boolean
   onUnlock?: () => void
+  mode?: Mode
 }
 
-export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock }: Props) {
+export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock, mode = 'customer' }: Props) {
   if (!pos) return null
 
   const openMenu = (e: React.MouseEvent) => {
@@ -39,6 +42,7 @@ export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock
   )
 
   if (locked) {
+    if (mode !== 'staff') return null
     return (
       <div
         className="fixed z-50 pointer-events-auto flex items-center bg-white border border-[rgba(0,91,85,.2)] shadow-lg rounded-full p-0"

--- a/lib/useSnapGuides.ts
+++ b/lib/useSnapGuides.ts
@@ -7,7 +7,14 @@ import { fabric } from 'fabric'
  * @param width  Full page width in canvas units
  * @param height Full page height in canvas units
  */
-export function enableSnapGuides(fc: fabric.Canvas, width: number, height: number) {
+export type Mode = 'staff' | 'customer'
+
+export function enableSnapGuides(
+  fc: fabric.Canvas,
+  width: number,
+  height: number,
+  mode: Mode = 'customer',
+) {
   const SNAP = 4
   // how strongly to pull the object toward a snapped position (0‑1)
   // use 1 for a hard snap with no drift
@@ -61,7 +68,8 @@ export function enableSnapGuides(fc: fabric.Canvas, width: number, height: numbe
       .filter(o =>
         o !== active &&
         (o as any).visible !== false &&
-        !(o as any)._guide
+        !(o as any)._guide &&
+        (mode === 'staff' || !(o as any).locked)
       )
       .map(o => metrics(o.getBoundingRect(true, true)))
   }


### PR DESCRIPTION
## Summary
- restrict QuickActionBar unlock button to staff mode
- hide lock toggle on ImageToolbar for customers
- show lock icon in LayerPanel when a layer is locked
- pass mode info to canvas helpers
- ignore locked layers for snap guides on customer side

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a44f04be88323ac2f0e7355024c5e