### PR TITLE
Use HDRI environment for mug render

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -101,18 +101,21 @@ export async function POST (req: NextRequest) {
           document.body.appendChild(renderer.domElement);
 
           if ('${hdrUrl}' !== '') {
-            let env;
+            let hdr;
             if ('${hdrExt}' === 'exr') {
               const exrLoader = new EXRLoader();
-              env = await exrLoader.loadAsync('${hdrUrl}');
+              hdr = await exrLoader.loadAsync('${hdrUrl}');
             } else {
               const hdrLoader = new RGBELoader();
-              env = await hdrLoader.loadAsync('${hdrUrl}');
+              hdr = await hdrLoader.loadAsync('${hdrUrl}');
             }
-            env.mapping = THREE.EquirectangularReflectionMapping;
-            scene.environment = env;
-            scene.background = new THREE.Color(0xffffff);
-            scene.environment.encoding = THREE.RGBEEncoding;
+            hdr.mapping = THREE.EquirectangularReflectionMapping;
+            const pmrem = new THREE.PMREMGenerator(renderer);
+            const envMap = pmrem.fromEquirectangular(hdr).texture;
+            hdr.dispose?.();
+            pmrem.dispose();
+            scene.environment = envMap;
+            scene.background = null;
             scene.environmentIntensity = 0.75;
           }
 


### PR DESCRIPTION
## Summary
- add PMREMGenerator step when loading HDR for scene lighting

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_687b64ec675883239d81b4924e6ae543