### PR TITLE
Fix upload button not responding

### DIFF
--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -166,7 +166,7 @@ export default function LayerPanel() {
         <input
           type="file"
           accept="image/*"
-          className="hidden"
+          className="sr-only"
           onChange={(e) => {
             const f = e.target.files?.[0];
             if (f) addImage(f);


### PR DESCRIPTION
## Summary
- ensure the upload input in `LayerPanel` is accessible by using `sr-only` instead of `hidden`

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, react/no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877ae1e28f48323b95815aac99405be