### PR TITLE
Fix optional HDR environment

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -46,13 +46,19 @@ export async function POST (req: NextRequest) {
     let hdrUrl = ''
     let hdrExt = ''
     if (variant.hdr) {
-      const hdrRes = await fetch(variant.hdr)
-      if (!hdrRes.ok)
-        throw new Error(`failed to fetch hdr: ${hdrRes.status}`)
-      const hdrBuf = await hdrRes.arrayBuffer()
-      hdrUrl =
-        'data:application/octet-stream;base64,' + Buffer.from(hdrBuf).toString('base64')
-      hdrExt = variant.hdr.split('.').pop()?.toLowerCase() ?? ''
+      try {
+        const hdrRes = await fetch(variant.hdr)
+        if (hdrRes.ok) {
+          const hdrBuf = await hdrRes.arrayBuffer()
+          hdrUrl =
+            'data:application/octet-stream;base64,' + Buffer.from(hdrBuf).toString('base64')
+          hdrExt = variant.hdr.split('.').pop()?.toLowerCase() ?? ''
+        } else {
+          console.warn(`[render] failed to fetch hdr: ${hdrRes.status}`)
+        }
+      } catch (err) {
+        console.warn('[render] error fetching hdr', err)
+      }
     }
 
     /* ─── 4 · launch headless Chrome ─── */
@@ -82,6 +88,9 @@ export async function POST (req: NextRequest) {
           (async () => {
           const scene = new THREE.Scene();
           scene.add(new THREE.AmbientLight(0xffffff, 1));
+          scene.background = new THREE.Color(0xffffff);
+          const hemi = new THREE.HemisphereLight(0xffffff, 0x444444, 0.75);
+          scene.add(hemi);
           const cam = new THREE.PerspectiveCamera(
             ${variant.camera?.fov ?? 35}, 1, 0.1, 100
           );
@@ -98,6 +107,7 @@ export async function POST (req: NextRequest) {
 
           const renderer = new THREE.WebGLRenderer({ alpha: true });
           renderer.setSize(2048, 2048);
+          renderer.outputColorSpace = THREE.SRGBColorSpace;
           document.body.appendChild(renderer.domElement);
 
           if ('${hdrUrl}' !== '') {


### PR DESCRIPTION
## Summary
- skip HDR environment fetch if empty or failed
- add fallback lighting when HDR not used

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_687ac51ad094832382f8efd68369aeb8