### PR TITLE
Fix camera pose when rendering mockups

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -18,7 +18,12 @@ export async function POST (req: NextRequest) {
       (_id==$id || variant->slug.current==$id)][0]{
         "model":  mockupSettings.model.asset->url,
         "areas":  mockupSettings.printAreas[]{ id, mesh },
-        "camera": mockupSettings.cameras[0]
+        "camera": mockupSettings.cameras[0]{
+          posX, posY, posZ,
+          targetX, targetY, targetZ,
+          rotationX, rotationY, rotationZ,
+          fov
+        }
       }`
     const client  = process.env.SANITY_READ_TOKEN ? sanityPreview : sanity
     const variant = await client.fetch(query, { id: variantId })
@@ -77,6 +82,11 @@ export async function POST (req: NextRequest) {
             ${variant.camera?.targetX ?? 0},
             ${variant.camera?.targetY ?? 0},
             ${variant.camera?.targetZ ?? 0}
+          );
+          cam.rotation.set(
+            ${variant.camera?.rotationX ?? 0},
+            ${variant.camera?.rotationY ?? 0},
+            ${variant.camera?.rotationZ ?? 0}
           );
 
           const renderer = new THREE.WebGLRenderer({ alpha: true });

--- a/sanity/schemaTypes/objects/cameraPose.ts
+++ b/sanity/schemaTypes/objects/cameraPose.ts
@@ -12,6 +12,9 @@ export default defineType({
     defineField({ name: 'targetX', type: 'number', title: 'Target X' }),
     defineField({ name: 'targetY', type: 'number', title: 'Target Y' }),
     defineField({ name: 'targetZ', type: 'number', title: 'Target Z' }),
+    defineField({ name: 'rotationX', type: 'number', title: 'Rotation X' }),
+    defineField({ name: 'rotationY', type: 'number', title: 'Rotation Y' }),
+    defineField({ name: 'rotationZ', type: 'number', title: 'Rotation Z' }),
     defineField({ name: 'fov', type: 'number', title: 'FOV' }),
   ],
 })


### PR DESCRIPTION
## Summary
- fetch camera pose fields from Sanity
- apply them when rendering mockups
- add rotation fields for camera pose

## Testing
- `npm run lint` *(fails: react-hooks and other errors)*


------
https://chatgpt.com/codex/tasks/task_e_687a3e668a488323ac7eb5f8894c36f3