### PR TITLE
Restrict layer locking to staff mode

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -928,6 +928,7 @@ const handleProofAll = async () => {
             <ImageToolbar
               canvas={activeFc}
               saving={saving}
+              mode={mode}
             />
           ) : (
             <div

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -527,12 +527,17 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
     const locked = !!(active as any).locked
     const next = !locked
     ;(active as any).locked = next
+    const isStaff = mode === 'staff'
     active.set({
       lockMovementX: next,
       lockMovementY: next,
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : isStaff || !next,
+      evented      : isStaff || !next,
+      hasControls  : !next,
+      editable     : !next,
     })
     fc.requestRenderAll()
     if ((active as any).layerIdx !== undefined) {
@@ -1771,15 +1776,18 @@ if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
           img.angle = ly.angle ?? 0
 
           ;(img as any).locked = ly.locked
-          if (ly.locked) {
-            img.set({
-              lockMovementX: true,
-              lockMovementY: true,
-              lockScalingX : true,
-              lockScalingY : true,
-              lockRotation : true,
-            })
-          }
+          const locked = !!ly.locked
+          const isStaff = mode === 'staff'
+          img.set({
+            lockMovementX: locked,
+            lockMovementY: locked,
+            lockScalingX : locked,
+            lockScalingY : locked,
+            lockRotation : locked,
+            selectable   : isStaff || !locked,
+            evented      : isStaff || !locked,
+            hasControls  : !locked,
+          })
 
           /* ---------- AI placeholder extras -------------------------------- */
           let doSync: (() => void) | undefined
@@ -1895,15 +1903,19 @@ doSync = () =>
     })
         tb.angle = ly.angle ?? 0
         ;(tb as any).locked = ly.locked
-        if (ly.locked) {
-          tb.set({
-            lockMovementX: true,
-            lockMovementY: true,
-            lockScalingX : true,
-            lockScalingY : true,
-            lockRotation : true,
-          })
-        }
+        const locked = !!ly.locked
+        const isStaff = mode === 'staff'
+        tb.set({
+          lockMovementX: locked,
+          lockMovementY: locked,
+          lockScalingX : locked,
+          lockScalingY : locked,
+          lockRotation : locked,
+          selectable   : isStaff || !locked,
+          evented      : isStaff || !locked,
+          hasControls  : !locked,
+          editable     : !locked,
+        })
         ;(tb as any).layerIdx = idx
         ;(tb as any).uid = ly.uid
         fc.insertAt(tb, idx, false)
@@ -1937,6 +1949,7 @@ doSync = () =>
         onMenu={p => setMenuPos(p)}
         locked={Boolean(fcRef.current?.getActiveObject() && (fcRef.current!.getActiveObject() as any).locked)}
         onUnlock={toggleActiveLock}
