### PR TITLE
Adjust HDRI intensity for mockup rendering

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -110,6 +110,9 @@ export async function POST (req: NextRequest) {
             }
             env.mapping = THREE.EquirectangularReflectionMapping;
             scene.environment = env;
+            scene.background = new THREE.Color(0xffffff);
+            scene.environment.encoding = THREE.RGBEEncoding;
+            scene.environmentIntensity = 0.75;
           }
 
           const gltfLoader = new GLTFLoader();


### PR DESCRIPTION
## Summary
- reduce HDR lighting intensity for the mockup renderer

## Testing
- `npm run lint`
- `npm run build` *(fails: various existing lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_687ab6d7d5dc83238b66c42fda4ffc9a