### PR TITLE
Fix module imports in puppeteer render

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -2,6 +2,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sanity, sanityPreview }     from '@/sanity/lib/client'
 import puppeteer                     from 'puppeteer'
+import path                          from 'path'
+import { pathToFileURL }             from 'url'
 
 export const runtime = 'nodejs'          // keep in the Node runtime
 export const dynamic = 'force-dynamic'   // don’t statically optimize
@@ -35,56 +37,86 @@ export async function POST (req: NextRequest) {
     /* ─── 3 · launch headless Chrome ─── */
     const browser = await puppeteer.launch({
       headless: 'new',
-      args: ['--no-sandbox'],               // <-- works on Lambda / Vercel
+      args: [
+        '--no-sandbox',
+        '--allow-file-access-from-files',
+      ],               // <-- works on Lambda / Vercel
     })
     const page = await browser.newPage()
     await page.setViewport({ width: 1024, height: 1024 })
 
-    /* ─── 4 · inline HTML with Three.js + render script ─── */
-    const html = /* html */ `
-      <script src="https://unpkg.com/three@0.178.0/build/three.min.js"></script>
-      <script src="https://unpkg.com/three@0.178.0/examples/js/loaders/GLTFLoader.js"></script>
-      <script>
+    /* ─── 4 · inject Three.js & render script ─── */
+    const html = '<html><body></body></html>'
+
+    page.on('console', msg => console.log('[render page]', msg.text()))
+    page.on('pageerror', err => console.error('[render page]', err))
+
+    await page.setContent(html, { waitUntil: 'domcontentloaded' })
+
+    const threePath = path.join(
+      process.cwd(),
+      'node_modules/three/build/three.module.js'
+    )
+    const gltfPath = path.join(
+      process.cwd(),
+      'node_modules/three/examples/jsm/loaders/GLTFLoader.js'
+    )
+
+    const threeUrl = pathToFileURL(threePath).href
+    const gltfUrl  = pathToFileURL(gltfPath).href
+
+    await page.addScriptTag({
+      type: 'importmap',
+      content: JSON.stringify({ imports: { three: threeUrl } })
+    })
+
+    await page.addScriptTag({
+      type: 'module',
+      content: `
+        import * as THREE from 'three';
+        import { GLTFLoader } from '${gltfUrl}';
         (async () => {
-          /* scene & camera */
-          const scene = new THREE.Scene()
-          scene.add(new THREE.AmbientLight(0xffffff, 1))
+          const scene = new THREE.Scene();
+          scene.add(new THREE.AmbientLight(0xffffff, 1));
           const cam = new THREE.PerspectiveCamera(
             ${variant.camera?.fov ?? 35}, 1, 0.1, 100
-          )
+          );
           cam.position.set(
             ${variant.camera?.posX ?? 2},
             ${variant.camera?.posY ?? 2},
             ${variant.camera?.posZ ?? 2}
-          )
+          );
           cam.lookAt(
             ${variant.camera?.targetX ?? 0},
             ${variant.camera?.targetY ?? 0},
             ${variant.camera?.targetZ ?? 0}
-          )
+          );
 
-          /* renderer */
-          const renderer = new THREE.WebGLRenderer({ alpha: true })
-          renderer.setSize(1024, 1024)
-          document.body.appendChild(renderer.domElement)
+          const renderer = new THREE.WebGLRenderer({ alpha: true });
+          renderer.setSize(1024, 1024);
+          document.body.appendChild(renderer.domElement);
 
-          /* load GLB */
-          const gltf = await new THREE.GLTFLoader().loadAsync('${variant.model}')
-          scene.add(gltf.scene)
+          const gltfLoader = new THREE.GLTFLoader();
+          gltfLoader.setCrossOrigin('anonymous');
+          const gltf = await gltfLoader.loadAsync('${variant.model}');
+          scene.add(gltf.scene);
 
-          /* swap customer texture */
-          const tex = new THREE.TextureLoader().load('${pngData}')
-          const mesh = gltf.scene.getObjectByName('${meshName}')
+          const texLoader = new THREE.TextureLoader();
+          texLoader.setCrossOrigin('anonymous');
+          const tex = await texLoader.loadAsync('${pngData}');
+          const mesh = gltf.scene.getObjectByName('${meshName}');
           if (mesh && mesh.material) {
-            mesh.material.map = tex
-            mesh.material.needsUpdate = true
+            mesh.material.map = tex;
+            mesh.material.needsUpdate = true;
           }
 
-          renderer.render(scene, cam)
-          window.__png = renderer.domElement.toDataURL('image/png')
-        })()
-      </script>`
-    await page.setContent(html, { waitUntil: 'networkidle0' })
+          renderer.render(scene, cam);
+          window.__png = renderer.domElement.toDataURL('image/png');
+        })();
+      `
+    })
+
+    await page.waitForFunction('window.__png', { timeout: 120000 })
     const dataUrl = await page.evaluate('window.__png')
     await browser.close()
 


### PR DESCRIPTION
## Summary
- import Three.js via importmap so relative modules resolve
- load GLTFLoader from file URL and map the `three` specifier
- allow file access in Puppeteer so local modules load

## Testing
- `npm run lint` *(fails with ESLint errors)*
- `npm run build` *(fails during compile with ESLint errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails to compile)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878e9efcb488323b196a809f03f1e93