### PR TITLE
Update add-to-basket UI

### DIFF
--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -2,9 +2,16 @@
 
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
+import Image from 'next/image'
 import { Check } from 'lucide-react'
 import { useBasket } from '@/lib/useBasket'
 import type { Mockup } from '@/lib/generateCardMockups'
+
+const ICONS: Record<string, string> = {
+  'gc-mini': '/icons/mini_card_icon.svg',
+  'gc-classic': '/icons/classic_card_icon.svg',
+  'gc-large': '/icons/giant_card_icon.svg',
+}
 
 interface Props {
   open: boolean
@@ -12,7 +19,12 @@ interface Props {
   slug: string
   title: string
   coverUrl: string
-  products?: { title: string; variantHandle: string }[]
+  products?: {
+    title: string
+    variantHandle: string
+    blurb?: string
+    price?: number
+  }[]
   onAdd?: (variant: string) => void
   generateProofUrls?: (variants: string[]) => Promise<Record<string, string>>
   mockups?: Record<'mini' | 'classic' | 'giant', Mockup>
@@ -43,10 +55,17 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
   const { addItem } = useBasket()
 
   const options =
-    products?.filter((p): p is { title: string; variantHandle: string } =>
-      Boolean(p && p.title && p.variantHandle),
-    ).map(p => ({ label: p.title, handle: p.variantHandle })) ??
-    DEFAULT_OPTIONS
+    products?.filter((p): p is {
+      title: string
+      variantHandle: string
+      blurb?: string
+      price?: number
+    } => Boolean(p && p.title && p.variantHandle)) ??
+    []
+
+  const opts = options.length
+    ? options
+    : DEFAULT_OPTIONS.map(o => ({ label: o.label, handle: o.handle }))
 
   const size = SIZE_MAP[choice ?? 'gc-classic']
   const preview = mockups ? mockups[size] : undefined
@@ -58,7 +77,7 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
     let proofs: Record<string, string> = {}
     if (generateProofUrls) {
       try {
-        const urls = await generateProofUrls(options.map(o => o.handle))
+        const urls = await generateProofUrls(opts.map(o => o.variantHandle ?? o.handle))
         proofs = urls
         const url = urls[choice]
         if (typeof url === 'string' && url) {
@@ -119,17 +138,39 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
             <div className="p-6 space-y-4">
               <h2 className="font-recoleta text-xl text-[--walty-teal]">Choose an option</h2>
               <ul className="space-y-2">
-                {options.map((opt) => (
-                  <li key={opt.handle}>
-                    <button
-                      onClick={() => setChoice(opt.handle)}
-                      className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.handle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
-                    >
-                      <span>{opt.label}</span>
-                      {choice === opt.handle && <Check className="text-[--walty-orange]" size={20} />}
-                    </button>
-                  </li>
-                ))}
+                {opts.map((opt) => {
+                  const handle = (opt as any).variantHandle ?? (opt as any).handle
+                  const label  = opt.title ?? (opt as any).label
+                  const price  = (opt as any).price
+                  const blurb  = (opt as any).blurb
+                  return (
+                    <li key={handle}>
+                      <label
+                        className={`flex items-center gap-3 px-3 py-2 border-2 rounded-md cursor-pointer ${choice === handle ? 'border-[--walty-orange] bg-[#f3dea8]' : 'border-gray-300 bg-[#F7F3EC]'}`}
+                      >
+                        <Image
+                          src={ICONS[handle] ?? '/icons/classic_card_icon.svg'}
+                          alt=""
+                          width={40}
+                          height={40}
+                        />
+                        <div className="flex-1 flex flex-col space-y-0.5">
+                          <div className="font-bold">{label}</div>
+                          {blurb && <p className="text-sm text-gray-600">{blurb}</p>}
+                          {typeof price === 'number' && <div className="font-normal">£{price.toFixed(2)}</div>}
+                        </div>
+                        <input
+                          type="radio"
+                          name="size"
+                          value={handle}
+                          checked={choice === handle}
+                          onChange={() => setChoice(handle)}
+                          className="accent-[--walty-orange]"
+                        />
+                      </label>
+                    </li>
+                  )
+                })}
               </ul>
               <div className="flex justify-end gap-4 pt-2">
                 <button onClick={onClose} className="rounded-md border border-gray-300 px-4 py-2">Back to editor</button>

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -21,6 +21,7 @@ export interface TemplateProduct {
   _id: string
   slug: string
   title: string
+  blurb?: string
   variantHandle: string
   price?: number
   printSpec?: PrintSpec
@@ -59,6 +60,7 @@ export async function getTemplatePages(
     "products": products[]->variants[]->{
       _id,
       title,
+      blurb,
       "slug": slug.current,
       variantHandle,
       price,


### PR DESCRIPTION
## Summary
- include blurb in template product type
- fetch blurb from Sanity when loading template data
- restyle AddToBasketDialog to match product page variant list
- compress AddToBasket option height

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, etc.)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module '@dnd-kit/core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687551af0dd48323a4c4582e70dc02fb