### PR TITLE
Fix derivative extension in headless GL

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -59,6 +59,17 @@ export async function POST (req: NextRequest) {
         glContext.getExtension = (name: string) =>
           name === 'OES_standard_derivatives' ? {} : origGetExtension(name)
 
+        // Include the extension in supported list to enable derivative
+        // functions when running under headless-gl
+        const origGetSupported = glContext.getSupportedExtensions.bind(glContext)
+        glContext.getSupportedExtensions = () => {
+          const exts = origGetSupported() || []
+          if (!exts.includes('OES_standard_derivatives')) {
+            exts.push('OES_standard_derivatives')
+          }
+          return exts
+        }
+
         /* 3-A.4 · Provide empty texImage3D for WebGL1 contexts */
         if (typeof glContext.texImage3D !== 'function') {
           glContext.texImage3D = () => {}


### PR DESCRIPTION
## Summary
- expose `OES_standard_derivatives` through `getSupportedExtensions`
- leave `getExtension('OES_standard_derivatives')` shim in place

## Testing
- `npm run lint` *(fails: React Hook and display-name errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878d79ea00c832396088f02d38640ea