### PR TITLE
Add live card mockups

### DIFF
--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { Dialog, Transition } from '@headlessui/react'
-import { Fragment, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { Check } from 'lucide-react'
 import { useBasket } from '@/lib/useBasket'
+import { mockupBackground, mockupBounds, MockupBounds } from '@/lib/createMockups'
+import { useSpringNumber } from '@/lib/useSpringNumber'
 
 interface Props {
   open: boolean
@@ -14,6 +16,7 @@ interface Props {
   products?: { title: string; variantHandle: string }[]
   onAdd?: (variant: string) => void
   generateProofUrls?: (variants: string[]) => Promise<Record<string, string>>
+  mockups?: Record<string, string>
 }
 
 const DEFAULT_OPTIONS = [
@@ -23,7 +26,7 @@ const DEFAULT_OPTIONS = [
   { label: 'Giant Card', handle: 'gc-large' },
 ]
 
-export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrls }: Props) {
+export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrls, mockups }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
@@ -32,6 +35,10 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
       Boolean(p && p.title && p.variantHandle),
     ).map(p => ({ label: p.title, handle: p.variantHandle })) ??
     DEFAULT_OPTIONS
+
+  useEffect(() => {
+    if (open) setChoice(options[0]?.handle ?? null)
+  }, [open, options])
 
   const handleAdd = async () => {
     if (!choice) return
@@ -62,6 +69,10 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
     setChoice(null)
   }
 
