### PR TITLE
Fix puppeteer render waiting

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -38,6 +38,8 @@ export async function POST (req: NextRequest) {
       args: ['--no-sandbox'],               // <-- works on Lambda / Vercel
     })
     const page = await browser.newPage()
+    page.on('pageerror', err => console.error('[render:pageerror]', err))
+    page.on('console', msg => console.log('[render:console]', msg.text()))
     await page.setViewport({ width: 1024, height: 1024 })
 
     /* ─── 4 · inline HTML with Three.js + render script ─── */
@@ -69,11 +71,16 @@ export async function POST (req: NextRequest) {
           document.body.appendChild(renderer.domElement)
 
           /* load GLB */
-          const gltf = await new THREE.GLTFLoader().loadAsync('${variant.model}')
+          THREE.DefaultLoadingManager.setCrossOrigin('anonymous')
+          const gltfLoader = new THREE.GLTFLoader()
+          gltfLoader.setCrossOrigin('anonymous')
+          const gltf = await gltfLoader.loadAsync('${variant.model}')
           scene.add(gltf.scene)
 
           /* swap customer texture */
-          const tex = new THREE.TextureLoader().load('${pngData}')
+          const texLoader = new THREE.TextureLoader()
+          texLoader.setCrossOrigin('anonymous')
+          const tex = await texLoader.loadAsync('${pngData}')
           const mesh = gltf.scene.getObjectByName('${meshName}')
           if (mesh && mesh.material) {
             mesh.material.map = tex
@@ -84,8 +91,9 @@ export async function POST (req: NextRequest) {
           window.__png = renderer.domElement.toDataURL('image/png')
         })()
       </script>`
-    await page.setContent(html, { waitUntil: 'networkidle0' })
-    const dataUrl = await page.evaluate('window.__png')
+  await page.setContent(html, { waitUntil: 'networkidle0' })
+  await page.waitForFunction('window.__png', { timeout: 60000 })
+  const dataUrl = await page.evaluate('window.__png')
     await browser.close()
 
     /* ─── 5 · respond ─── */


### PR DESCRIPTION
## Summary
- add console logging in puppeteer page to surface page errors
- set cross-origin handling correctly for GLTF and texture loading

## Testing
- `npm run lint` *(fails: warnings and errors)*
- `npm run build` *(fails during lint step)*

------
https://chatgpt.com/codex/tasks/task_e_6878e9efcb488323b196a809f03f1e93