### PR TITLE
Fix canvas flicker on zoom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1686,8 +1686,10 @@ window.addEventListener('keydown', onKey)
       container.style.overflow = 'visible'
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
+    fc.setDimensions(
+      { width: PREVIEW_W * zoom, height: PREVIEW_H * zoom },
+      { cssOnly: true },
+    )
     canvas.style.width = `${PREVIEW_W * zoom}px`
     canvas.style.height = `${PREVIEW_H * zoom}px`
 


### PR DESCRIPTION
## Summary
- avoid clearing the canvas every frame during zoom

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a6c7189f48323805cebf72f5cd656