### PR TITLE
Fix canvas zoom flicker

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -670,7 +670,7 @@ const handleProofAll = async () => {
       const base = fc.getZoom() / current
       const point = origin
         ? new fabric.Point(origin.x, origin.y)
-        : new fabric.Point(fc.getWidth() / 2, fc.getHeight() / 2)
+        : new fabric.Point(previewW() / 2, previewH() / 2)
       fc.zoomToPoint(point, base * next)
       fc.requestRenderAll()
     })
@@ -686,16 +686,14 @@ const handleProofAll = async () => {
   }, [])
 
   const handleZoomIn = useCallback(() => {
-    const fc = activeFc
-    const origin = fc ? { x: fc.getWidth() / 2, y: fc.getHeight() / 2 } : null
+    const origin = { x: previewW() / 2, y: previewH() / 2 }
     setZoomSmooth(targetZoom.current + 0.25, origin)
-  }, [activeFc, setZoomSmooth])
+  }, [zoom, setZoomSmooth])
 
   const handleZoomOut = useCallback(() => {
-    const fc = activeFc
-    const origin = fc ? { x: fc.getWidth() / 2, y: fc.getHeight() / 2 } : null
+    const origin = { x: previewW() / 2, y: previewH() / 2 }
     setZoomSmooth(targetZoom.current - 0.25, origin)
-  }, [activeFc, setZoomSmooth])
+  }, [zoom, setZoomSmooth])
   const ran = useRef(false)
   useEffect(() => {
     if (ran.current || typeof window === 'undefined') return
@@ -1081,7 +1079,7 @@ const handleProofAll = async () => {
           onChange={e => {
             const val = parseFloat(e.currentTarget.value)
             setSliderPos(val)
-            const origin = activeFc ? { x: activeFc.getWidth() / 2, y: activeFc.getHeight() / 2 } : null
+            const origin = { x: previewW() / 2, y: previewH() / 2 }
             setZoomSmooth(sliderToZoom(val), origin)
           }}
           className="h-2 w-32"

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -638,9 +638,8 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
         break
       case 'align':
         if (active) {
-          const zoom = fc.viewportTransform?.[0] ?? 1
-          const fcH = (fc.getHeight() ?? 0) / zoom
-          const fcW = (fc.getWidth()  ?? 0) / zoom
+          const fcH = PREVIEW_H
+          const fcW = PREVIEW_W
           const { width, height } = active.getBoundingRect(true, true)
           active.set({ left: fcW / 2 - width / 2, top: fcH / 2 - height / 2 })
           active.setCoords()
@@ -844,9 +843,11 @@ if (container) {
   // keep the ref so scroll listeners work
   containerRef.current = container;
 }
-  
-  fc.setWidth(PREVIEW_W * zoom)
-  fc.setHeight(PREVIEW_H * zoom)
+
+  fc.setWidth(PREVIEW_W)
+  fc.setHeight(PREVIEW_H)
+  canvas.style.transformOrigin = '0 0'
+  canvas.style.transform = `scale(${zoom})`
   addBackdrop(fc);
   // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
@@ -1677,10 +1678,12 @@ window.addEventListener('keydown', onKey)
       container.style.overflow = 'visible'
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
-    canvas.style.width = `${PREVIEW_W * zoom}px`
-    canvas.style.height = `${PREVIEW_H * zoom}px`
+    fc.setWidth(PREVIEW_W)
+    fc.setHeight(PREVIEW_H)
+    canvas.style.width = `${PREVIEW_W}px`
+    canvas.style.height = `${PREVIEW_H}px`
+    canvas.style.transformOrigin = '0 0'
+    canvas.style.transform = `scale(${zoom})`
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState } from "react";
 import { fabric } from "fabric";
 import { useEditor } from "./EditorStore";
+import { previewW, previewH } from "./FabricCanvas";
 import ToolFlipImage     from "./toolbar/ToolFlipImage";
 import ToolOpacitySlider from "./toolbar/ToolOpacitySlider";
 import IconButton        from "./toolbar/IconButton";
@@ -70,9 +71,8 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
   if (!fc) return null;
 
   /* canvas metrics */
-  const zoom = fc.viewportTransform?.[0] ?? 1;
-  const fcH  = (fc.getHeight() ?? 0) / zoom;
-  const fcW  = (fc.getWidth()  ?? 0) / zoom;
+  const fcH  = previewH();
+  const fcW  = previewW();
 
   const img = fc.getActiveObject() as fabric.Image | null;
   if (!img || (img as any).type !== "image") return null;

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useState } from 'react'
 import { fabric }              from 'fabric'
-import { getActiveTextbox }    from './FabricCanvas'
+import { getActiveTextbox, previewW, previewH }    from './FabricCanvas'
 import { useEditor }           from './EditorStore'
 
 /* UI building blocks */
@@ -92,9 +92,8 @@ export default function TextToolbar (props: Props) {
   /* ------------------------------------------------------------------ */
   /* 4.  Centre-on-page maths (copied from Image toolbar)               */
   /* ------------------------------------------------------------------ */
-  const zoom = fc.viewportTransform?.[0] ?? 1
-  const fcH  = (fc.getHeight() ?? 0) / zoom
-  const fcW  = (fc.getWidth()  ?? 0) / zoom
+  const fcH  = previewH()
+  const fcW  = previewW()
 
   const cycleVertical = () => {
     if (!tb) return


### PR DESCRIPTION
## Summary
- avoid resetting canvas dimensions during zoom
- update zoom origin logic
- compute toolbar alignment using preview dimensions

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, no-img-element, etc.)*
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a46b6ff148323a8ade8b222e5b7f2