### PR TITLE
Add Sanity visualVariant schema

### DIFF
--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -7,6 +7,7 @@ import cardProduct   from './cardProduct'
 import product       from './product'
 import productMockup from './productMockup'
 import sitePage      from './sitePage'
+import visualVariant from './visualVariant'
 
 /* commerce ---------------------------------------------- */
 import fulfilOption from './commerce/fulfilOption'
@@ -21,6 +22,10 @@ import editableImage from './editableImage'
 import editableText  from './editableText'
 import heroSection   from './heroSection'
 import printSpec     from './printSpec'
+import mockupSettings from './objects/mockupSettings'
+import printArea      from './objects/printArea'
+import cameraPose     from './objects/cameraPose'
+import colourVariant  from './objects/colourVariant'
 
 /* facet look-ups ----------------------------------------------- */
 import occasion from './occasion'   // ← RE-ADDED ✔
@@ -38,6 +43,7 @@ export const schemaTypes = [
   sitePage,
   fulfilOption,
   skuMap,
+  visualVariant,
   aiPlaceholder,
   printSpec,
 
@@ -46,6 +52,10 @@ export const schemaTypes = [
   editableImage,
   editableText,
   heroSection,
+  mockupSettings,
+  printArea,
+  cameraPose,
+  colourVariant,
 
   /* facets */
   occasion,

--- a/sanity/schemaTypes/objects/cameraPose.ts
+++ b/sanity/schemaTypes/objects/cameraPose.ts
@@ -1,0 +1,17 @@
+import {defineType, defineField} from 'sanity'
+
+export default defineType({
+  name: 'cameraPose',
+  type: 'object',
+  title: 'Camera pose',
+  fields: [
+    defineField({ name: 'name', type: 'string', validation: r => r.required() }),
+    defineField({ name: 'posX', type: 'number', title: 'Pos X', validation: r => r.required() }),
+    defineField({ name: 'posY', type: 'number', title: 'Pos Y', validation: r => r.required() }),
+    defineField({ name: 'posZ', type: 'number', title: 'Pos Z', validation: r => r.required() }),
+    defineField({ name: 'targetX', type: 'number', title: 'Target X' }),
+    defineField({ name: 'targetY', type: 'number', title: 'Target Y' }),
+    defineField({ name: 'targetZ', type: 'number', title: 'Target Z' }),
+    defineField({ name: 'fov', type: 'number', title: 'FOV' }),
+  ],
+})

--- a/sanity/schemaTypes/objects/colourVariant.ts
+++ b/sanity/schemaTypes/objects/colourVariant.ts
@@ -1,0 +1,17 @@
+import {defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineType({
+  name: 'colourVariant',
+  type: 'object',
+  title: 'Colour variant',
+  fields: [
+    defineField({ name: 'name', type: 'string', title: 'Colour name', validation: r => r.required() }),
+    defineField({ name: 'tint', type: 'string', title: 'Tint HEX', validation: r => r.required() }),
+    defineField({
+      name: 'meshes',
+      type: 'array',
+      title: 'Mesh names',
+      of: [defineArrayMember({ type: 'string' })],
+    }),
+  ],
+})

--- a/sanity/schemaTypes/objects/mockupSettings.ts
+++ b/sanity/schemaTypes/objects/mockupSettings.ts
@@ -1,0 +1,32 @@
+import {defineType, defineField} from 'sanity'
+
+export default defineType({
+  name: 'mockupSettings',
+  type: 'object',
+  title: 'Mockup settings',
+  fields: [
+    defineField({
+      name: 'model',
+      type: 'file',
+      title: 'GLB model',
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'hdr',
+      type: 'file',
+      title: 'HDR environment',
+    }),
+    defineField({
+      name: 'printAreas',
+      type: 'array',
+      title: 'Printable areas',
+      of: [{type: 'printArea'}],
+    }),
+    defineField({
+      name: 'cameras',
+      type: 'array',
+      title: 'Camera poses',
+      of: [{type: 'cameraPose'}],
+    }),
+  ],
+})

--- a/sanity/schemaTypes/objects/printArea.ts
+++ b/sanity/schemaTypes/objects/printArea.ts
@@ -1,0 +1,11 @@
+import {defineType, defineField} from 'sanity'
+
+export default defineType({
+  name: 'printArea',
+  type: 'object',
+  title: 'Print area',
+  fields: [
+    defineField({ name: 'id', type: 'string', title: 'Area ID', validation: r => r.required() }),
+    defineField({ name: 'mesh', type: 'string', title: 'Mesh name', validation: r => r.required() }),
+  ],
+})

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -95,5 +95,11 @@ export default defineType({
     of: [{ type: 'reference', to: [{ type: 'cardProduct' }] }],
     validation: r => r.min(1),
   }),
+  defineField({
+    name: 'visualVariants',
+    type: 'array',
+    title: 'Visual variants',
+    of: [{ type: 'reference', to: [{ type: 'visualVariant' }] }],
+  }),
   ],
 })

--- a/sanity/schemaTypes/visualVariant.ts
+++ b/sanity/schemaTypes/visualVariant.ts
@@ -1,0 +1,48 @@
+import {defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineType({
+  name: 'visualVariant',
+  type: 'document',
+  title: 'Visual variant',
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'skuMap',
+      type: 'reference',
+      title: 'SKU map',
+      to: [{ type: 'skuMap' }],
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'mockupSettings',
+      type: 'mockupSettings',
+      title: 'Mockup settings',
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'colourVariants',
+      type: 'array',
+      title: 'Colour variants',
+      of: [{ type: 'colourVariant' }],
+    }),
+    defineField({
+      name: 'previewImages',
+      type: 'array',
+      title: 'Preview images',
+      of: [
+        defineArrayMember({
+          type: 'object',
+          fields: [
+            defineField({ name: 'colour', type: 'string', title: 'Colour key' }),
+            defineField({ name: 'camera', type: 'string', title: 'Camera' }),
+            defineField({ name: 'url', type: 'url', title: 'PNG URL' }),
+          ],
+        }),
+      ],
+    }),
+  ],
+})

--- a/sanity/schemaTypes/visualVariant.ts
+++ b/sanity/schemaTypes/visualVariant.ts
@@ -11,10 +11,10 @@ export default defineType({
       validation: r => r.required(),
     }),
     defineField({
-      name: 'skuMap',
+      name: 'variant',
       type: 'reference',
-      title: 'SKU map',
-      to: [{ type: 'skuMap' }],
+      title: 'Variant',
+      to: [{ type: 'cardProduct' }],
       validation: r => r.required(),
     }),
     defineField({

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -178,6 +178,7 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
               S.documentTypeListItem('printSpec').title('Print specs'),
               S.documentTypeListItem('fulfilOption').title('Fulfil options'),
               S.documentTypeListItem('skuMap').title('SKU maps'),
+              S.documentTypeListItem('visualVariant').title('Visual variants'),
             ]),
         ),
 


### PR DESCRIPTION
## Summary
- add `visualVariant` document
- create reusable object schemas under `objects/`
- export new types and update product document
- expose visual variants in desk structure

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, no-img-element, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68765f713c808323b9a924480ffa9979