### PR TITLE
Fix upload API runtime

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -3,6 +3,9 @@
  *********************************************************************/
 import { NextRequest, NextResponse } from 'next/server'
 import { sanityWriteClient as sanity } from '@/sanity/lib/client'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
 export async function POST (req: NextRequest) {
   const data = await req.formData()
   const file = data.get('file') as File | null


### PR DESCRIPTION
## Summary
- ensure `/api/upload` explicitly runs in the Node runtime

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, react-hooks/rules-of-hooks, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877a6e4f0148323b99e3b06602f4c3b