### PR TITLE
Improve rendering lighting

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -81,7 +81,18 @@ export async function POST (req: NextRequest) {
           import { EXRLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/EXRLoader.js';
           (async () => {
           const scene = new THREE.Scene();
-          scene.add(new THREE.AmbientLight(0xffffff, 1));
+          const renderer = new THREE.WebGLRenderer({ alpha: true });
+          renderer.setSize(2048, 2048);
+          renderer.physicallyCorrectLights = true;
+          renderer.useLegacyLights = false;
+          renderer.shadowMap.enabled = true;
+          document.body.appendChild(renderer.domElement);
+
+          const key = new THREE.RectAreaLight(0xffffff, 20, 0.3, 0.3);
+          key.position.set(1.5, 2, 1);
+          key.lookAt(0, 0.5, 0);
+          key.castShadow = true;
+          scene.add(key);
           const cam = new THREE.PerspectiveCamera(
             ${variant.camera?.fov ?? 35}, 1, 0.1, 100
           );
@@ -96,9 +107,6 @@ export async function POST (req: NextRequest) {
             ${variant.camera?.targetZ ?? 0}
           );
 
-          const renderer = new THREE.WebGLRenderer({ alpha: true });
-          renderer.setSize(2048, 2048);
-          document.body.appendChild(renderer.domElement);
 
           if ('${hdrUrl}' !== '') {
             let env;


### PR DESCRIPTION
## Summary
- enable physically-correct lights in puppeteer renderer script
- replace AmbientLight with shadow-casting RectAreaLight for softer illumination
- keep HDR environment as fill light

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b68e09d288323844e30aa6343ea7b