### PR TITLE
Align basket dialog styling with product page

### DIFF
--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -1,84 +1,109 @@
-'use client'
+"use client";
 
-import { Dialog, Transition } from '@headlessui/react'
-import { Fragment, useState } from 'react'
-import { Check } from 'lucide-react'
-import { useBasket } from '@/lib/useBasket'
-import type { Mockup } from '@/lib/generateCardMockups'
+import { Dialog, Transition } from "@headlessui/react";
+import { Fragment, useState } from "react";
+import Image from "next/image";
+import { useBasket } from "@/lib/useBasket";
+import type { Mockup } from "@/lib/generateCardMockups";
+
+interface ProductOption {
+  title: string;
+  variantHandle: string;
+  blurb?: string;
+  price?: number;
+}
 
 interface Props {
-  open: boolean
-  onClose: () => void
-  slug: string
-  title: string
-  coverUrl: string
-  products?: { title: string; variantHandle: string }[]
-  onAdd?: (variant: string) => void
-  generateProofUrls?: (variants: string[]) => Promise<Record<string, string>>
-  mockups?: Record<'mini' | 'classic' | 'giant', Mockup>
+  open: boolean;
+  onClose: () => void;
+  slug: string;
+  title: string;
+  coverUrl: string;
+  products?: ProductOption[];
+  onAdd?: (variant: string) => void;
+  generateProofUrls?: (variants: string[]) => Promise<Record<string, string>>;
+  mockups?: Record<"mini" | "classic" | "giant", Mockup>;
 }
 
-const DEFAULT_OPTIONS = [
-  { label: 'Digital Card', handle: 'digital' },
-  { label: 'Mini Card', handle: 'gc-mini' },
-  { label: 'Classic Card', handle: 'gc-classic' },
-  { label: 'Giant Card', handle: 'gc-large' },
-]
+const DEFAULT_OPTIONS: ProductOption[] = [
+  { title: "Digital Card", variantHandle: "digital", price: 0 },
+  { title: "Mini Card", variantHandle: "gc-mini", price: 2.5 },
+  { title: "Classic Card", variantHandle: "gc-classic", price: 3.5 },
+  { title: "Giant Card", variantHandle: "gc-large", price: 5 },
+];
 
-const SIZE_MAP: Record<string, 'mini' | 'classic' | 'giant'> = {
-  mini: 'mini',
-  classic: 'classic',
-  giant: 'giant',
-  'gc-mini': 'mini',
-  'gc-classic': 'classic',
-  'gc-large': 'giant',
-}
+const SIZE_MAP: Record<string, "mini" | "classic" | "giant"> = {
+  mini: "mini",
+  classic: "classic",
+  giant: "giant",
+  "gc-mini": "mini",
+  "gc-classic": "classic",
+  "gc-large": "giant",
+};
 
-const BG_W = 2000
-const BG_H = 1333
-const ROOM_BG = '/mockups/cards/Card_mockups_room_background.jpg'
+const ICONS: Record<string, string> = {
+  "gc-mini": "/icons/mini_card_icon.svg",
+  "gc-classic": "/icons/classic_card_icon.svg",
+  "gc-large": "/icons/giant_card_icon.svg",
+  digital: "/icons/classic_card_icon.svg",
+};
 
