### PR TITLE
Remove overlay from card mockup generation

### DIFF
--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
 import { Check } from 'lucide-react'
 import { useBasket } from '@/lib/useBasket'
+import type { Mockup } from '@/lib/generateCardMockups'
 
 interface Props {
   open: boolean
@@ -14,6 +15,7 @@ interface Props {
   products?: { title: string; variantHandle: string }[]
   onAdd?: (variant: string) => void
   generateProofUrls?: (variants: string[]) => Promise<Record<string, string>>
+  mockups?: Record<'mini' | 'classic' | 'giant', Mockup>
 }
 
 const DEFAULT_OPTIONS = [
@@ -23,7 +25,20 @@ const DEFAULT_OPTIONS = [
   { label: 'Giant Card', handle: 'gc-large' },
 ]
 
-export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrls }: Props) {
+const SIZE_MAP: Record<string, 'mini' | 'classic' | 'giant'> = {
+  mini: 'mini',
+  classic: 'classic',
+  giant: 'giant',
+  'gc-mini': 'mini',
+  'gc-classic': 'classic',
+  'gc-large': 'giant',
+}
+
+const BG_W = 2000
+const BG_H = 1333
+const ROOM_BG = '/mockups/cards/Card_mockups_room_background.jpg'
+
+export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrls, mockups }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
@@ -32,6 +47,9 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
       Boolean(p && p.title && p.variantHandle),
     ).map(p => ({ label: p.title, handle: p.variantHandle })) ??
     DEFAULT_OPTIONS
+
+  const size = SIZE_MAP[choice ?? 'gc-classic']
+  const preview = mockups ? mockups[size] : undefined
 
   const handleAdd = async () => {
     if (!choice) return
@@ -79,30 +97,50 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
           leaveFrom="opacity-100 scale-100"
           leaveTo="opacity-0 scale-95"
         >
-          <Dialog.Panel className="relative z-10 bg-white rounded shadow-lg w-[min(90vw,420px)] p-6 space-y-6">
-            <h2 className="font-recoleta text-xl text-[--walty-teal]">Choose an option</h2>
-            <ul className="space-y-2">
-              {options.map((opt) => (
-                <li key={opt.handle}>
-                  <button
-                    onClick={() => setChoice(opt.handle)}
-                    className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.handle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
-                  >
-                    <span>{opt.label}</span>
-                    {choice === opt.handle && <Check className="text-[--walty-orange]" size={20} />}
-                  </button>
-                </li>
-              ))}
-            </ul>
-            <div className="flex justify-end gap-4 pt-2">
-              <button onClick={onClose} className="rounded-md border border-gray-300 px-4 py-2">Back to editor</button>
-              <button
-                onClick={handleAdd}
-                disabled={!choice}
-                className={`rounded-md px-4 py-2 font-semibold text-white ${choice ? 'bg-[--walty-orange] hover:bg-orange-600' : 'bg-gray-300 cursor-not-allowed'}`}
-              >
-                Add to basket
-              </button>
+          <Dialog.Panel className="relative z-10 bg-white rounded shadow-lg w-[min(90vw,480px)] overflow-hidden">
+            <div className="relative w-full">
+              <img src={ROOM_BG} alt="room" className="w-full h-auto" />
+              {preview && (
+                <img
+                  src={preview.image}
+                  alt="preview"
+                  className="absolute"
+                  style={{
+                    top: `${(preview.box.y / BG_H) * 100}%`,
+                    left: `${(preview.box.x / BG_W) * 100}%`,
+                    width: `${(preview.box.width / BG_W) * 100}%`,
+                    height: `${(preview.box.height / BG_H) * 100}%`,
+                    transition:
+                      'all 0.4s cubic-bezier(0.175,0.885,0.32,1.275)',
+                  }}
+                />
+              )}
+            </div>
+            <div className="p-6 space-y-4">
+              <h2 className="font-recoleta text-xl text-[--walty-teal]">Choose an option</h2>
+              <ul className="space-y-2">
+                {options.map((opt) => (
+                  <li key={opt.handle}>
+                    <button
+                      onClick={() => setChoice(opt.handle)}
+                      className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.handle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
+                    >
+                      <span>{opt.label}</span>
+                      {choice === opt.handle && <Check className="text-[--walty-orange]" size={20} />}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <div className="flex justify-end gap-4 pt-2">
+                <button onClick={onClose} className="rounded-md border border-gray-300 px-4 py-2">Back to editor</button>
+                <button
+                  onClick={handleAdd}
+                  disabled={!choice}
+                  className={`rounded-md px-4 py-2 font-semibold text-white ${choice ? 'bg-[--walty-orange] hover:bg-orange-600' : 'bg-gray-300 cursor-not-allowed'}`}
+                >
+                  Add to basket
+                </button>
+              </div>
             </div>
           </Dialog.Panel>
         </Transition.Child>

--- a/lib/generateCardMockups.ts
+++ b/lib/generateCardMockups.ts
@@ -1,0 +1,61 @@
+export interface BBox { x: number; y: number; width: number; height: number }
+export interface Mockup { image: string; box: BBox }
+
+const SIZE_SPECS: Record<'mini' | 'classic' | 'giant', BBox> = {
+  mini:    { x: 833, y: 639, width: 340, height: 500 },
+  classic: { x: 797, y: 556, width: 421, height: 589 },
+  giant:   { x: 658, y: 168, width: 700, height: 972 },
+}
+
+const MASKS = {
+  mini: '/mockups/cards/mini_mask.png',
+  classic: '/mockups/cards/classic_mask.png',
+  giant: '/mockups/cards/giant_mask.png',
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => resolve(img)
+    img.onerror = err => reject(err)
+    img.src = src
+  })
+}
+
+export async function generateCardMockups(frontUrl: string) {
+  const frontImg = await loadImage(frontUrl)
+  const result: Record<'mini' | 'classic' | 'giant', Mockup> = {
+    mini: { image: '', box: SIZE_SPECS.mini },
+    classic: { image: '', box: SIZE_SPECS.classic },
+    giant: { image: '', box: SIZE_SPECS.giant },
+  }
+
+  for (const key of ['mini', 'classic', 'giant'] as const) {
+    const spec = SIZE_SPECS[key]
+    const mask = await loadImage(MASKS[key])
+    const canvas = document.createElement('canvas')
+    canvas.width = spec.width
+    canvas.height = spec.height
+    const ctx = canvas.getContext('2d')!
+    ctx.drawImage(frontImg, 0, 0, spec.width, spec.height)
+    ctx.globalCompositeOperation = 'destination-in'
+    ctx.drawImage(
+      mask,
+      spec.x,
+      spec.y,
+      spec.width,
+      spec.height,
+      0,
+      0,
+      spec.width,
+      spec.height,
+    )
+    result[key].image = canvas.toDataURL('image/png')
+  }
+
+  return result
+}
+
+export const CARD_MOCKUP_SPECS = SIZE_SPECS
+


### PR DESCRIPTION
## Summary
- update mockup generator so overlays no longer darken the card preview

## Testing
- `npm run lint` *(fails: numerous existing ESLint issues)*
- `npm run build` *(fails to compile due to ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686fd6dc8cb883239fd49e94981b65a7