### PR TITLE
Fix blown-out mockup renders

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -97,6 +97,9 @@ export async function POST (req: NextRequest) {
 
           const renderer = new THREE.WebGLRenderer({ alpha: true });
           renderer.setSize(1024, 1024);
+          renderer.outputColorSpace = THREE.SRGBColorSpace;
+          renderer.toneMapping = THREE.ACESFilmicToneMapping;
+          renderer.toneMappingExposure = 1;
           document.body.appendChild(renderer.domElement);
 
           if ('${hdrUrl}' !== '') {


### PR DESCRIPTION
## Summary
- adjust WebGL renderer settings for mockup rendering

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ab4d557e4832395358b71124247ee