### PR TITLE
Restrict file uploader types

### DIFF
--- a/app/components/CanvasInner.tsx
+++ b/app/components/CanvasInner.tsx
@@ -64,7 +64,7 @@ export default function CanvasInner() {
         {/* plain file input for now */}
         <input
           type="file"
-          accept="image/*"
+          accept="image/png, image/jpeg"
           onChange={(e) => {
             const file = e.currentTarget.files?.[0];
             if (file) addImage(file);

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -165,7 +165,7 @@ export default function LayerPanel() {
         <span className="font-medium">Upload</span>
         <input
           type="file"
-          accept="image/*"
+          accept="image/png, image/jpeg"
           className="hidden"
           onChange={(e) => {
             const f = e.target.files?.[0];

--- a/app/components/SelfieDrawer.tsx
+++ b/app/components/SelfieDrawer.tsx
@@ -351,7 +351,7 @@ function DropZone({
       <input
         ref={inputRef}
         type="file"
-        accept="image/*"
+        accept="image/png, image/jpeg"
         onChange={e => handleFiles(e.target.files)}
         className="sr-only"
       />


### PR DESCRIPTION
## Summary
- restrict file inputs to PNG and JPEG formats to speed up file dialogs

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876cd5e1d7c8323a6503d2419e7571d