### PR TITLE
Fix editor controls

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -661,6 +661,7 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
         break
     }
     setMenuPos(null)
+    requestAnimationFrame(() => requestAnimationFrame(syncSel))
   }
 
 /* ---------- mount once --------------------------------------- */
@@ -1518,6 +1519,9 @@ const onKey = (e: KeyboardEvent) => {
   const active = fc.getActiveObject() as fabric.Object | undefined
   const cmd    = e.metaKey || e.ctrlKey
   const locked = (active as any)?.locked
+
+  // When editing text, allow normal key behaviour
+  if ((active as any)?.isEditing) return
 
   /* —— COPY ————————————————————————————————————— */
   if (cmd && e.code === 'KeyC' && active) {

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -45,10 +45,14 @@ interface Props {
 export default function ImageToolbar({ canvas: fc, saving }: Props) {
   /* local state / editor wiring */
   const [, force]      = useState({});
-  const reorder        = useEditor(s => s.reorder);
   const updateLayer    = useEditor(s => s.updateLayer);
   const activePage     = useEditor(s => s.activePage);
   const layerCount     = useEditor(s => s.pages[s.activePage]?.layers.length || 0);
+
+  /* alignment state */
+  const [vIdx, setVIdx] = useState(0);
+  const [hIdx, setHIdx] = useState(0);
+  const [lastAxis, setLastAxis] = useState<'v' | 'h' | null>(null);
 
   /* re-render on selection changes */
   useEffect(() => {
@@ -67,15 +71,15 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
     };
   }, [fc]);
 
-  if (!fc) return null;
+  const zoom = fc?.viewportTransform?.[0] ?? 1;
+  const fcH  = (fc?.getHeight() ?? 0) / zoom;
+  const fcW  = (fc?.getWidth()  ?? 0) / zoom;
 
-  /* canvas metrics */
-  const zoom = fc.viewportTransform?.[0] ?? 1;
-  const fcH  = (fc.getHeight() ?? 0) / zoom;
-  const fcW  = (fc.getWidth()  ?? 0) / zoom;
+  const img = fc?.getActiveObject() as fabric.Image | null | undefined;
 
-  const img = fc.getActiveObject() as fabric.Image | null;
-  if (!img || (img as any).type !== "image") return null;
+  useEffect(() => { setVIdx(0); setHIdx(0); setLastAxis(null); }, [img]);
+
+  if (!fc || !img || (img as any).type !== "image") return null;
 
   /* helper: mutate + refresh */
   const mutate = (p: Partial<fabric.Image>) => {
@@ -89,16 +93,23 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
   };
 
   /* page-alignment cycles */
+
   const cycleVertical = () => {
-    const { top, height } = img.getBoundingRect(true, true);
-    const pos = [0, fcH / 2 - height / 2, fcH - height];
-    mutate({ top: pos[(pos.findIndex(p => Math.abs(top - p) < 1) + 1) % 3] });
+    const { height } = img.getBoundingRect(true, true);
+    const pos = [fcH / 2 - height / 2, fcH - height, 0];
+    const idx = lastAxis === 'v' ? vIdx : 0;
+    mutate({ top: pos[idx] });
+    setVIdx((idx + 1) % 3);
+    setLastAxis('v');
   };
 
   const cycleHorizontal = () => {
-    const { left, width } = img.getBoundingRect(true, true);
-    const pos = [0, fcW / 2 - width / 2, fcW - width];
-    mutate({ left: pos[(pos.findIndex(p => Math.abs(left - p) < 1) + 1) % 3] });
+    const { width } = img.getBoundingRect(true, true);
+    const pos = [fcW / 2 - width / 2, fcW - width, 0];
+    const idx = lastAxis === 'h' ? hIdx : 0;
+    mutate({ left: pos[idx] });
+    setHIdx((idx + 1) % 3);
+    setLastAxis('h');
   };
 
   /* layer lock */
@@ -119,14 +130,20 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
 
   /* layer order helpers */
   const sendBackward = () => {
-    if (locked) return
-    const idx = (img as any).layerIdx ?? 0;
-    if (idx < layerCount - 1) reorder(idx, idx + 1);
+    if (locked || !fc) return;
+    fc.sendBackwards(img);
+    fc.setActiveObject(img);
+    fc.requestRenderAll();
+    const sync = (fc as any)._syncLayers as (() => void) | undefined;
+    sync && sync();
   };
   const bringForward = () => {
-    if (locked) return
-    const idx = (img as any).layerIdx ?? 0;
-    if (idx > 0 && idx <= layerCount - 1) reorder(idx, idx - 1);
+    if (locked || !fc) return;
+    fc.bringForward(img);
+    fc.setActiveObject(img);
+    fc.requestRenderAll();
+    const sync = (fc as any)._syncLayers as (() => void) | undefined;
+    sync && sync();
   };
 
   /* remove active image */


### PR DESCRIPTION
## Summary
- fix deletion of textboxes when using Backspace
- keep action bar visible after actions
- adjust align cycle order for text and image toolbar
- ensure centering resets when switching axes
- fix layer order buttons and keep toolbar open

## Testing
- `npm run lint` *(fails: react-hooks rules and other unrelated issues)*

------
https://chatgpt.com/codex/tasks/task_e_686a4b6ad31c8323b6a63a0bef932977