### PR TITLE
Optimize thumbnail update logic

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -190,48 +190,26 @@ export default function CardEditor({
   const THUMB_MULT = 0.25
   const THUMB_DELAY = 300
   const thumbTimer = useRef<NodeJS.Timeout | null>(null)
-  const lastThumb = useRef(0)
 
   const updateThumbFromCanvas = (idx: number, fc: fabric.Canvas) => {
-    const run = () => {
+    if (thumbTimer.current) clearTimeout(thumbTimer.current)
+    thumbTimer.current = setTimeout(() => {
       try {
         if (!(fc as any).lowerCanvasEl) return
-        fc.renderAll()
-        requestAnimationFrame(() => {
-          try {
-            const canvasEl = fc.toCanvasElement(THUMB_MULT)
-            canvasEl.toBlob(
-              blob => {
-                if (!blob) return
-                const url = URL.createObjectURL(blob)
-                setThumbs(prev => {
-                  const next = [...prev]
-                  next[idx] = url
-                  return next
-                })
-              },
-              'image/jpeg',
-              0.8,
-            )
-          } catch (err) {
-            console.error('thumb blob failed', err)
-          }
+        const dataUrl = fc.toDataURL({
+          format: 'jpeg',
+          quality: 0.8,
+          multiplier: THUMB_MULT,
+        })
+        setThumbs(prev => {
+          const next = [...prev]
+          next[idx] = dataUrl
+          return next
         })
       } catch (err) {
         console.error('thumb failed', err)
       }
-    }
-    const now = Date.now()
-    if (now - lastThumb.current > THUMB_DELAY) {
-      lastThumb.current = now
-      run()
-    } else {
-      if (thumbTimer.current) clearTimeout(thumbTimer.current)
-      thumbTimer.current = setTimeout(() => {
-        lastThumb.current = Date.now()
-        run()
-      }, THUMB_DELAY)
-    }
+    }, THUMB_DELAY)
   }
 
   const updateThumb = (idx: number) => {


### PR DESCRIPTION
## Summary
- debounce thumbnail generation in `CardEditor`
- use `toDataURL` instead of `renderAll()` for generating thumbnails

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e7ae7d270832389acedfb9b1c94a8