### PR TITLE
Fix shader compilation in render API

### DIFF
--- a/lib/WebGL1Renderer.ts
+++ b/lib/WebGL1Renderer.ts
@@ -1,0 +1,9 @@
+import { WebGLRenderer, type WebGLRendererParameters } from 'three'
+
+export default class WebGL1Renderer extends WebGLRenderer {
+  readonly isWebGL1Renderer = true
+  constructor(parameters?: WebGLRendererParameters) {
+    super(parameters)
+    ;(this as any).capabilities.isWebGL2 = false
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight WebGL1Renderer helper
- use the helper in the render route instead of falling back to WebGL2
- force GLSL1 shader compilation in render route

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6878a9a323fc8323a12fbcb1da2e7f76