### PR TITLE
Fix canvas zoom flicker

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -829,24 +829,20 @@ useEffect(() => {
   cropEl.addEventListener('contextmenu', ctxMenu);
  
 /* --- keep Fabric’s wrapper the same size as the visible preview --- */
-const container = canvasRef.current!.parentElement as HTMLElement | null;
-if (container) {
-  const pad = 4 * zoom;
+  const container = canvasRef.current!.parentElement as HTMLElement | null;
+  if (container) {
+    const pad = 4 * zoom;
+    container.style.padding  = `${pad}px`;
+    container.style.overflow = 'visible';
 
-  // zoom-aware dimensions
-  container.style.width     = `${PREVIEW_W * zoom}px`;
-  container.style.height    = `${PREVIEW_H * zoom}px`;
-  container.style.maxWidth  = `${PREVIEW_W * zoom}px`;
-  container.style.maxHeight = `${PREVIEW_H * zoom}px`;
-  container.style.padding   = `${pad}px`;
-  container.style.overflow  = 'visible';
+    // keep the ref so scroll listeners work
+    containerRef.current = container;
+  }
 
-  // keep the ref so scroll listeners work
-  containerRef.current = container;
-}
-  
-  fc.setWidth(PREVIEW_W * zoom)
-  fc.setHeight(PREVIEW_H * zoom)
+  const canvasW = PREVIEW_W
+  const canvasH = PREVIEW_H
+  fc.setWidth(canvasW)
+  fc.setHeight(canvasH)
   addBackdrop(fc);
   // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
@@ -1669,18 +1665,12 @@ window.addEventListener('keydown', onKey)
     const container = canvas.parentElement as HTMLElement | null
     if (container) {
       const pad = 4 * zoom
-      container.style.width = `${PREVIEW_W * zoom}px`
-      container.style.height = `${PREVIEW_H * zoom}px`
-      container.style.maxWidth = `${PREVIEW_W * zoom}px`
-      container.style.maxHeight = `${PREVIEW_H * zoom}px`
       container.style.padding = `${pad}px`
       container.style.overflow = 'visible'
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
-    canvas.style.width = `${PREVIEW_W * zoom}px`
-    canvas.style.height = `${PREVIEW_H * zoom}px`
+    canvas.style.transform = `scale(${zoom})`
+    canvas.style.transformOrigin = 'top left'
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
@@ -1926,9 +1916,9 @@ doSync = () =>
     <>
       <canvas
         ref={canvasRef}
-        width={PREVIEW_W * zoom}
-        height={PREVIEW_H * zoom}
-        style={{ width: PREVIEW_W * zoom, height: PREVIEW_H * zoom }}
+        width={PREVIEW_W}
+        height={PREVIEW_H}
+        style={{ width: PREVIEW_W, height: PREVIEW_H, transform: `scale(${zoom})`, transformOrigin: 'top left' }}
         className={`border shadow rounded ${className}`}
       />
       <QuickActionBar


### PR DESCRIPTION
## Summary
- prevent Fabric canvas resizing when zooming
- scale the canvas using CSS transforms instead
- fix undefined variable error by using explicit canvas dimensions

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686a46b6ff148323a8ade8b222e5b7f2