### PR TITLE
Keep Fabric canvas size static on zoom

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -839,11 +839,11 @@ const container = canvasRef.current!.parentElement as HTMLElement | null;
 if (container) {
   const pad = 4 * zoom;
 
-  // zoom-aware dimensions
-  container.style.width     = `${PREVIEW_W * zoom}px`;
-  container.style.height    = `${PREVIEW_H * zoom}px`;
-  container.style.maxWidth  = `${PREVIEW_W * zoom}px`;
-  container.style.maxHeight = `${PREVIEW_H * zoom}px`;
+  // fixed dimensions – zoom handled via viewportTransform
+  container.style.width     = `${PREVIEW_W}px`;
+  container.style.height    = `${PREVIEW_H}px`;
+  container.style.maxWidth  = `${PREVIEW_W}px`;
+  container.style.maxHeight = `${PREVIEW_H}px`;
   container.style.padding   = `${pad}px`;
   container.style.overflow  = 'visible';
 
@@ -851,8 +851,8 @@ if (container) {
   containerRef.current = container;
 }
   
-  fc.setWidth(PREVIEW_W * zoom)
-  fc.setHeight(PREVIEW_H * zoom)
+  fc.setWidth(PREVIEW_W)
+  fc.setHeight(PREVIEW_H)
   addBackdrop(fc);
   // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0]);
@@ -1678,20 +1678,17 @@ window.addEventListener('keydown', onKey)
     const container = canvas.parentElement as HTMLElement | null
     if (container) {
       const pad = 4 * zoom
-      container.style.width = `${PREVIEW_W * zoom}px`
-      container.style.height = `${PREVIEW_H * zoom}px`
-      container.style.maxWidth = `${PREVIEW_W * zoom}px`
-      container.style.maxHeight = `${PREVIEW_H * zoom}px`
+      // only adjust padding; keep DOM dimensions intact
       container.style.padding = `${pad}px`
       container.style.overflow = 'visible'
     }
 
-    fc.setWidth(PREVIEW_W * zoom)
-    fc.setHeight(PREVIEW_H * zoom)
-    canvas.style.width = `${PREVIEW_W * zoom}px`
-    canvas.style.height = `${PREVIEW_H * zoom}px`
+    // Zoom purely through Fabric's viewport transform
+    fc.setWidth(PREVIEW_W)
+    fc.setHeight(PREVIEW_H)
 
     fc.setViewportTransform([SCALE * zoom, 0, 0, SCALE * zoom, 0, 0])
+    fc.calcOffset()
     if (cropToolRef.current) (cropToolRef.current as any).SCALE = SCALE * zoom
     fc.requestRenderAll()
   }, [zoom])
@@ -1947,9 +1944,9 @@ doSync = () =>
     <>
       <canvas
         ref={canvasRef}
-        width={PREVIEW_W * zoom}
-        height={PREVIEW_H * zoom}
-        style={{ width: PREVIEW_W * zoom, height: PREVIEW_H * zoom }}
+        width={PREVIEW_W}
+        height={PREVIEW_H}
+        style={{ width: PREVIEW_W, height: PREVIEW_H }}
         className={`border shadow rounded ${className}`}
       />
       <QuickActionBar
@@ -1968,5 +1965,4 @@ doSync = () =>
         />
       )}
     </>
-  )
-}
+  )}


### PR DESCRIPTION
## Summary
- avoid changing canvas element dimensions when zooming
- rely on viewportTransform while keeping DOM size fixed

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e1f5c0ec08323bfb0d989d3260133