### PR TITLE
Fix import for three.js area lights

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -79,7 +79,10 @@ export async function POST (req: NextRequest) {
           import { GLTFLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/GLTFLoader.js';
           import { RGBELoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/RGBELoader.js';
           import { EXRLoader } from 'https://unpkg.com/three@0.178.0/examples/jsm/loaders/EXRLoader.js';
+          import { RectAreaLight } from 'https://unpkg.com/three@0.178.0/examples/jsm/lights/RectAreaLight.js';
+          import { RectAreaLightUniformsLib } from 'https://unpkg.com/three@0.178.0/examples/jsm/lights/RectAreaLightUniformsLib.js';
           (async () => {
+          RectAreaLightUniformsLib.init();
           const scene = new THREE.Scene();
           scene.add(new THREE.AmbientLight(0xffffff, 1));
           const cam = new THREE.PerspectiveCamera(
@@ -99,6 +102,28 @@ export async function POST (req: NextRequest) {
           const renderer = new THREE.WebGLRenderer({ alpha: true });
           renderer.setSize(2048, 2048);
           document.body.appendChild(renderer.domElement);
+
+          // physically correct lighting & tone mapping
+          renderer.useLegacyLights = false;
+          renderer.physicallyCorrectLights = true;
+          renderer.toneMapping = THREE.ACESFilmicToneMapping;
+          renderer.toneMappingExposure = 1.25;
+
+          // three-point rectangular lighting setup
+          const key = new RectAreaLight(0xffffff, 55, 1.0, 1.0);
+          key.position.set(1.5, 2.5, 1.5);
+          key.lookAt(0, 1, 0);
+          scene.add(key);
+
+          const fill = new RectAreaLight(0xffffff, 15, 1.2, 1.2);
+          fill.position.set(-2.0, 1.8, 2.5);
+          fill.lookAt(0, 1, 0);
+          scene.add(fill);
+
+          const rim = new RectAreaLight(0xffffff, 25, 0.6, 0.6);
+          rim.position.set(0.0, -0.2, -2.0);
+          rim.lookAt(0, 0, 0);
+          scene.add(rim);
 
           if ('${hdrUrl}' !== '') {
             let env;


### PR DESCRIPTION
## Summary
- update render route to import `RectAreaLight` from the proper file

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687b76b13c908323a52439ff5eff7eb2