+  const bounds: MockupBounds | undefined = choice ? mockupBounds[choice as keyof typeof mockupBounds] : undefined
+  const w = useSpringNumber(bounds?.width ?? 0)
+  const h = useSpringNumber(bounds?.height ?? 0)
+
   return (
     <Transition.Root show={open} as={Fragment}>
       <Dialog
@@ -80,6 +91,22 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
           leaveTo="opacity-0 scale-95"
         >
           <Dialog.Panel className="relative z-10 bg-white rounded shadow-lg w-[min(90vw,420px)] p-6 space-y-6">
+            {mockups && choice && (
+              <div className="relative w-full">
+                <img src={mockupBackground} alt="room" className="w-full" />
+                <img
+                  src={mockups[choice]}
+                  className="absolute top-0 left-0"
+                  style={{
+                    left: `${(bounds?.left ?? 0) * 100}%`,
+                    top: `${(bounds?.top ?? 0) * 100}%`,
+                    width: `${w * 100}%`,
+                    height: `${h * 100}%`,
+                  }}
+                  alt="preview"
+                />
+              </div>
+            )}
             <h2 className="font-recoleta text-xl text-[--walty-teal]">Choose an option</h2>
             <ul className="space-y-2">
               {options.map((opt) => (

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -32,6 +32,7 @@ import WaltyEditorHeader                from './WaltyEditorHeader'
 import type { TemplatePage }            from './FabricCanvas'
 import type { TemplateProduct }         from '@/app/library/getTemplatePages'
 import { SEL_COLOR }                    from '@/lib/fabricDefaults'
+import { createCardMockups }            from '@/lib/createMockups'
 
 
 /* ---------- helpers ------------------------------------------------ */
@@ -350,6 +351,21 @@ const [previewImgs, setPreviewImgs] = useState<string[]>([])
 
 /* add-to-basket modal state */
 const [basketOpen, setBasketOpen] = useState(false)
+const [mockups, setMockups] = useState<Record<string,string>|null>(null)
+
+const openBasket = async () => {
+  const fc = canvasMap[0]
+  if (!fc) { setBasketOpen(true); return }
+  const dataUrl = fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })
+  try {
+    const m = await createCardMockups(dataUrl)
+    setMockups(m)
+  } catch (err) {
+    console.error('mockup generation', err)
+    setMockups(null)
+  }
+  setBasketOpen(true)
+}
 
 /* listen for the event FabricCanvas now emits */
 useEffect(() => {
@@ -862,7 +878,7 @@ const handleProofAll = async () => {
     >
       <WaltyEditorHeader                     /* ② mount new component */
         onPreview={handlePreview}
-        onAddToBasket={() => setBasketOpen(true)}
+        onAddToBasket={openBasket}
         height={72}                          /* match the design */
       />
 
@@ -1064,12 +1080,13 @@ const handleProofAll = async () => {
       />
       <AddToBasketDialog
         open={basketOpen}
-        onClose={() => setBasketOpen(false)}
+        onClose={() => { setBasketOpen(false); setMockups(null) }}
         slug={slug}
         title={title}
         coverUrl={coverImage || ''}
         products={products}
         generateProofUrls={generateProofURLs}
+        mockups={mockups || undefined}
       />
       <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 bg-white shadow px-3 py-2 rounded">
         <span className="text-xs">{Math.round(zoom * 100)}%</span>

--- a/lib/createMockups.ts
+++ b/lib/createMockups.ts
@@ -1,0 +1,66 @@
+export interface MockupBounds { left:number; top:number; width:number; height:number }
+
+const BACKGROUND = '/mockups/cards/Card_mockups_room_background.jpg'
+const SIZES = {
+  'gc-mini': {
+    overlay: '/mockups/cards/scene_mini_overlay.png',
+    mask: '/mockups/cards/mini_mask.png',
+    bounds: { left: 0.4165, top: 0.48012, width: 0.17, height: 0.37509 },
+  },
+  'gc-classic': {
+    overlay: '/mockups/cards/scene_classic_overlay.png',
+    mask: '/mockups/cards/classic_mask.png',
+    bounds: { left: 0.3985, top: 0.4171, width: 0.2105, height: 0.44261 },
+  },
+  'gc-large': {
+    overlay: '/mockups/cards/scene_giant_overlay.png',
+    mask: '/mockups/cards/giant_mask.png',
+    bounds: { left: 0.3295, top: 0.12678, width: 0.35, height: 0.72918 },
+  },
+} as const
+
+const W = 2000
+const H = 1333
+
+type SizeKey = keyof typeof SIZES
+
+export async function createCardMockups(frontUrl: string): Promise<Record<SizeKey,string>> {
+  const load = (src: string) => new Promise<HTMLImageElement>((res, rej) => {
+    const img = new Image();
+    img.onload = () => res(img);
+    img.onerror = rej;
+    img.src = src;
+  })
+
+  const design = await load(frontUrl)
+  const result: Record<SizeKey,string> = {} as any
+
+  for (const key of Object.keys(SIZES) as SizeKey[]) {
+    const info = SIZES[key]
+    const [overlay, mask] = await Promise.all([load(info.overlay), load(info.mask)])
+    const full = document.createElement('canvas')
+    full.width = W
+    full.height = H
+    const ctx = full.getContext('2d')!
+    ctx.drawImage(mask, 0, 0)
+    ctx.globalCompositeOperation = 'source-in'
+    const b = info.bounds
+    ctx.drawImage(design, 0, 0, design.width, design.height, b.left*W, b.top*H, b.width*W, b.height*H)
+    ctx.globalCompositeOperation = 'source-over'
+    ctx.drawImage(overlay, 0, 0)
+    // crop
+    const crop = document.createElement('canvas')
+    crop.width = b.width*W
+    crop.height = b.height*H
+    crop.getContext('2d')!.drawImage(full, b.left*W, b.top*H, b.width*W, b.height*H, 0,0,b.width*W,b.height*H)
+    result[key] = crop.toDataURL('image/png')
+  }
+  return result
+}
+
+export const mockupBackground = BACKGROUND
+export const mockupBounds: Record<SizeKey, MockupBounds> = {
+  'gc-mini': SIZES['gc-mini'].bounds,
+  'gc-classic': SIZES['gc-classic'].bounds,
+  'gc-large': SIZES['gc-large'].bounds,
+}

--- a/lib/useSpringNumber.ts
+++ b/lib/useSpringNumber.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function useSpringNumber(target: number, stiffness=0.2, damping=0.5) {
+  const [val, setVal] = useState(target)
+  const valRef = useRef(val)
+  const velRef = useRef(0)
+  useEffect(() => {
+    let frame: number
+    const step = () => {
+      const diff = target - valRef.current
+      const acc = diff * stiffness
+      velRef.current = (velRef.current + acc) * (1 - damping)
+      valRef.current += velRef.current
+      setVal(valRef.current)
+      if (Math.abs(velRef.current) > 0.001 || Math.abs(diff) > 0.001) {
+        frame = requestAnimationFrame(step)
+      } else {
+        setVal(target)
+        valRef.current = target
+      }
+    }
+    frame = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(frame)
+  }, [target, stiffness, damping])
+  return val
+}


### PR DESCRIPTION
## Summary
- generate card-size mockups client-side
- preview mockups in AddToBasket dialog with animated sizing

## Testing
- `npm run lint` *(fails: react-hooks violations in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_686fd6dc8cb883239fd49e94981b65a7