### PR TITLE
Fix shader compilation in render API

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -87,6 +87,11 @@ export async function POST (req: NextRequest) {
       canvas,
       context: glContext as unknown as WebGLRenderingContext,
     })
+    // WebGLCapabilities in three 0.178 always marks the context as WebGL2.
+    // This breaks headless-gl which only implements WebGL1. Force the
+    // renderer to treat the context as WebGL1 so shaders are generated with
+    // `#version 100` and avoid unsupported features like `sampler3D`.
+    ;(renderer as any).capabilities.isWebGL2 = false
     renderer.setSize(width, height)
 
     /* ───── 4 · Scene & model ───── */


### PR DESCRIPTION
## Summary
- enforce WebGL1 mode in the render API

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6878a9a323fc8323a12fbcb1da2e7f76