### PR TITLE
Add card mockup previews

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -31,6 +31,7 @@ import { CropTool }                     from '@/lib/CropTool'
 import WaltyEditorHeader                from './WaltyEditorHeader'
 import type { TemplatePage }            from './FabricCanvas'
 import type { TemplateProduct }         from '@/app/library/getTemplatePages'
+import { generateCardMockups }          from '@/lib/generateMockups'
 import { SEL_COLOR }                    from '@/lib/fabricDefaults'
 
 
@@ -500,6 +501,20 @@ const handlePreview = () => {
   })
   setPreviewImgs(imgs)
   setPreviewOpen(true)
+}
+
+const generateMockupImages = async () => {
+  const fc = canvasMap[0]
+  if (!fc) return {}
+  const tool = (fc as any)._cropTool as CropTool | undefined
+  if (tool?.isActive) tool.commit()
+  fc.renderAll()
+  const front = fc.toDataURL({
+    format: 'png',
+    quality: 1,
+    multiplier: EXPORT_MULT(),
+  })
+  return await generateCardMockups(front)
 }
 
 /* helper – gather pages and rendered images once */
@@ -1070,6 +1085,7 @@ const handleProofAll = async () => {
         coverUrl={coverImage || ''}
         products={products}
         generateProofUrls={generateProofURLs}
+        generateMockups={generateMockupImages}
       />
       <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 bg-white shadow px-3 py-2 rounded">
         <span className="text-xs">{Math.round(zoom * 100)}%</span>

--- a/lib/generateMockups.ts
+++ b/lib/generateMockups.ts
@@ -1,0 +1,38 @@
+export async function generateCardMockups(frontUrl: string): Promise<Record<string,string>> {
+  const load = (src: string) => new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+
+  const background = await load('/mockups/cards/Card_mockups_room_background.jpg');
+  const sizes = ['mini','classic','giant'] as const;
+  const result: Record<string,string> = {};
+  const front = await load(frontUrl);
+
+  for (const size of sizes) {
+    const overlay = await load(`/mockups/cards/scene_${size}_overlay.png`);
+    const mask = await load(`/mockups/cards/${size}_mask.png`);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = background.width;
+    canvas.height = background.height;
+    const ctx = canvas.getContext('2d')!;
+
+    ctx.drawImage(background, 0, 0, canvas.width, canvas.height);
+
+    ctx.save();
+    ctx.drawImage(mask, 0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-in';
+    ctx.drawImage(front, 0, 0, canvas.width, canvas.height);
+    ctx.restore();
+
+    ctx.drawImage(overlay, 0, 0, canvas.width, canvas.height);
+
+    result[`gc-${size}`] = canvas.toDataURL('image/png');
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- create `generateCardMockups` helper
- display mockup previews when choosing size
- generate mockup images from the editor

## Testing
- `npm run lint` *(fails: react and next lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_686fd6dc8cb883239fd49e94981b65a7