### PR TITLE
Update AddToBasketDialog styling

### DIFF
--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
+import Image from 'next/image'
 import { Check } from 'lucide-react'
 import { useBasket } from '@/lib/useBasket'
 import type { Mockup } from '@/lib/generateCardMockups'
@@ -12,18 +13,36 @@ interface Props {
   slug: string
   title: string
   coverUrl: string
-  products?: { title: string; variantHandle: string }[]
+  products?: {
+    title: string
+    variantHandle: string
+    blurb?: string
+    price?: number
+  }[]
   onAdd?: (variant: string) => void
   generateProofUrls?: (variants: string[]) => Promise<Record<string, string>>
   mockups?: Record<'mini' | 'classic' | 'giant', Mockup>
 }
 
-const DEFAULT_OPTIONS = [
-  { label: 'Digital Card', handle: 'digital' },
-  { label: 'Mini Card', handle: 'gc-mini' },
-  { label: 'Classic Card', handle: 'gc-classic' },
-  { label: 'Giant Card', handle: 'gc-large' },
+interface Option {
+  label: string
+  handle: string
+  blurb?: string
+  price?: number
+}
+
+const DEFAULT_OPTIONS: Option[] = [
+  { label: 'Digital Card', handle: 'digital', price: 0 },
+  { label: 'Mini Card', handle: 'gc-mini', price: 2.5 },
+  { label: 'Classic Card', handle: 'gc-classic', price: 3.5 },
+  { label: 'Giant Card', handle: 'gc-large', price: 5 },
 ]
+
+const ICONS: Record<string, string> = {
+  'gc-mini': '/icons/mini_card_icon.svg',
+  'gc-classic': '/icons/classic_card_icon.svg',
+  'gc-large': '/icons/giant_card_icon.svg',
+}
 
 const SIZE_MAP: Record<string, 'mini' | 'classic' | 'giant'> = {
   mini: 'mini',
@@ -43,9 +62,19 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
   const { addItem } = useBasket()
 
   const options =
-    products?.filter((p): p is { title: string; variantHandle: string } =>
-      Boolean(p && p.title && p.variantHandle),
-    ).map(p => ({ label: p.title, handle: p.variantHandle })) ??
+    products?.filter(
+      (p): p is {
+        title: string
+        variantHandle: string
+        blurb?: string
+        price?: number
+      } => Boolean(p && p.title && p.variantHandle),
+    ).map(p => ({
+      label: p.title,
+      handle: p.variantHandle,
+      blurb: p.blurb,
+      price: p.price,
+    })) ??
     DEFAULT_OPTIONS
 
   const size = SIZE_MAP[choice ?? 'gc-classic']
@@ -121,13 +150,35 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
               <ul className="space-y-2">
                 {options.map((opt) => (
                   <li key={opt.handle}>
-                    <button
-                      onClick={() => setChoice(opt.handle)}
-                      className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.handle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
+                    <label
+                      className={`flex items-center gap-4 p-3 border-2 rounded-md cursor-pointer w-full ${choice === opt.handle ? 'border-[--walty-orange] bg-[#f3dea8]' : 'border-gray-300 bg-[#F7F3EC]'}`}
                     >
-                      <span>{opt.label}</span>
-                      {choice === opt.handle && <Check className="text-[--walty-orange]" size={20} />}
-                    </button>
+                      {ICONS[opt.handle] && (
+                        <Image
+                          src={ICONS[opt.handle]}
+                          alt=""
+                          width={52}
+                          height={52}
+                        />
+                      )}
+                      <div className="flex-1 flex flex-col space-y-1">
+                        <div className="font-bold">{opt.label}</div>
+                        {opt.blurb && (
+                          <p className="text-sm text-gray-600">{opt.blurb}</p>
+                        )}
+                        {typeof opt.price === 'number' && (
+                          <div className="font-normal">£{opt.price.toFixed(2)}</div>
+                        )}
+                      </div>
+                      <input
+                        type="radio"
+                        name="variant"
+                        value={opt.handle}
+                        checked={choice === opt.handle}
+                        onChange={() => setChoice(opt.handle)}
+                        className="accent-[--walty-orange]"
+                      />
+                    </label>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- display variant options with product page styling in add-to-basket dialog

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687551af0dd48323a4c4582e70dc02fb