### PR TITLE
Add RectAreaLights to render pipeline

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -79,7 +79,9 @@ export async function POST (req: NextRequest) {
           import { GLTFLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/GLTFLoader.js';
           import { RGBELoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/RGBELoader.js';
           import { EXRLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/EXRLoader.js';
+          import { RectAreaLight, RectAreaLightUniformsLib } from 'https://unpkg.com/three@0.178.0/examples/jsm/lights/RectAreaLightUniformsLib.js';
           (async () => {
+          RectAreaLightUniformsLib.init();
           const scene = new THREE.Scene();
           scene.add(new THREE.AmbientLight(0xffffff, 1));
           const cam = new THREE.PerspectiveCamera(
@@ -97,8 +99,27 @@ export async function POST (req: NextRequest) {
           );
 
           const renderer = new THREE.WebGLRenderer({ alpha: true });
+          renderer.useLegacyLights = false;
+          renderer.physicallyCorrectLights = true;
+          renderer.toneMapping = THREE.ACESFilmicToneMapping;
+          renderer.toneMappingExposure = 1.25;
           renderer.setSize(2048, 2048);
           document.body.appendChild(renderer.domElement);
+
+          const key = new RectAreaLight(0xffffff, 55, 1.0, 1.0);
+          key.position.set(1.5, 2.5, 1.5);
+          key.lookAt(0, 1, 0);
+          scene.add(key);
+
+          const fill = new RectAreaLight(0xffffff, 15, 1.2, 1.2);
+          fill.position.set(-2.0, 1.8, 2.5);
+          fill.lookAt(0, 1, 0);
+          scene.add(fill);
+
+          const rim = new RectAreaLight(0xffffff, 25, 0.6, 0.6);
+          rim.position.set(0.0, -0.2, -2.0);
+          rim.lookAt(0, 0, 0);
+          scene.add(rim);
 
           if ('${hdrUrl}' !== '') {
             let env;


### PR DESCRIPTION
## Summary
- light up product renders with RectAreaLight

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b76b13c908323a52439ff5eff7eb2