### PR TITLE
Fix canvas flicker on zoom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -1686,8 +1686,11 @@ window.addEventListener('keydown', onKey)
       container.style.overflow = 'visible'
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
+    fc.setDimensions({
+      width: PREVIEW_W * zoom,
+      height: PREVIEW_H * zoom,
+    })
+    fc.renderAll()
     canvas.style.width = `${PREVIEW_W * zoom}px`
     canvas.style.height = `${PREVIEW_H * zoom}px`
 


### PR DESCRIPTION
## Summary
- avoid clearing the canvas every frame during zoom
- render canvas immediately after resizing to prevent flicker while keeping object scaling intact

## Testing
- `npm run lint` *(fails: react hooks rules errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a6c7189f48323805cebf72f5cd656