### PR TITLE
Add physical key light to renderer

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -81,7 +81,10 @@ export async function POST (req: NextRequest) {
           import { EXRLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/EXRLoader.js';
           (async () => {
           const scene = new THREE.Scene();
-          scene.add(new THREE.AmbientLight(0xffffff, 1));
+          const key = new THREE.RectAreaLight(0xffffff, 20, 0.3, 0.3);
+          key.position.set(1.5, 2, 1);
+          key.lookAt(0, 0.5, 0);
+          scene.add(key);
           const cam = new THREE.PerspectiveCamera(
             ${variant.camera?.fov ?? 35}, 1, 0.1, 100
           );
@@ -98,7 +101,11 @@ export async function POST (req: NextRequest) {
 
           const renderer = new THREE.WebGLRenderer({ alpha: true });
           renderer.setSize(2048, 2048);
+          renderer.physicallyCorrectLights = true;
+          renderer.useLegacyLights        = false;
           document.body.appendChild(renderer.domElement);
+          renderer.shadowMap.enabled = true;
+          key.castShadow = true;
 
           if ('${hdrUrl}' !== '') {
             let env;


### PR DESCRIPTION
## Summary
- turn on physically correct lighting
- add a RectAreaLight as a key light with shadows enabled
- keep HDR as the fill light

## Testing
- `npm run lint` *(fails: several lint errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687b68e09d288323844e30aa6343ea7b