### PR TITLE
Enable variant-driven GLB rendering

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,23 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { readFile } from 'fs/promises'
-import path from 'path'
-import { createCanvas, Image } from 'canvas'
+import { createCanvas } from 'canvas'
 import gl from 'gl'
 import * as THREE from 'three'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { sanity, sanityPreview } from '@/sanity/lib/client'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: NextRequest) {
   try {
-    const { designPNGs } = await req.json()
-    if (!designPNGs || typeof designPNGs !== 'object' || typeof designPNGs['wrap'] !== 'string') {
+    const { variantId, designPNGs } = await req.json()
+    if (!variantId || typeof variantId !== 'string' || !designPNGs || typeof designPNGs !== 'object') {
       return NextResponse.json({ error: 'bad input' }, { status: 400 })
     }
 
-    const base64 = designPNGs['wrap'] as string
-    const pngData = base64.replace(/^data:image\/\w+;base64,/, '')
-    const textureBuffer = Buffer.from(pngData, 'base64')
+    const designEntries = Object.entries(designPNGs).filter(([, v]) => typeof v === 'string') as [string, string][]
+    if (!designEntries.length) {
+      return NextResponse.json({ error: 'no design data' }, { status: 400 })
+    }
 
     const width = 1024
     const height = 1024
@@ -30,30 +30,79 @@ export async function POST(req: NextRequest) {
     scene.add(new THREE.AmbientLight(0xffffff))
 
     const loader = new GLTFLoader()
-    const modelPath = path.join(process.cwd(), 'public', 'mug.glb')
-    const modelData = await readFile(modelPath)
+
+    const query = `*[_type=="visualVariant" && (variant._ref==$id || variant->slug.current==$id || _id==$id)][0]{
+      "modelUrl": mockupSettings.model.asset->url,
+      "areas": mockupSettings.printAreas[]{id, mesh},
+      "camera": mockupSettings.cameras[0]
+    }`
+    const params = { id: variantId }
+    const client = process.env.SANITY_READ_TOKEN ? sanityPreview : sanity
+    const variant = await client.fetch<{
+      modelUrl?: string
+      areas?: { id: string; mesh?: string }[]
+      camera?: {
+        name?: string
+        posX?: number
+        posY?: number
+        posZ?: number
+        targetX?: number
+        targetY?: number
+        targetZ?: number
+        fov?: number
+      }
+    }>(query, params)
+    if (!variant?.modelUrl) {
+      return NextResponse.json({ error: 'variant-not-found' }, { status: 404 })
+    }
+
+    const modelResp = await fetch(variant.modelUrl)
+    if (!modelResp.ok) {
+      return NextResponse.json({ error: 'model-download' }, { status: 500 })
+    }
+    const modelBuffer = await modelResp.arrayBuffer()
     const gltf = await new Promise<THREE.GLTF>((resolve, reject) => {
-      loader.parse(modelData.buffer as ArrayBuffer, '', resolve, reject)
+      loader.parse(modelBuffer as ArrayBuffer, '', resolve, reject)
     })
     scene.add(gltf.scene)
 
     const textureLoader = new THREE.TextureLoader()
-    const texture = textureLoader.load(`data:image/png;base64,${textureBuffer.toString('base64')}`)
-    const mesh = gltf.scene.getObjectByName('PrintArea-wrap') as THREE.Mesh
-    if (mesh && mesh.material && (mesh.material as any).map) {
-      ;(mesh.material as any).map = texture
-      ;(mesh.material as any).needsUpdate = true
+    const urls: Record<string, string> = {}
+    for (const [areaId, dataUrl] of designEntries) {
+      const pngData = dataUrl.replace(/^data:image\/\w+;base64,/, '')
+      const buf = Buffer.from(pngData, 'base64')
+      const texture = textureLoader.load(`data:image/png;base64,${buf.toString('base64')}`)
+      const meshName =
+        variant.areas?.find(a => a.id === areaId)?.mesh || `PrintArea-${areaId}`
+      const mesh = gltf.scene.getObjectByName(meshName) as THREE.Mesh
+      if (mesh && mesh.material && (mesh.material as any).map) {
+        ;(mesh.material as any).map = texture
+        ;(mesh.material as any).needsUpdate = true
+      }
     }
 
-    const camera = new THREE.PerspectiveCamera(35, width / height, 0.1, 100)
-    camera.position.set(2, 2, 2)
-    camera.lookAt(0, 0, 0)
+    const camDef = variant.camera
+    const fov = camDef?.fov ?? 35
+    const camera = new THREE.PerspectiveCamera(fov, width / height, 0.1, 100)
+    camera.position.set(
+      camDef?.posX ?? 2,
+      camDef?.posY ?? 2,
+      camDef?.posZ ?? 2
+    )
+    const target = new THREE.Vector3(
+      camDef?.targetX ?? 0,
+      camDef?.targetY ?? 0,
+      camDef?.targetZ ?? 0
+    )
+    camera.lookAt(target)
+    const cameraName = camDef?.name || 'default'
 
     renderer.render(scene, camera)
 
     const buffer = canvas.toBuffer('image/png')
     const out = `data:image/png;base64,${buffer.toString('base64')}`
-    return NextResponse.json({ urls: { wrap: out } })
+    urls[cameraName] = out
+    return NextResponse.json({ urls })
   } catch (err) {
     console.error('[render]', err)
     return NextResponse.json({ error: 'server-error' }, { status: 500 })


### PR DESCRIPTION
## Summary
- render API now loads GLB URL from Sanity based on `variantId`
- fetch first camera pose from Sanity and set Three.js camera
- apply textures for each submitted print area rather than only `wrap`
- return rendered PNG keyed by camera name

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other lint errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876d4f320248323b73a260d586c5210