### PR TITLE
Fix canvas fallback for server-side rendering

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -59,7 +59,7 @@ export async function POST (req: NextRequest) {
           name === 'OES_standard_derivatives' ? {} : origGetExtension(name)
 
     /* 3-B · Browser-DOM poly-fill so ImageLoader works in Node */
-    const { Image } = await import('canvas')
+    const { Image } = await import('@/lib/canvas')
     ;(globalThis as any).Image = Image
 
         // -- add event-listener stubs (cast to any to silence TS)

--- a/lib/canvas.ts
+++ b/lib/canvas.ts
@@ -1,6 +1,22 @@
 // lib/canvas.ts
 import type * as NodeCanvas from 'canvas'
-const { createCanvas: _createRawCanvas, loadImage } = require('canvas') as typeof NodeCanvas
+
+let canvasMod: typeof NodeCanvas | null = null
+try {
+  canvasMod = require('canvas') as typeof NodeCanvas
+} catch {
+  try {
+    canvasMod = require('@napi-rs/canvas') as typeof NodeCanvas
+  } catch {
+    canvasMod = null
+  }
+}
+
+if (!canvasMod) {
+  throw new Error('canvas-not-installed')
+}
+
+const { createCanvas: _createRawCanvas, loadImage, Image } = canvasMod
 
 export function createCanvas (width: number, height: number) {
   const canvas = _createRawCanvas(width, height) as any
@@ -10,4 +26,4 @@ export function createCanvas (width: number, height: number) {
   return canvas
 }
 
-export { loadImage }
+export { loadImage, Image }


### PR DESCRIPTION
## Summary
- add runtime fallback to `@napi-rs/canvas`
- use the canvas helper module in API route

## Testing
- `npx eslint lib/canvas.ts app/api/render/route.ts`
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules and other errors)*
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build` *(fails: compile errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6877ddbb154c8323bc52563e974e3f55