### PR TITLE
Use WebGL1Renderer for server-side mockups

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sanity, sanityPreview } from '@/sanity/lib/client'
 import { createCanvas } from '@/lib/canvas'
+import { WebGL1Renderer } from 'three/examples/jsm/renderers/WebGL1Renderer.js'
 
 // ⬇︎ types-only import so we can cast meshes safely
 import type { Mesh as ThreeMesh } from 'three'
@@ -14,7 +15,6 @@ export async function POST (req: NextRequest) {
     /* ───── 1 · Runtime-load libs ───── */
     const THREE          = await import('three')
     const { GLTFLoader } = await import('three/examples/jsm/loaders/GLTFLoader')
-    let WebGL1Renderer: any; try { ({ WebGL1Renderer } = eval('require')('three/examples/jsm/renderers/WebGL1Renderer.js')); } catch { ({ WebGLRenderer: WebGL1Renderer } = await import('three')); }
     const { default: gl } = await import(/* webpackIgnore: true */ 'gl')
 
     const {


### PR DESCRIPTION
## Summary
- import `WebGL1Renderer` from `three/examples/jsm/renderers/WebGL1Renderer.js`
- instantiate `WebGL1Renderer` with the headless `gl` context and set renderer size

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6878a164ddf08323aa9a62296ff4db7e