### PR TITLE
Fix CORS issue by inlining GLB

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -32,7 +32,15 @@ export async function POST (req: NextRequest) {
     const meshName =
       variant.areas?.find(a => a.id === areaId)?.mesh || `PrintArea-${areaId}`
 
-    /* ─── 3 · launch headless Chrome ─── */
+    /* ─── 3 · fetch GLB so CORS isn't an issue ─── */
+    const glbRes = await fetch(variant.model)
+    if (!glbRes.ok)
+      throw new Error(`failed to fetch model: ${glbRes.status}`)
+    const glbBuf = await glbRes.arrayBuffer()
+    const glbUrl =
+      'data:model/gltf-binary;base64,' + Buffer.from(glbBuf).toString('base64')
+
+    /* ─── 4 · launch headless Chrome ─── */
     const browser = await puppeteer.launch({
       headless: 'new',
       args: ['--no-sandbox'],               // <-- works on Lambda / Vercel
@@ -40,55 +48,69 @@ export async function POST (req: NextRequest) {
     const page = await browser.newPage()
     await page.setViewport({ width: 1024, height: 1024 })
 
-    /* ─── 4 · inline HTML with Three.js + render script ─── */
-    const html = /* html */ `
-      <script src="https://unpkg.com/three@0.178.0/build/three.min.js"></script>
-      <script src="https://unpkg.com/three@0.178.0/examples/js/loaders/GLTFLoader.js"></script>
-      <script>
-        (async () => {
-          /* scene & camera */
-          const scene = new THREE.Scene()
-          scene.add(new THREE.AmbientLight(0xffffff, 1))
+    /* ─── 5 · inject import map and render script ─── */
+    const html = `<!DOCTYPE html>
+      <html>
+        <body></body>
+        <script type="importmap">
+          {
+            "imports": {
+              "three": "https://unpkg.com/three@0.178.0/build/three.module.js"
+            }
+          }
+        </script>
+        <script type="module">
+          import * as THREE from 'three';
+          import { GLTFLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/GLTFLoader.js';
+          (async () => {
+          const scene = new THREE.Scene();
+          scene.add(new THREE.AmbientLight(0xffffff, 1));
           const cam = new THREE.PerspectiveCamera(
             ${variant.camera?.fov ?? 35}, 1, 0.1, 100
-          )
+          );
           cam.position.set(
             ${variant.camera?.posX ?? 2},
             ${variant.camera?.posY ?? 2},
             ${variant.camera?.posZ ?? 2}
-          )
+          );
           cam.lookAt(
             ${variant.camera?.targetX ?? 0},
             ${variant.camera?.targetY ?? 0},
             ${variant.camera?.targetZ ?? 0}
-          )
+          );
 
-          /* renderer */
-          const renderer = new THREE.WebGLRenderer({ alpha: true })
-          renderer.setSize(1024, 1024)
-          document.body.appendChild(renderer.domElement)
+          const renderer = new THREE.WebGLRenderer({ alpha: true });
+          renderer.setSize(1024, 1024);
+          document.body.appendChild(renderer.domElement);
 
-          /* load GLB */
-          const gltf = await new THREE.GLTFLoader().loadAsync('${variant.model}')
-          scene.add(gltf.scene)
+          const gltfLoader = new GLTFLoader();
+          const gltf = await gltfLoader.loadAsync('${glbUrl}');
+          scene.add(gltf.scene);
 
-          /* swap customer texture */
-          const tex = new THREE.TextureLoader().load('${pngData}')
-          const mesh = gltf.scene.getObjectByName('${meshName}')
+          const texLoader = new THREE.TextureLoader();
+          const tex = await texLoader.loadAsync('${pngData}');
+          const mesh = gltf.scene.getObjectByName('${meshName}');
           if (mesh && mesh.material) {
-            mesh.material.map = tex
-            mesh.material.needsUpdate = true
+            mesh.material.map = tex;
+            mesh.material.needsUpdate = true;
           }
 
-          renderer.render(scene, cam)
-          window.__png = renderer.domElement.toDataURL('image/png')
-        })()
-      </script>`
+          renderer.render(scene, cam);
+          window.__png = renderer.domElement.toDataURL('image/png');
+        })();
+        </script>
+      </html>`
+
+    page.on('console', msg => console.log('[render page]', msg.text()))
+    page.on('pageerror', err => console.error('[render page]', err))
+
     await page.setContent(html, { waitUntil: 'networkidle0' })
+
+    await page.waitForFunction('window.__png', { timeout: 120000 })
     const dataUrl = await page.evaluate('window.__png')
     await browser.close()
 
-    /* ─── 5 · respond ─── */
+    /* ─── 6 · respond ─── */
     return NextResponse.json({
       urls: { [variant.camera?.name || 'hero']: dataUrl }
     })

--- a/app/mockup-test/[variantId]/MockupClient.tsx
+++ b/app/mockup-test/[variantId]/MockupClient.tsx
@@ -21,8 +21,9 @@ export default function MockupClient({ variantId, areaId }: Props) {
         body: JSON.stringify({ variantId, designPNGs: { [areaId]: base64 } })
       })
       const data = await res.json()
-      if (data?.urls && data.urls[areaId]) {
-        setPreview(data.urls[areaId])
+      if (data?.urls) {
+        const key = Object.keys(data.urls)[0]
+        if (key && data.urls[key]) setPreview(data.urls[key])
       }
     }
     reader.readAsDataURL(file)


### PR DESCRIPTION
## Summary
- fetch the GLB model server-side and embed it as a data URL to avoid CORS errors
- update the injected script to load the inline GLB
- fix mockup test page so preview updates

## Testing
- `npm run lint` *(fails with many lint errors)*
- `npm run build` *(fails during compile with ESLint errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails to compile)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878e9efcb488323b196a809f03f1e93