### PR TITLE
Implement server-side GLB renderer (incomplete)

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,21 +1,59 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { readFile } from 'fs/promises'
+import path from 'path'
+import { createCanvas, Image } from 'canvas'
+import gl from 'gl'
+import * as THREE from 'three'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: NextRequest) {
   try {
     const { designPNGs } = await req.json()
-    if (!designPNGs || typeof designPNGs !== 'object') {
+    if (!designPNGs || typeof designPNGs !== 'object' || typeof designPNGs['wrap'] !== 'string') {
       return NextResponse.json({ error: 'bad input' }, { status: 400 })
     }
-    const urls: Record<string, string> = {}
-    for (const key of Object.keys(designPNGs)) {
-      const src = designPNGs[key]
-      if (typeof src === 'string') {
-        urls[key] = src
-      }
+
+    const base64 = designPNGs['wrap'] as string
+    const pngData = base64.replace(/^data:image\/\w+;base64,/, '')
+    const textureBuffer = Buffer.from(pngData, 'base64')
+
+    const width = 1024
+    const height = 1024
+    const canvas = createCanvas(width, height)
+    const glContext = gl(width, height)
+    const renderer = new THREE.WebGLRenderer({ context: glContext as unknown as WebGLRenderingContext, canvas })
+    renderer.setSize(width, height)
+
+    const scene = new THREE.Scene()
+    scene.add(new THREE.AmbientLight(0xffffff))
+
+    const loader = new GLTFLoader()
+    const modelPath = path.join(process.cwd(), 'public', 'mug.glb')
+    const modelData = await readFile(modelPath)
+    const gltf = await new Promise<THREE.GLTF>((resolve, reject) => {
+      loader.parse(modelData.buffer as ArrayBuffer, '', resolve, reject)
+    })
+    scene.add(gltf.scene)
+
+    const textureLoader = new THREE.TextureLoader()
+    const texture = textureLoader.load(`data:image/png;base64,${textureBuffer.toString('base64')}`)
+    const mesh = gltf.scene.getObjectByName('PrintArea-wrap') as THREE.Mesh
+    if (mesh && mesh.material && (mesh.material as any).map) {
+      ;(mesh.material as any).map = texture
+      ;(mesh.material as any).needsUpdate = true
     }
-    return NextResponse.json({ urls })
+
+    const camera = new THREE.PerspectiveCamera(35, width / height, 0.1, 100)
+    camera.position.set(2, 2, 2)
+    camera.lookAt(0, 0, 0)
+
+    renderer.render(scene, camera)
+
+    const buffer = canvas.toBuffer('image/png')
+    const out = `data:image/png;base64,${buffer.toString('base64')}`
+    return NextResponse.json({ urls: { wrap: out } })
   } catch (err) {
     console.error('[render]', err)
     return NextResponse.json({ error: 'server-error' }, { status: 500 })

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "react-virtuoso": "^4.12.7",
     "sanity": "^3.88.1",
     "sanity-plugin-media": "^3.0.2",
+    "three": "^0.165.0",
+    "canvas": "^2.11.2",
+    "gl": "^5.0.0",
     "sharp": "^0.34.1",
     "styled-components": "^6.1.17",
     "zustand": "^5.0.3"


### PR DESCRIPTION
## Summary
- flesh out the render API route with a three.js based pipeline
- add three.js and supporting libraries to dependencies

## Testing
- `npm run build` *(fails: module not found for three, gl, GLTFLoader, canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68769e28267c8323a6f598acdc847b0c