### PR TITLE
Fix zoom flicker

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -658,7 +658,7 @@ const handleProofAll = async () => {
     if (Math.abs(current - target) < 0.001) {
       zoomRef.current = target
       setZoom(target)
-      canvasMap.forEach(fc => fc?.requestRenderAll())
+      canvasMap.forEach(fc => fc?.renderAll())
       animRef.current = undefined
       return
     }
@@ -672,7 +672,7 @@ const handleProofAll = async () => {
         ? new fabric.Point(origin.x, origin.y)
         : new fabric.Point(fc.getWidth() / 2, fc.getHeight() / 2)
       fc.zoomToPoint(point, base * next)
-      fc.requestRenderAll()
+      fc.renderAll()
     })
     setZoom(next)
     animRef.current = requestAnimationFrame(animateZoom)

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1693,7 +1693,7 @@ window.addEventListener('keydown', onKey)
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
-    fc.requestRenderAll()
+    fc.renderAll()
   }, [zoom])
 
   /* ---------- crop mode toggle ------------------------------ */


### PR DESCRIPTION
## Summary
- render canvases immediately when zooming instead of waiting for rAF

## Testing
- `npm run build` *(fails: issues in repo)*
- `npm run lint` *(fails: issues in repo)*

------
https://chatgpt.com/codex/tasks/task_e_686a6c7189f48323805cebf72f5cd656