### PR TITLE
Fix WebGL renderer import

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -14,7 +14,7 @@ export async function POST (req: NextRequest) {
     /* ───── 1 · Runtime-load libs ───── */
     const THREE          = await import('three')
     const { GLTFLoader } = await import('three/examples/jsm/loaders/GLTFLoader')
-    let WebGL1Renderer: any; try { ({ WebGL1Renderer } = eval('require')('three/examples/jsm/renderers/WebGL1Renderer.js')); } catch { ({ WebGLRenderer: WebGL1Renderer } = await import('three')); }
+    const { WebGL1Renderer } = await import('@/lib/WebGL1Renderer')
     const { default: gl } = await import(/* webpackIgnore: true */ 'gl')
 
     const {

--- a/lib/WebGL1Renderer.ts
+++ b/lib/WebGL1Renderer.ts
@@ -1,0 +1,10 @@
+import { WebGLRenderer, WebGLRendererParameters } from 'three'
+
+export class WebGL1Renderer extends WebGLRenderer {
+  constructor (parameters?: WebGLRendererParameters) {
+    super(parameters)
+    ;(this as any).isWebGL1Renderer = true
+  }
+}
+
+export default WebGL1Renderer

--- a/types/three-webgl1.d.ts
+++ b/types/three-webgl1.d.ts
@@ -1,7 +1,7 @@
-declare module 'three/examples/jsm/renderers/WebGL1Renderer.js' {
-    import { WebGLRenderer, WebGLRendererParameters } from 'three';
-    export class WebGL1Renderer extends WebGLRenderer {
-      constructor(parameters?: WebGLRendererParameters);
-    }
+declare module '@/lib/WebGL1Renderer' {
+  import { WebGLRenderer, WebGLRendererParameters } from 'three'
+  export class WebGL1Renderer extends WebGLRenderer {
+    constructor(parameters?: WebGLRendererParameters);
   }
-  
+  export default WebGL1Renderer
+}


### PR DESCRIPTION
## Summary
- implement a simple `WebGL1Renderer` wrapper
- update type declaration
- use local `WebGL1Renderer` in render API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878a9a323fc8323a12fbcb1da2e7f76