### PR TITLE
Fix shader compilation in render API

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -14,8 +14,11 @@ export async function POST (req: NextRequest) {
     /* ───── 1 · Runtime-load libs ───── */
     const THREE          = await import('three')
     const { GLTFLoader } = await import('three/examples/jsm/loaders/GLTFLoader')
-    let WebGL1Renderer: any; try { ({ WebGL1Renderer } = eval('require')('three/examples/jsm/renderers/WebGL1Renderer.js')); } catch { ({ WebGLRenderer: WebGL1Renderer } = await import('three')); }
+    const { default: WebGL1Renderer } = await import('@/lib/WebGL1Renderer')
+    const { patchThreeForWebGL1 } = await import('@/lib/patchThreeForWebGL1')
     const { default: gl } = await import(/* webpackIgnore: true */ 'gl')
+
+    patchThreeForWebGL1(THREE)
 
     const {
       Scene, AmbientLight, TextureLoader,
@@ -87,6 +90,17 @@ export async function POST (req: NextRequest) {
       canvas,
       context: glContext as unknown as WebGLRenderingContext,
     })
+    // WebGLCapabilities in three 0.178 always marks the context as WebGL2.
+    // This breaks headless-gl which only implements WebGL1. Force the
+    // renderer to treat the context as WebGL1 so shaders are generated with
+    // `#version 100` and avoid unsupported features like `sampler3D`.
+    ;(renderer as any).capabilities.isWebGL2 = false
+    const origGetParams = (renderer as any).programCache.getParameters
+    ;(renderer as any).programCache.getParameters = (...args: any[]) => {
+      const params = origGetParams.apply((renderer as any).programCache, args)
+      params.glslVersion = THREE.GLSL1
+      return params
+    }
     renderer.setSize(width, height)
 
     /* ───── 4 · Scene & model ───── */

--- a/lib/WebGL1Renderer.ts
+++ b/lib/WebGL1Renderer.ts
@@ -1,0 +1,9 @@
+import { WebGLRenderer, type WebGLRendererParameters } from 'three'
+
+export default class WebGL1Renderer extends WebGLRenderer {
+  readonly isWebGL1Renderer = true
+  constructor(parameters?: WebGLRendererParameters) {
+    super(parameters)
+    ;(this as any).capabilities.isWebGL2 = false
+  }
+}

--- a/lib/patchThreeForWebGL1.ts
+++ b/lib/patchThreeForWebGL1.ts
@@ -1,0 +1,25 @@
+export function patchThreeForWebGL1(THREE: any) {
+  const origShader = THREE.WebGLShader
+  const downgrade = (source: string): string => {
+    return source
+      .replace(/^#version 300 es\s*\n/, '#version 100\n')
+      .replace(/^\s*#define attribute in\s*\n/mg, '')
+      .replace(/^\s*#define varying out\s*\n/mg, '')
+      .replace(/^\s*#define varying in\s*\n/mg, '')
+      .replace(/^\s*#define texture2D texture\s*\n/mg, '')
+      .replace(/^\s*#define textureCube texture\s*\n/mg, '')
+      .replace(/^\s*#define texture2DProj textureProj\s*\n/mg, '')
+      .replace(/^\s*#define texture2DLodEXT textureLod\s*\n/mg, '')
+      .replace(/^\s*#define texture2DProjLodEXT textureProjLod\s*\n/mg, '')
+      .replace(/^\s*#define textureCubeLodEXT textureLod\s*\n/mg, '')
+      .replace(/^\s*#define texture2DGradEXT textureGrad\s*\n/mg, '')
+      .replace(/^\s*#define texture2DProjGradEXT textureProjGrad\s*\n/mg, '')
+      .replace(/^\s*#define textureCubeGradEXT textureGrad\s*\n/mg, '')
+      .replace(/^\s*layout\(location = 0\) out highp vec4 pc_fragColor;\s*\n/mg, '')
+      .replace(/^\s*#define gl_FragColor pc_fragColor\s*\n/mg, '')
+      .replace(/^\s*#define gl_FragDepthEXT gl_FragDepth\s*\n/mg, '')
+  }
+  THREE.WebGLShader = function(gl: any, type: any, source: string) {
+    return origShader(gl, type, downgrade(source))
+  }
+}


### PR DESCRIPTION
## Summary
- ensure Three.js shaders compile as GLSL1
- patch WebGL shaders to strip WebGL2 directives
- apply patch in the render API

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6878a9a323fc8323a12fbcb1da2e7f76