-export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrls, mockups }: Props) {
-  const [choice, setChoice] = useState<string | null>(null)
-  const { addItem } = useBasket()
+const BG_W = 2000;
+const BG_H = 1333;
+const ROOM_BG = "/mockups/cards/Card_mockups_room_background.jpg";
 
-  const options =
-    products?.filter((p): p is { title: string; variantHandle: string } =>
+export default function AddToBasketDialog({
+  open,
+  onClose,
+  slug,
+  title,
+  coverUrl,
+  products,
+  onAdd,
+  generateProofUrls,
+  mockups,
+}: Props) {
+  const [choice, setChoice] = useState<string | null>(null);
+  const { addItem } = useBasket();
+
+  const options: ProductOption[] =
+    products?.filter((p): p is ProductOption =>
       Boolean(p && p.title && p.variantHandle),
-    ).map(p => ({ label: p.title, handle: p.variantHandle })) ??
-    DEFAULT_OPTIONS
+    ) ?? DEFAULT_OPTIONS;
 
-  const size = SIZE_MAP[choice ?? 'gc-classic']
-  const preview = mockups ? mockups[size] : undefined
+  const size = SIZE_MAP[choice ?? "gc-classic"];
+  const preview = mockups ? mockups[size] : undefined;
 
   const handleAdd = async () => {
-    if (!choice) return
+    if (!choice) return;
 
-    let proof = ''
-    let proofs: Record<string, string> = {}
+    let proof = "";
+    let proofs: Record<string, string> = {};
     if (generateProofUrls) {
       try {
-        const urls = await generateProofUrls(options.map(o => o.handle))
-        proofs = urls
-        const url = urls[choice]
-        if (typeof url === 'string' && url) {
-          proof = url
+        const urls = await generateProofUrls(
+          options.map((o) => o.variantHandle),
+        );
+        proofs = urls;
+        const url = urls[choice];
+        if (typeof url === "string" && url) {
+          proof = url;
         } else {
-          console.warn('Proof generation failed for', choice)
-          return
+          console.warn("Proof generation failed for", choice);
+          return;
         }
       } catch (err) {
-        console.error('proof generation', err)
-        return
+        console.error("proof generation", err);
+        return;
       }
     }
 
-    if (!proof) return
-    addItem({ slug, title, variant: choice, image: coverUrl, proofs })
-    onAdd?.(choice)
-    onClose()
-    setChoice(null)
-  }
+    if (!proof) return;
+    addItem({ slug, title, variant: choice, image: coverUrl, proofs });
+    onAdd?.(choice);
+    onClose();
+    setChoice(null);
+  };
 
   return (
     <Transition.Root show={open} as={Fragment}>
@@ -110,33 +135,64 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
                     left: `${(preview.box.x / BG_W) * 100}%`,
                     width: `${(preview.box.width / BG_W) * 100}%`,
                     height: `${(preview.box.height / BG_H) * 100}%`,
-                    transition:
-                      'all 0.4s cubic-bezier(0.175,0.885,0.32,1.275)',
+                    transition: "all 0.4s cubic-bezier(0.175,0.885,0.32,1.275)",
                   }}
                 />
               )}
             </div>
             <div className="p-6 space-y-4">
-              <h2 className="font-recoleta text-xl text-[--walty-teal]">Choose an option</h2>
-              <ul className="space-y-2">
+              <h2 className="font-recoleta text-xl text-[--walty-teal]">
+                Choose an option
+              </h2>
+              <ul className="space-y-3">
                 {options.map((opt) => (
-                  <li key={opt.handle}>
-                    <button
-                      onClick={() => setChoice(opt.handle)}
-                      className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.handle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
+                  <li key={opt.variantHandle}>
+                    <label
+                      className={`flex items-center gap-4 p-3 border-2 rounded-md cursor-pointer w-full ${choice === opt.variantHandle ? "border-[--walty-orange] bg-[#f3dea8]" : "border-gray-300 bg-[#F7F3EC]"}`}
                     >
-                      <span>{opt.label}</span>
-                      {choice === opt.handle && <Check className="text-[--walty-orange]" size={20} />}
-                    </button>
+                      <Image
+                        src={
+                          ICONS[opt.variantHandle] ??
+                          "/icons/classic_card_icon.svg"
+                        }
+                        alt=""
+                        width={52}
+                        height={52}
+                      />
+                      <div className="flex-1 flex flex-col space-y-1">
+                        <div className="font-bold">{opt.title}</div>
+                        {opt.blurb && (
+                          <p className="text-sm text-gray-600">{opt.blurb}</p>
+                        )}
+                        {typeof opt.price === "number" && (
+                          <div className="font-normal">
+                            £{opt.price.toFixed(2)}
+                          </div>
+                        )}
+                      </div>
+                      <input
+                        type="radio"
+                        name="variant"
+                        value={opt.variantHandle}
+                        checked={choice === opt.variantHandle}
+                        onChange={() => setChoice(opt.variantHandle)}
+                        className="accent-[--walty-orange]"
+                      />
+                    </label>
                   </li>
                 ))}
               </ul>
               <div className="flex justify-end gap-4 pt-2">
-                <button onClick={onClose} className="rounded-md border border-gray-300 px-4 py-2">Back to editor</button>
+                <button
+                  onClick={onClose}
+                  className="rounded-md border border-gray-300 px-4 py-2"
+                >
+                  Back to editor
+                </button>
                 <button
                   onClick={handleAdd}
                   disabled={!choice}
-                  className={`rounded-md px-4 py-2 font-semibold text-white ${choice ? 'bg-[--walty-orange] hover:bg-orange-600' : 'bg-gray-300 cursor-not-allowed'}`}
+                  className={`rounded-md px-4 py-2 font-semibold text-white ${choice ? "bg-[--walty-orange] hover:bg-orange-600" : "bg-gray-300 cursor-not-allowed"}`}
                 >
                   Add to basket
                 </button>
@@ -146,5 +202,5 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
         </Transition.Child>
       </Dialog>
     </Transition.Root>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- restyle AddToBasketDialog to mimic product page options
- add icons and info for each card variant

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687551af0dd48323a4c4582e70dc02fb