### PR TITLE
Improve puppeteer render waiting

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -2,6 +2,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sanity, sanityPreview }     from '@/sanity/lib/client'
 import puppeteer                     from 'puppeteer'
+import path                          from 'path'
+import { readFile }                  from 'fs/promises'
 
 export const runtime = 'nodejs'          // keep in the Node runtime
 export const dynamic = 'force-dynamic'   // don’t statically optimize
@@ -40,51 +42,76 @@ export async function POST (req: NextRequest) {
     const page = await browser.newPage()
     await page.setViewport({ width: 1024, height: 1024 })
 
-    /* ─── 4 · inline HTML with Three.js + render script ─── */
-    const html = /* html */ `
-      <script src="https://unpkg.com/three@0.178.0/build/three.min.js"></script>
-      <script src="https://unpkg.com/three@0.178.0/examples/js/loaders/GLTFLoader.js"></script>
-      <script>
+    /* ─── 4 · inject Three.js & render script ─── */
+    const html = '<html><body></body></html>'
+
+    page.on('console', msg => console.log('[render page]', msg.text()))
+    page.on('pageerror', err => console.error('[render page]', err))
+
+    await page.setContent(html, { waitUntil: 'domcontentloaded' })
+
+    const threePath = path.join(
+      process.cwd(),
+      'node_modules/three/build/three.module.js'
+    )
+    const gltfPath = path.join(
+      process.cwd(),
+      'node_modules/three/examples/jsm/loaders/GLTFLoader.js'
+    )
+
+    const threeSrc = await readFile(threePath, 'utf8')
+    const gltfSrc  = await readFile(gltfPath, 'utf8')
+
+    const threeUrl = `data:text/javascript;base64,${Buffer.from(threeSrc).toString('base64')}`
+    const gltfUrl  = `data:text/javascript;base64,${Buffer.from(gltfSrc).toString('base64')}`
+
+    await page.addScriptTag({
+      type: 'module',
+      content: `
+        import * as THREE from '${threeUrl}';
+        import { GLTFLoader } from '${gltfUrl}';
         (async () => {
-          /* scene & camera */
-          const scene = new THREE.Scene()
-          scene.add(new THREE.AmbientLight(0xffffff, 1))
+          const scene = new THREE.Scene();
+          scene.add(new THREE.AmbientLight(0xffffff, 1));
           const cam = new THREE.PerspectiveCamera(
             ${variant.camera?.fov ?? 35}, 1, 0.1, 100
-          )
+          );
           cam.position.set(
             ${variant.camera?.posX ?? 2},
             ${variant.camera?.posY ?? 2},
             ${variant.camera?.posZ ?? 2}
-          )
+          );
           cam.lookAt(
             ${variant.camera?.targetX ?? 0},
             ${variant.camera?.targetY ?? 0},
             ${variant.camera?.targetZ ?? 0}
-          )
+          );
 
-          /* renderer */
-          const renderer = new THREE.WebGLRenderer({ alpha: true })
-          renderer.setSize(1024, 1024)
-          document.body.appendChild(renderer.domElement)
+          const renderer = new THREE.WebGLRenderer({ alpha: true });
+          renderer.setSize(1024, 1024);
+          document.body.appendChild(renderer.domElement);
 
-          /* load GLB */
-          const gltf = await new THREE.GLTFLoader().loadAsync('${variant.model}')
-          scene.add(gltf.scene)
+          const gltfLoader = new THREE.GLTFLoader();
+          gltfLoader.setCrossOrigin('anonymous');
+          const gltf = await gltfLoader.loadAsync('${variant.model}');
+          scene.add(gltf.scene);
 
-          /* swap customer texture */
-          const tex = new THREE.TextureLoader().load('${pngData}')
-          const mesh = gltf.scene.getObjectByName('${meshName}')
+          const texLoader = new THREE.TextureLoader();
+          texLoader.setCrossOrigin('anonymous');
+          const tex = await texLoader.loadAsync('${pngData}');
+          const mesh = gltf.scene.getObjectByName('${meshName}');
           if (mesh && mesh.material) {
-            mesh.material.map = tex
-            mesh.material.needsUpdate = true
+            mesh.material.map = tex;
+            mesh.material.needsUpdate = true;
           }
 
-          renderer.render(scene, cam)
-          window.__png = renderer.domElement.toDataURL('image/png')
-        })()
-      </script>`
-    await page.setContent(html, { waitUntil: 'networkidle0' })
+          renderer.render(scene, cam);
+          window.__png = renderer.domElement.toDataURL('image/png');
+        })();
+      `
+    })
+
+    await page.waitForFunction('window.__png', { timeout: 120000 })
     const dataUrl = await page.evaluate('window.__png')
     await browser.close()
 


### PR DESCRIPTION
## Summary
- use `setCrossOrigin` on loaders so assets load correctly
- add console logging to debug puppeteer page errors
- wait longer for preview image generation
- bundle Three.js scripts instead of relying on external CDN
- load Three.js from `node_modules` using data URLs so require.resolve isn't needed

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm run build` *(fails during lint step)*
- `npm test` *(fails: missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6878e9efcb488323b196a809f03f1e93