+        mode={mode}
       />
       {menuPos && (
         <ContextMenu

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -40,9 +40,10 @@ import {
 interface Props {
   canvas: fabric.Canvas | null;
   saving: boolean;
+  mode?: 'staff' | 'customer';
 }
 
-export default function ImageToolbar({ canvas: fc, saving }: Props) {
+export default function ImageToolbar({ canvas: fc, saving, mode = 'customer' }: Props) {
   /* local state / editor wiring */
   const [, force]      = useState({});
   const reorder        = useEditor(s => s.reorder);
@@ -106,12 +107,16 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
   const toggleLock = () => {
     const next = !locked;
     (img as any).locked = next;
+    const isStaff = mode === 'staff';
     img.set({
       lockMovementX: next,
       lockMovementY: next,
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : isStaff || !next,
+      evented      : isStaff || !next,
+      hasControls  : !next,
     });
     fc.requestRenderAll();
     updateLayer(activePage, (img as any).layerIdx, { locked: next });
@@ -158,7 +163,9 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
         <IconButton Icon={AlignToPageVertical}   label="Center vertical" caption="Center Y" onClick={cycleVertical} disabled={locked} />
         <IconButton Icon={AlignToPageHorizontal} label="Center horizontal" caption="Center X" onClick={cycleHorizontal} disabled={locked} />
         <IconButton Icon={Eraser} label="Remove background" caption="BG Erase" onClick={() => alert("TODO: remove background") } disabled={locked} />
-        <IconButton Icon={locked ? Lock : Unlock} label={locked ? "Unlock layer" : "Lock layer"} active={locked} onClick={toggleLock} />
+        {mode === 'staff' && (
+          <IconButton Icon={locked ? Lock : Unlock} label={locked ? 'Unlock layer' : 'Lock layer'} active={locked} onClick={toggleLock} />
+        )}
         <IconButton Icon={ArrowDownToLine} label="Send backward" caption="Send ↓" onClick={sendBackward} disabled={locked} />
         <IconButton Icon={ArrowUpToLine}   label="Bring forward" caption="Bring ↑" onClick={bringForward} disabled={locked} />
         <IconButton Icon={Trash2} label="Delete image" caption="Delete" onClick={deleteCurrent} disabled={locked} />

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -23,6 +23,7 @@ import {
   Upload as UploadIcon,
   Trash2,
   GripVertical,
+  Lock,
 } from "lucide-react";
 import { useEditor } from "./EditorStore";
 
@@ -50,7 +51,7 @@ function Row({ id, idx }: { id: string; idx: number }) {
       className={`relative group flex h-14 items-center gap-2 rounded-lg
                   border-2 border-walty-teal/40 px-2 text-sm
                   hover:bg-walty-orange/10
-                  ${layer?.locked ? "cursor-default" : "cursor-grab"}`}
+                  ${layer?.locked ? 'cursor-default opacity-50' : 'cursor-grab'}`}
     >
       {/* drag handle */}
       <button
@@ -91,6 +92,10 @@ function Row({ id, idx }: { id: string; idx: number }) {
           />
         )}
       </span>
+
+      {layer.locked && (
+        <Lock className="h-4 w-4 text-walty-teal" />
+      )}
 
       {/* delete */}
       <button

--- a/app/components/QuickActionBar.tsx
+++ b/app/components/QuickActionBar.tsx
@@ -15,9 +15,10 @@ interface Props {
   onMenu: (pos: { x: number; y: number }) => void
   locked?: boolean
   onUnlock?: () => void
+  mode?: 'staff' | 'customer'
 }
 
-export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock }: Props) {
+export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock, mode = 'customer' }: Props) {
   if (!pos) return null
 
   const openMenu = (e: React.MouseEvent) => {
@@ -44,15 +45,21 @@ export default function QuickActionBar({ pos, onAction, onMenu, locked, onUnlock
         className="fixed z-50 pointer-events-auto flex items-center bg-white border border-[rgba(0,91,85,.2)] shadow-lg rounded-full p-0"
         style={{ top: pos.y, left: pos.x, transform: 'translate(-50%, -100%)' }}
       >
-        <button
-          type="button"
-          aria-label="Unlock layer"
-          title="Unlock layer"
-          onClick={onUnlock}
-          className="h-8 w-8 flex items-center justify-center ml-0 rounded-lg text-[--walty-teal] hover:bg-[--walty-orange]/10 hover:text-[--walty-orange] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
-        >
-          <Lock className="w-5 h-5" />
-        </button>
+        {mode === 'staff' ? (
+          <button
+            type="button"
+            aria-label="Unlock layer"
+            title="Unlock layer"
+            onClick={onUnlock}
+            className="h-8 w-8 flex items-center justify-center ml-0 rounded-lg text-[--walty-teal] hover:bg-[--walty-orange]/10 hover:text-[--walty-orange] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+          >
+            <Lock className="w-5 h-5" />
+          </button>
+        ) : (
+          <div className="h-8 w-8 flex items-center justify-center ml-0 rounded-lg text-[--walty-teal] opacity-40">
+            <Lock className="w-5 h-5" />
+          </div>
+        )}
       </div>
     )
   }

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -118,12 +118,17 @@ export default function TextToolbar (props: Props) {
     if (!tb) return
     const next = !locked
     ;(tb as any).locked = next
+    const isStaff = mode === 'staff'
     tb.set({
       lockMovementX: next,
       lockMovementY: next,
       lockScalingX : next,
       lockScalingY : next,
       lockRotation : next,
+      selectable   : isStaff || !next,
+      evented      : isStaff || !next,
+      hasControls  : !next,
+      editable     : !next,
     })
     fc.requestRenderAll()
     updateLayer(activePage, (tb as any).layerIdx, { locked: next })

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -79,6 +79,7 @@ if (raw._type === 'aiLayer') {
 
   /* ② editable / bg image -------------------------------------- */
   if (raw._type === 'editableImage' || raw._type === 'bgImage') {
+    const locked = !!raw.locked
     return {
       type :'image',
       src  : imgUrl(raw.src) ?? imgUrl(raw) ?? raw.srcUrl,
@@ -100,13 +101,15 @@ if (raw._type === 'aiLayer') {
       ...(raw.cropW != null && { cropW: raw.cropW }),
       ...(raw.cropH != null && { cropH: raw.cropH }),
       opacity: raw.opacity,
-      selectable: raw._type !== 'bgImage',
-      editable  : raw._type !== 'bgImage',
+      selectable: raw._type !== 'bgImage' && !locked,
+      editable  : raw._type !== 'bgImage' && !locked,
+      locked,
     }
   }
 
   /* ③ editable text -------------------------------------------- */
   if (raw._type === 'editableText') {
+    const locked = !!raw.locked
     return {
       type :'text',
       text : raw.text ?? '',
@@ -140,6 +143,9 @@ if (raw._type === 'aiLayer') {
       scaleX    : raw.scaleX,
       scaleY    : raw.scaleY,
       ...(raw.angle != null && { angle: raw.angle }),
+      selectable: !locked,
+      editable  : !locked,
+      locked,
     }
   }
 
@@ -228,6 +234,7 @@ if (layer.type === 'image') {
     ...(layer.angle   != null && { angle: layer.angle }),
     ...(layer.flipX   != null && { flipX: layer.flipX }),
     ...(layer.flipY   != null && { flipY: layer.flipY }),
+    ...(layer.locked != null && { locked: layer.locked }),
   };
 
 /* 1️⃣ Already have assetId → easiest */
@@ -278,6 +285,7 @@ else if (typeof layer.src === 'string') {
       ...(layer.scaleX  != null && { scaleX : layer.scaleX }),
       ...(layer.scaleY  != null && { scaleY : layer.scaleY }),
       ...(layer.angle   != null && { angle : layer.angle }),
+      ...(layer.locked != null && { locked: layer.locked }),
     }
   }
 


### PR DESCRIPTION
## Summary
- permit selection of locked layers for staff users
- include lock flag when loading and saving layers
- hide lock controls from customers

## Testing
- `npm run lint` *(fails: React hooks ordering and other errors)*
- `npm run build` *(fails to compile due to ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a44f04be88323ac2f0e7355024c5e