### PR TITLE
Enhance mockup clarity via supersampling

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sanity, sanityPreview }     from '@/sanity/lib/client'
 import puppeteer                     from 'puppeteer'
+import sharp                         from 'sharp'
 
 export const runtime = 'nodejs'          // keep in the Node runtime
 export const dynamic = 'force-dynamic'   // don’t statically optimize
@@ -60,7 +61,7 @@ export async function POST (req: NextRequest) {
       args: ['--no-sandbox'],               // <-- works on Lambda / Vercel
     })
     const page = await browser.newPage()
-    await page.setViewport({ width: 1024, height: 1024 })
+    await page.setViewport({ width: 2048, height: 2048 })
 
     /* ─── 5 · inject import map and render script ─── */
     const html = `<!DOCTYPE html>
@@ -96,7 +97,7 @@ export async function POST (req: NextRequest) {
           );
 
           const renderer = new THREE.WebGLRenderer({ alpha: true });
-          renderer.setSize(1024, 1024);
+          renderer.setSize(2048, 2048);
           document.body.appendChild(renderer.domElement);
 
           if ('${hdrUrl}' !== '') {
@@ -139,9 +140,19 @@ export async function POST (req: NextRequest) {
     const dataUrl = await page.evaluate('window.__png')
     await browser.close()
 
+    const raw = Buffer.from(
+      dataUrl.replace(/^data:image\/png;base64,/, ''),
+      'base64'
+    )
+    const resized = await sharp(raw)
+      .resize(1024, 1024)
+      .png()
+      .toBuffer()
+    const finalUrl = 'data:image/png;base64,' + resized.toString('base64')
+
     /* ─── 6 · respond ─── */
     return NextResponse.json({
-      urls: { [areaId]: dataUrl }
+      urls: { [areaId]: finalUrl }
     })
   } catch (err) {
     console.error('[render]', err)


### PR DESCRIPTION
## Summary
- supersample mocked-up mug renders by rendering at 2048×2048
- downscale back to 1024×1024 using `sharp`

## Testing
- `npm run lint` *(fails: React hook and lint errors)*
- `npm run build` *(fails during lint step)*

------
https://chatgpt.com/codex/tasks/task_e_687ab72dc0e483238e2c7421427a71dc