### PR TITLE
Fix zoom flicker

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -670,7 +670,10 @@ const handleProofAll = async () => {
       const base = fc.getZoom() / current
       const point = origin
         ? new fabric.Point(origin.x, origin.y)
-        : new fabric.Point(fc.getWidth() / 2, fc.getHeight() / 2)
+        : (() => {
+            const rect = fc.upperCanvasEl.getBoundingClientRect()
+            return new fabric.Point(rect.width / 2, rect.height / 2)
+          })()
       fc.zoomToPoint(point, base * next)
       fc.requestRenderAll()
     })
@@ -687,13 +690,23 @@ const handleProofAll = async () => {
 
   const handleZoomIn = useCallback(() => {
     const fc = activeFc
-    const origin = fc ? { x: fc.getWidth() / 2, y: fc.getHeight() / 2 } : null
+    const origin = fc
+      ? (() => {
+          const rect = fc.upperCanvasEl.getBoundingClientRect()
+          return { x: rect.width / 2, y: rect.height / 2 }
+        })()
+      : null
     setZoomSmooth(targetZoom.current + 0.25, origin)
   }, [activeFc, setZoomSmooth])
 
   const handleZoomOut = useCallback(() => {
     const fc = activeFc
-    const origin = fc ? { x: fc.getWidth() / 2, y: fc.getHeight() / 2 } : null
+    const origin = fc
+      ? (() => {
+          const rect = fc.upperCanvasEl.getBoundingClientRect()
+          return { x: rect.width / 2, y: rect.height / 2 }
+        })()
+      : null
     setZoomSmooth(targetZoom.current - 0.25, origin)
   }, [activeFc, setZoomSmooth])
   const ran = useRef(false)
@@ -1082,7 +1095,12 @@ const handleProofAll = async () => {
           onChange={e => {
             const val = parseFloat(e.currentTarget.value)
             setSliderPos(val)
-            const origin = activeFc ? { x: activeFc.getWidth() / 2, y: activeFc.getHeight() / 2 } : null
+            const origin = activeFc
+              ? (() => {
+                  const rect = activeFc.upperCanvasEl.getBoundingClientRect()
+                  return { x: rect.width / 2, y: rect.height / 2 }
+                })()
+              : null
             setZoomSmooth(sliderToZoom(val), origin)
           }}
           className="h-2 w-32"

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -644,8 +644,8 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
       case 'align':
         if (active) {
           const zoom = fc.viewportTransform?.[0] ?? 1
-          const fcH = (fc.getHeight() ?? 0) / zoom
-          const fcW = (fc.getWidth()  ?? 0) / zoom
+          const fcH = fc.getHeight() ?? 0
+          const fcW = fc.getWidth() ?? 0
           const { width, height } = active.getBoundingRect(true, true)
           active.set({ left: fcW / 2 - width / 2, top: fcH / 2 - height / 2 })
           active.setCoords()
@@ -850,12 +850,17 @@ if (container) {
   // keep the ref so scroll listeners work
   containerRef.current = container;
 }
-  
-  fc.setWidth(PREVIEW_W * zoom)
-  fc.setHeight(PREVIEW_H * zoom)
+
+  fc.setWidth(PREVIEW_W)
+  fc.setHeight(PREVIEW_H)
   addBackdrop(fc);
   // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
+  const canvas = canvasRef.current!
+  canvas.style.width = `${PREVIEW_W}px`
+  canvas.style.height = `${PREVIEW_H}px`
+  canvas.style.transformOrigin = 'top left'
+  canvas.style.transform = `scale(${zoom})`
   enableSnapGuides(fc, PAGE_W, PAGE_H);
 
   /* keep event coordinates aligned with any scroll/resize */
@@ -1686,13 +1691,16 @@ window.addEventListener('keydown', onKey)
       container.style.overflow = 'visible'
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
-    canvas.style.width = `${PREVIEW_W * zoom}px`
-    canvas.style.height = `${PREVIEW_H * zoom}px`
+    fc.setWidth(PREVIEW_W)
+    fc.setHeight(PREVIEW_H)
+    canvas.style.width = `${PREVIEW_W}px`
+    canvas.style.height = `${PREVIEW_H}px`
+    canvas.style.transformOrigin = 'top left'
+    canvas.style.transform = `scale(${zoom})`
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
+    fc.calcOffset()
     fc.requestRenderAll()
   }, [zoom])
 


### PR DESCRIPTION
## Summary
- scale fabric canvases using CSS transform instead of resizing them
- zoom around the canvas centre using its bounding box

## Testing
- `npm run lint` *(fails: React hook and display-name issues)*

------
https://chatgpt.com/codex/tasks/task_e_686ac532ef1c8323832269eae28889a5