### PR TITLE
Fix canvas import

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## CMS-driven preview
 Products now store a `previewSpec` and page settings. Templates link to these products so the editor opens with the correct canvas size and safe‑area guides.
+
+## Rendering requirements
+
+Server-side mockup rendering depends on a Node canvas implementation. The API
+tries to load the native `canvas` module first and falls back to
+`@napi-rs/canvas`. If neither module is available, `/api/render` will return a
+`canvas-not-installed` error. Ensure one of these packages can be resolved in
+your environment.

--- a/README.md
+++ b/README.md
@@ -55,5 +55,15 @@ Products now store a `previewSpec` and page settings. Templates link to these pr
 Server-side mockup rendering depends on a Node canvas implementation. The API
 tries to load the native `canvas` module first and falls back to
 `@napi-rs/canvas`. If neither module is available, `/api/render` will return a
-`canvas-not-installed` error. Ensure one of these packages can be resolved in
-your environment.
+`canvas-not-installed` error. Make sure one of these packages is installed by
+running either:
+
+```bash
+npm install canvas       # builds from source
+# or
+npm install @napi-rs/canvas  # prebuilt binaries
+```
+
+After pulling updates that modify `package.json`, reinstall dependencies with
+`npm install` (or `pnpm install` if you use pnpm) so the canvas package is
+available to the API.

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,14 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createCanvas } from 'canvas'
-import gl from 'gl'
-import * as THREE from 'three'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import { sanity, sanityPreview } from '@/sanity/lib/client'
+
+export const runtime = 'nodejs'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: NextRequest) {
   try {
+    let createCanvas: any
+    try {
+      ;({ createCanvas } = await import(/* webpackIgnore: true */ 'canvas'))
+    } catch (err) {
+      try {
+        ;({ createCanvas } = await import(
+          /* webpackIgnore: true */ '@napi-rs/canvas'
+        ))
+      } catch (err2) {
+        console.error('[render] no canvas module', err, err2)
+        return NextResponse.json({ error: 'canvas-not-installed' }, { status: 500 })
+      }
+    }
+    const { default: gl } = await import(/* webpackIgnore: true */ 'gl')
+    const THREE = await import(/* webpackIgnore: true */ 'three')
+    const { GLTFLoader } = await import(
+      /* webpackIgnore: true */ 'three/examples/jsm/loaders/GLTFLoader.js'
+    )
     const { variantId, designPNGs } = await req.json()
     if (!variantId || typeof variantId !== 'string' || !designPNGs || typeof designPNGs !== 'object') {
       return NextResponse.json({ error: 'bad input' }, { status: 400 })
@@ -61,7 +77,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'model-download' }, { status: 500 })
     }
     const modelBuffer = await modelResp.arrayBuffer()
-    const gltf = await new Promise<THREE.GLTF>((resolve, reject) => {
+    const gltf = await new Promise<any>((resolve, reject) => {
       loader.parse(modelBuffer as ArrayBuffer, '', resolve, reject)
     })
     scene.add(gltf.scene)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "sanity-plugin-media": "^3.0.2",
     "three": "^0.165.0",
     "canvas": "^2.11.2",
+    "@napi-rs/canvas": "^0.1.40",
     "gl": "^5.0.0",
     "sharp": "^0.34.1",
     "styled-components": "^6.1.17",


### PR DESCRIPTION
## Summary
- allow `/api/render` to fall back to `@napi-rs/canvas` when `canvas` isn't installed
- document mockup rendering dependencies

## Testing
- `npm run lint` *(fails: multiple ESLint errors)*
- `timeout 20 npm run build` *(hangs without finishing)*

------
https://chatgpt.com/codex/tasks/task_e_6876daacf0a88323805d9f4af7908aae