### PR TITLE
Fix blown-out WebGL mockups

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -109,7 +109,10 @@ export async function POST (req: NextRequest) {
               env = await hdrLoader.loadAsync('${hdrUrl}');
             }
             env.mapping = THREE.EquirectangularReflectionMapping;
+            env.encoding = THREE.RGBEEncoding;
             scene.environment = env;
+            scene.background = new THREE.Color(0xffffff);
+            scene.environmentIntensity = 0.75;
           }
 
           const gltfLoader = new GLTFLoader();


### PR DESCRIPTION
## Summary
- tone down HDR lighting in /api/render

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ab6d7d5dc83238b66c42fda4ffc9a