### PR TITLE
Fix shader compilation in render API

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -14,7 +14,7 @@ export async function POST (req: NextRequest) {
     /* ───── 1 · Runtime-load libs ───── */
     const THREE          = await import('three')
     const { GLTFLoader } = await import('three/examples/jsm/loaders/GLTFLoader')
-    let WebGL1Renderer: any; try { ({ WebGL1Renderer } = eval('require')('three/examples/jsm/renderers/WebGL1Renderer.js')); } catch { ({ WebGLRenderer: WebGL1Renderer } = await import('three')); }
+    const { WebGLRenderer } = THREE
     const { default: gl } = await import(/* webpackIgnore: true */ 'gl')
 
     const {
@@ -37,32 +37,20 @@ export async function POST (req: NextRequest) {
     /* ───── 3 · Canvas + GL context ───── */
     const width = 1024, height = 1024
     const canvas    = createCanvas(width, height) as any
-    const glContext = gl(width, height, { preserveDrawingBuffer: true }) as any
-
-        /* 3-A.1 · Pretend we’re WebGL 1 so Three compiles #version 100 shaders */
-        const origGetParameter = glContext.getParameter.bind(glContext)
-        glContext.getParameter = (p: number) => {
-          if (p === glContext.VERSION)                  return 'WebGL 1.0'
-          if (p === glContext.SHADING_LANGUAGE_VERSION) return 'WebGL GLSL ES 1.0'
-          return origGetParameter(p)
-        }
+    const glContext = gl(width, height, { preserveDrawingBuffer: true, webgl2: true }) as any
     
-        /* 3-A.2 · Stub VAO calls that headless-gl 8 doesn’t expose */
+        /* 3-A.1 · Stub VAO calls that headless-gl 8 doesn’t expose */
         if (typeof glContext.createVertexArray !== 'function') {
           glContext.createVertexArray = () => null
           glContext.bindVertexArray   = () => {}
           glContext.deleteVertexArray = () => {}
         }
     
-        /* 3-A.3 · Fake OES_standard_derivatives so dFdx/dFdy compile */
+        /* 3-A.2 · Fake OES_standard_derivatives so dFdx/dFdy compile */
         const origGetExtension = glContext.getExtension.bind(glContext)
         glContext.getExtension = (name: string) =>
           name === 'OES_standard_derivatives' ? {} : origGetExtension(name)
 
-        /* 3-A.4 · Provide empty texImage3D for WebGL1 contexts */
-        if (typeof glContext.texImage3D !== 'function') {
-          glContext.texImage3D = () => {}
-        }
 
     /* 3-B · Browser-DOM poly-fill so ImageLoader works in Node */
     const { Image } = await import('@/lib/canvas')
@@ -82,7 +70,7 @@ export async function POST (req: NextRequest) {
       createElementNS: () => new Image(),
     }
 
-    const renderer = new WebGL1Renderer({
+    const renderer = new WebGLRenderer({
       antialias: false,
       canvas,
       context: glContext as unknown as WebGLRenderingContext,


### PR DESCRIPTION
## Summary
- use `WebGLRenderer` with a WebGL2 context
- remove outdated WebGL1 workarounds

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6878a9a323fc8323a12fbcb1da2e7f76