### PR TITLE
Add render stub & simple mockup test

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { designPNGs } = await req.json()
+    if (!designPNGs || typeof designPNGs !== 'object') {
+      return NextResponse.json({ error: 'bad input' }, { status: 400 })
+    }
+    const urls: Record<string, string> = {}
+    for (const key of Object.keys(designPNGs)) {
+      const src = designPNGs[key]
+      if (typeof src === 'string') {
+        urls[key] = src
+      }
+    }
+    return NextResponse.json({ urls })
+  } catch (err) {
+    console.error('[render]', err)
+    return NextResponse.json({ error: 'server-error' }, { status: 500 })
+  }
+}

--- a/app/mockup-test/[variantId]/MockupClient.tsx
+++ b/app/mockup-test/[variantId]/MockupClient.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useState } from 'react'
+
+interface Props {
+  variantId: string
+  areaId: string
+}
+
+export default function MockupClient({ variantId, areaId }: Props) {
+  const [preview, setPreview] = useState<string>('')
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = async () => {
+      const base64 = reader.result as string
+      const res = await fetch('/api/render', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ variantId, designPNGs: { [areaId]: base64 } })
+      })
+      const data = await res.json()
+      if (data?.urls && data.urls[areaId]) {
+        setPreview(data.urls[areaId])
+      }
+    }
+    reader.readAsDataURL(file)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="w-64 h-64 border flex items-center justify-center">
+        {preview && (
+          <img src={preview} alt="preview" className="max-h-full object-contain" />
+        )}
+      </div>
+      <input type="file" accept="image/png" onChange={handleChange} />
+    </div>
+  )
+}

--- a/app/mockup-test/[variantId]/page.tsx
+++ b/app/mockup-test/[variantId]/page.tsx
@@ -1,0 +1,22 @@
+import MockupClient from './MockupClient'
+import { sanityPreview } from '@/sanity/lib/client'
+
+export default async function MockupTestPage({ params }: { params: { variantId: string }}) {
+  const { variantId } = params
+  const data = await sanityPreview.fetch(
+    `*[_type=="visualVariant" && (variant._ref==$id || variant->slug.current==$id || _id==$id)][0]{
+      title,
+      mockupSettings{ printAreas }
+    }`,
+    { id: variantId }
+  )
+
+  const areaId = data?.mockupSettings?.printAreas?.[0]?.id || 'wrap'
+
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-xl font-bold">{data?.title || variantId}</h1>
+      <MockupClient variantId={variantId} areaId={areaId} />
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/api/render` route that echoes uploaded PNGs
- implement `/mockup-test/[variantId]` page with file upload to call the API

## Testing
- `npm run lint` *(fails: react-hooks rules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68769956ad3083239ba80b0a24470167