### PR TITLE
Throttle thumbnail generation

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -188,50 +188,29 @@ export default function CardEditor({
   const [thumbs, setThumbs] = useState<string[]>(['', '', '', ''])
 
   const THUMB_MULT = 0.25
-  const THUMB_DELAY = 300
+  const THUMB_DELAY = 1000
   const thumbTimer = useRef<NodeJS.Timeout | null>(null)
-  const lastThumb = useRef(0)
 
   const updateThumbFromCanvas = (idx: number, fc: fabric.Canvas) => {
     const run = () => {
       try {
         if (!(fc as any).lowerCanvasEl) return
-        fc.renderAll()
-        requestAnimationFrame(() => {
-          try {
-            const canvasEl = fc.toCanvasElement(THUMB_MULT)
-            canvasEl.toBlob(
-              blob => {
-                if (!blob) return
-                const url = URL.createObjectURL(blob)
-                setThumbs(prev => {
-                  const next = [...prev]
-                  next[idx] = url
-                  return next
-                })
-              },
-              'image/jpeg',
-              0.8,
-            )
-          } catch (err) {
-            console.error('thumb blob failed', err)
-          }
+        const dataUrl = fc.toDataURL({
+          format: 'jpeg',
+          quality: 0.8,
+          multiplier: THUMB_MULT,
+        })
+        setThumbs(prev => {
+          const next = [...prev]
+          next[idx] = dataUrl
+          return next
         })
       } catch (err) {
         console.error('thumb failed', err)
       }
     }
-    const now = Date.now()
-    if (now - lastThumb.current > THUMB_DELAY) {
-      lastThumb.current = now
-      run()
-    } else {
-      if (thumbTimer.current) clearTimeout(thumbTimer.current)
-      thumbTimer.current = setTimeout(() => {
-        lastThumb.current = Date.now()
-        run()
-      }, THUMB_DELAY)
-    }
+    if (thumbTimer.current) clearTimeout(thumbTimer.current)
+    thumbTimer.current = setTimeout(run, THUMB_DELAY)
   }
 
   const updateThumb = (idx: number) => {


### PR DESCRIPTION
## Summary
- slow down thumbnail updates so they run after a 1s idle delay
- use `fabric.Canvas.toDataURL` instead of rendering the visible canvas

## Testing
- `npm run lint` *(fails: React hooks lint errors and no-img warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686e1b0019788323af7258dafc2ccb1b