### PR TITLE
Fix canvas import

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createCanvas } from 'canvas'
 import gl from 'gl'
 import * as THREE from 'three'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
@@ -21,6 +20,7 @@ export async function POST(req: NextRequest) {
 
     const width = 1024
     const height = 1024
+    const { createCanvas } = await import('canvas')
     const canvas = createCanvas(width, height)
     const glContext = gl(width, height)
     const renderer = new THREE.WebGLRenderer({ context: glContext as unknown as WebGLRenderingContext, canvas })


### PR DESCRIPTION
## Summary
- avoid compile errors by dynamically importing `canvas`

## Testing
- `npm run build` *(fails: react lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876daacf0a88323805d9f4af7908aae