### PR TITLE
Fix shader compilation in render API

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -14,7 +14,7 @@ export async function POST (req: NextRequest) {
     /* ───── 1 · Runtime-load libs ───── */
     const THREE          = await import('three')
     const { GLTFLoader } = await import('three/examples/jsm/loaders/GLTFLoader')
-    let WebGL1Renderer: any; try { ({ WebGL1Renderer } = eval('require')('three/examples/jsm/renderers/WebGL1Renderer.js')); } catch { ({ WebGLRenderer: WebGL1Renderer } = await import('three')); }
+    const { default: WebGL1Renderer } = await import('@/lib/WebGL1Renderer')
     const { default: gl } = await import(/* webpackIgnore: true */ 'gl')
 
     const {
@@ -87,6 +87,11 @@ export async function POST (req: NextRequest) {
       canvas,
       context: glContext as unknown as WebGLRenderingContext,
     })
+    // WebGLCapabilities in three 0.178 always marks the context as WebGL2.
+    // This breaks headless-gl which only implements WebGL1. Force the
+    // renderer to treat the context as WebGL1 so shaders are generated with
+    // `#version 100` and avoid unsupported features like `sampler3D`.
+    ;(renderer as any).capabilities.isWebGL2 = false
     renderer.setSize(width, height)
 
     /* ───── 4 · Scene & model ───── */

--- a/lib/WebGL1Renderer.ts
+++ b/lib/WebGL1Renderer.ts
@@ -1,0 +1,9 @@
+import { WebGLRenderer, type WebGLRendererParameters } from 'three'
+
+export default class WebGL1Renderer extends WebGLRenderer {
+  readonly isWebGL1Renderer = true
+  constructor(parameters?: WebGLRendererParameters) {
+    super(parameters)
+    ;(this as any).capabilities.isWebGL2 = false
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight WebGL1Renderer helper
- use the helper in the render route instead of falling back to WebGL2

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6878a9a323fc8323a12fbcb1da2e7f76