### PR TITLE
Add HDR load error handling

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -17,6 +17,7 @@ export async function POST (req: NextRequest) {
     const query = `*[_type=="visualVariant" &&
       (_id==$id || variant->slug.current==$id)][0]{
         "model":  mockupSettings.model.asset->url,
+        "hdr":    mockupSettings.hdr.asset->url,
         "areas":  mockupSettings.printAreas[]{ id, mesh },
         "camera": mockupSettings.cameras[0]
       }`
@@ -40,6 +41,17 @@ export async function POST (req: NextRequest) {
     const glbUrl =
       'data:model/gltf-binary;base64,' + Buffer.from(glbBuf).toString('base64')
 
+    /* optional HDR environment */
+    let hdrUrl = ''
+    if (variant.hdr) {
+      const hdrRes = await fetch(variant.hdr)
+      if (!hdrRes.ok)
+        throw new Error(`failed to fetch hdr: ${hdrRes.status}`)
+      const hdrBuf = await hdrRes.arrayBuffer()
+      hdrUrl =
+        'data:application/octet-stream;base64,' + Buffer.from(hdrBuf).toString('base64')
+    }
+
     /* ─── 4 · launch headless Chrome ─── */
     const browser = await puppeteer.launch({
       headless: 'new',
@@ -62,6 +74,7 @@ export async function POST (req: NextRequest) {
         <script type="module">
           import * as THREE from 'three';
           import { GLTFLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/GLTFLoader.js';
+          import { RGBELoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/RGBELoader.js';
           (async () => {
           const scene = new THREE.Scene();
           scene.add(new THREE.AmbientLight(0xffffff, 1));
@@ -82,6 +95,17 @@ export async function POST (req: NextRequest) {
           const renderer = new THREE.WebGLRenderer({ alpha: true });
           renderer.setSize(1024, 1024);
           document.body.appendChild(renderer.domElement);
+
+          if ('${hdrUrl}' !== '') {
+            const hdrLoader = new RGBELoader();
+            try {
+              const env = await hdrLoader.loadAsync('${hdrUrl}');
+              env.mapping = THREE.EquirectangularReflectionMapping;
+              scene.environment = env;
+            } catch (err) {
+              console.error('failed to load HDR', err);
+            }
+          }
 
           const gltfLoader = new GLTFLoader();
           const gltf = await gltfLoader.loadAsync('${glbUrl}');


### PR DESCRIPTION
## Summary
- catch failures when loading HDR environment

## Testing
- `npm run lint` *(fails: React hook and image warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687aabf0e5ec8323a547a3188adada01